### PR TITLE
[SPARK-51524] Fix Package Author information to `Apache Spark project`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+version: 1
+metadata:
+  authors: "Apache Spark project"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Package Author` information to `Apache Spark project` in the `Swift Package Index` website.
- https://swiftpackageindex.com/apache/spark-connect-swift

### Why are the changes needed?

The AS-IS author information is wrong. It should be `Written by Apache Spark project`.

![](https://github.com/user-attachments/assets/39f41c9a-193c-4f93-8e3c-49749c3f6273)

According to the `Swift Package Index` recommendation, we need to override the author via `.spi.yml` file.
- https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3730

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual check after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.