### PR TITLE
[SPARK-51539] Refactor `SparkConnectClient` to use `analyze` helper function

### DIFF
--- a/Sources/SparkConnect/TypeAliases.swift
+++ b/Sources/SparkConnect/TypeAliases.swift
@@ -25,6 +25,7 @@ typealias Plan = Spark_Connect_Plan
 typealias Project = Spark_Connect_Project
 typealias KeyValue = Spark_Connect_KeyValue
 typealias Limit = Spark_Connect_Limit
+typealias OneOf_Analyze = AnalyzePlanRequest.OneOf_Analyze
 typealias Range = Spark_Connect_Range
 typealias Relation = Spark_Connect_Relation
 typealias SparkConnectService = Spark_Connect_SparkConnectService


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to refactor `SparkConnectClient` to use `analyze` helper function.

### Why are the changes needed?

To remove the duplication code pattern via newly added `private func analyze` like `Scala Spark Connect` client. 

### Does this PR introduce _any_ user-facing change?

No, this is an internal refactoring.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.