### PR TITLE
[SPARK-51493] Refine `merge_spark_pr.py` to use `connect-swift-x.y.z` version

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -311,7 +311,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     versions = [
         x
         for x in versions
-        if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
+        if not x.raw["released"]
+        and not x.raw["archived"]
+        and re.match(r"connect-swift-\d+\.\d+\.\d+", x.name)
     ]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to refine `merge_spark_pr.py` to use `connect-swift-x.y.z` version pattern.

### Why are the changes needed?

To avoid using the version of Apache Spark repository.

### Does this PR introduce _any_ user-facing change?

No, this is an dev script.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.
