### PR TITLE
[MINOR] Remove build warnings on `try` expression in `SparkSession`

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -106,7 +106,7 @@ public actor SparkSession {
   ///   - step: A value for the step.
   /// - Returns: A ``DataFrame`` instance.
   public func range(_ start: Int64, _ end: Int64, _ step: Int64 = 1) async throws -> DataFrame {
-    return try await DataFrame(spark: self, plan: client.getPlanRange(start, end, step))
+    return await DataFrame(spark: self, plan: client.getPlanRange(start, end, step))
   }
 
   /// Create a ``DataFrame`` for the given SQL statement.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove build warnings on `try` expression in `SparkSession`.

### Why are the changes needed?

Due to the unnecessary `try`, it shows repetitive warnings currently.
```
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/SparkSession.swift:109:12: warning: no calls to throwing functions occur within 'try' expression
107 |   /// - Returns: A ``DataFrame`` instance.
108 |   public func range(_ start: Int64, _ end: Int64, _ step: Int64 = 1) async throws -> DataFrame {
109 |     return try await DataFrame(spark: self, plan: client.getPlanRange(start, end, step))
    |            `- warning: no calls to throwing functions occur within 'try' expression
110 |   }
111 |
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/SparkSession.swift:109:12: warning: no calls to throwing functions occur within 'try' expression
107 |   /// - Returns: A ``DataFrame`` instance.
108 |   public func range(_ start: Int64, _ end: Int64, _ step: Int64 = 1) async throws -> DataFrame {
109 |     return try await DataFrame(spark: self, plan: client.getPlanRange(start, end, step))
    |            `- warning: no calls to throwing functions occur within 'try' expression
110 |   }
111 |
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/SparkSession.swift:109:12: warning: no calls to throwing functions occur within 'try' expression
107 |   /// - Returns: A ``DataFrame`` instance.
108 |   public func range(_ start: Int64, _ end: Int64, _ step: Int64 = 1) async throws -> DataFrame {
109 |     return try await DataFrame(spark: self, plan: client.getPlanRange(start, end, step))
    |            `- warning: no calls to throwing functions occur within 'try' expression
110 |   }
111 |
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.