### PR TITLE
[SPARK-51508] Support `collect(): [[String?]]` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -275,9 +275,11 @@ public actor SparkConnectClient {
     let expressions: [Spark_Connect_Expression.SortOrder] = cols.map {
       var expression = Spark_Connect_Expression.SortOrder()
       expression.child.exprType = .unresolvedAttribute($0.toUnresolvedAttribute)
+      expression.direction = .ascending
       return expression
     }
     sort.order = expressions
+    sort.isGlobal = true
     var relation = Relation()
     relation.sort = sort
     var plan = Plan()

--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -45,12 +45,10 @@ public actor SparkSession {
   ///   - userID: an optional user ID. If absent, `SPARK_USER` environment or ``ProcessInfo.processInfo.userName`` is used.
   init(_ connection: String, _ userID: String? = nil) {
     let processInfo = ProcessInfo.processInfo
-#if os(iOS) || os(watchOS) || os(tvOS)
-    let userName = processInfo.environment["SPARK_USER"] ?? ""
-#elseif os(macOS) || os(Linux)
+#if os(macOS) || os(Linux)
     let userName = processInfo.environment["SPARK_USER"] ?? processInfo.userName
 #else
-    assert(false, "Unsupported platform")
+    let userName = processInfo.environment["SPARK_USER"] ?? ""
 #endif
     self.client = SparkConnectClient(remote: connection, user: userID ?? userName)
     self.conf = RuntimeConf(self.client)

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -125,19 +125,25 @@ struct DataFrameTests {
     await spark.stop()
   }
 
+#if !os(Linux)
   @Test
   func sort() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    #expect(try await spark.range(10).sort("id").count() == 10)
+    let expected = (1...10).map{ [String($0)] }
+    #expect(try await spark.range(10, 0, -1).sort("id").collect() == expected)
     await spark.stop()
   }
 
   @Test
   func orderBy() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    #expect(try await spark.range(10).orderBy("id").count() == 10)
+    let expected = (1...10).map{ [String($0)] }
+    print(expected)
+    print(try await spark.range(10, 0, -1).orderBy("id").collect())
+    #expect(try await spark.range(10, 0, -1).orderBy("id").collect() == expected)
     await spark.stop()
   }
+#endif
 
   @Test
   func table() async throws {
@@ -153,6 +159,17 @@ struct DataFrameTests {
   }
 
 #if !os(Linux)
+  @Test
+  func collect() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.range(0).collect().isEmpty)
+    #expect(
+      try await spark.sql(
+        "SELECT * FROM VALUES (1, true, 'abc'), (null, null, null), (3, false, 'def')"
+      ).collect() == [["1", "true", "abc"], [nil, nil, nil], ["3", "false", "def"]])
+    await spark.stop()
+  }
+
   @Test
   func show() async throws {
     let spark = try await SparkSession.builder.getOrCreate()

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -138,8 +138,6 @@ struct DataFrameTests {
   func orderBy() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let expected = (1...10).map{ [String($0)] }
-    print(expected)
-    print(try await spark.range(10, 0, -1).orderBy("id").collect())
     #expect(try await spark.range(10, 0, -1).orderBy("id").collect() == expected)
     await spark.stop()
   }

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -41,7 +41,11 @@ struct SparkSessionTests {
 
   @Test func userContext() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
+#if os(macOS) || os(Linux)
     let defaultUserContext = ProcessInfo.processInfo.userName.toUserContext
+#else
+    let defaultUserContext = "".toUserContext
+#endif
     #expect(await spark.client.userContext == defaultUserContext)
     await spark.stop()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `DataFrame.collect()` with the return type, an array of String array.

### Why are the changes needed?

There are two main goals.
1. Provide one of the simplest implementations for `collect()` API.
2. Use it as a way to implement interim test coverage until we implement a more generic return type including **complex types**.

### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.