### PR TITLE
[SPARK-51490] Support `iOS`, `watchOS`, and `tvOS`

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -45,7 +45,13 @@ public actor SparkSession {
   ///   - userID: an optional user ID. If absent, `SPARK_USER` environment or ``ProcessInfo.processInfo.userName`` is used.
   init(_ connection: String, _ userID: String? = nil) {
     let processInfo = ProcessInfo.processInfo
+#if os(iOS) || os(watchOS) || os(tvOS)
+    let userName = processInfo.environment["SPARK_USER"] ?? ""
+#elseif os(macOS) || os(Linux)
     let userName = processInfo.environment["SPARK_USER"] ?? processInfo.userName
+#else
+    assert(false, "Unsupported platform")
+#endif
     self.client = SparkConnectClient(remote: connection, user: userID ?? userName)
     self.conf = RuntimeConf(self.client)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `iOS`, `watchOS`, and `tvOS`.

### Why are the changes needed?

`ProcessInfo.processInfo.userName` is not allowed in `iOS`, `watchOS`, and `tvOS` according to `Platform Compatibility` matrix.
- https://swiftpackageindex.com/apache/spark-connect-swift
![Screenshot 2025-03-12 at 11 16 52](https://github.com/user-attachments/assets/ad67336b-71d9-4a35-8bab-84b7ea860bcd)

### Does this PR introduce _any_ user-facing change?

No, the compilation fails on these OSs until now.

### How was this patch tested?

Manual review. After this PR, `Platform Compatibility` should be updated at the next refresh.

https://swiftpackageindex.com/apache/spark-connect-swift

### Was this patch authored or co-authored using generative AI tooling?

No.