### PR TITLE
[SPARK-51477] Enable autolink to SPARK jira issue

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,7 @@ github:
     merge: false
     squash: true
     rebase: true
+  autolink_jira: SPARK
 
 notifications:
   pullrequests: reviews@spark.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable autolink to SPARK JIRA issue.

### Why are the changes needed?

To provide the convenient way to visit the issues like Apache Spark repository.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.