### PR TITLE
[MINOR] Fix build warnings

### DIFF
--- a/Sources/SparkConnect/ArrowReader.swift
+++ b/Sources/SparkConnect/ArrowReader.swift
@@ -298,10 +298,8 @@ public class ArrowReader {  // swiftlint:disable:this type_body_length
             messageEndOffset: messageEndOffset
           ).get()
           result.batches.append(recordBatch)
-        } catch let error as ArrowError {
+        } catch let error {
           return .failure(error)
-        } catch {
-          return .failure(.unknownError("Unexpected error: \(error)"))
         }
       default:
         return .failure(.unknownError("Unhandled header type: \(message.headerType)"))
@@ -361,10 +359,8 @@ public class ArrowReader {  // swiftlint:disable:this type_body_length
         ).get()
         result.batches.append(recordBatch)
         return .success(())
-      } catch let error as ArrowError {
+      } catch let error {
         return .failure(error)
-      } catch {
-        return .failure(.unknownError("Unexpected error: \(error)"))
       }
 
     default:

--- a/Tests/SparkConnectTests/RuntimeConfTests.swift
+++ b/Tests/SparkConnectTests/RuntimeConfTests.swift
@@ -31,7 +31,7 @@ struct RuntimeConfTests {
     _ = try await client.connect(UUID().uuidString)
     let conf = RuntimeConf(client)
 
-    #expect(try await conf.get("spark.app.name") != nil)
+    #expect(try await !conf.get("spark.app.name").isEmpty)
 
     try await #require(throws: Error.self) {
       try await conf.get("spark.test.non-exist")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to clean up build warnings.

### Why are the changes needed?

**BEFORE**
```
$ swift build | grep warning
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:301:27: warning: 'as' test is always true
    |                           `- warning: 'as' test is always true
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:364:25: warning: 'as' test is always true
    |                         `- warning: 'as' test is always true
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:301:27: warning: 'as' test is always true
    |                           `- warning: 'as' test is always true
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:364:25: warning: 'as' test is always true
    |                         `- warning: 'as' test is always true
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:301:27: warning: 'as' test is always true
    |                           `- warning: 'as' test is always true
/Users/dongjoon/APACHE/spark-connect-swift/Sources/SparkConnect/ArrowReader.swift:364:25: warning: 'as' test is always true
    |                         `- warning: 'as' test is always true
```

**AFTER**
```
$ swift build | grep warning
```

### Does this PR introduce _any_ user-facing change?

A code cleanup.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.