### PR TITLE
[SPARK-51561] Upgrade `gRPC Swift` to `2.1.2` and `gRPC Swift NIO Transport` to `1.0.2`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,9 +34,9 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.1.0"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.1.2"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.1.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.2"),
     .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v24.3.7"),
   ],

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ So far, this library project is tracking the upstream changes like the [Apache S
 ## Requirement
 - [Apache Spark 4.0.0 RC2 (March 2025)](https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc2-bin/)
 - [Swift 6.0 (2024)](https://swift.org)
-- [gRPC Swift 2.1 (March 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.1.0)
-- [gRPC Swift Protobuf 1.0 (March 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.1.0)
-- [gRPC Swift NIO Transport 1.0 (March 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.0.1)
+- [gRPC Swift 2.1 (March 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.1.2)
+- [gRPC Swift Protobuf 1.1 (March 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.1.0)
+- [gRPC Swift NIO Transport 1.0 (March 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.0.2)
 - [Apache Arrow Swift](https://github.com/apache/arrow/tree/main/swift)
 
 ## How to use in your apps


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade 
- `gRPC Swift` to `2.1.2`
- `gRPC Swift NIO Transport` to `1.0.2`

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/grpc/grpc-swift/releases/tag/2.1.2
- https://github.com/grpc/grpc-swift/releases/tag/2.1.1
    - https://github.com/grpc/grpc-swift/pull/2206
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.0.2
    - https://github.com/grpc/grpc-swift-nio-transport/pull/80

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.