### PR TITLE
[SPARK-51676] Support `printSchema` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -355,4 +355,24 @@ public actor DataFrame: Sendable {
       print(response.explain.explainString)
     }
   }
+
+  /// Prints the schema to the console in a nice tree format.
+  public func printSchema() async throws {
+    try await printSchema(Int32.max)
+  }
+
+  /// Prints the schema up to the given level to the console in a nice tree format.
+  /// - Parameter level: A level to be printed.
+  public func printSchema(_ level: Int32) async throws {
+    try await withGRPCClient(
+      transport: .http2NIOPosix(
+        target: .dns(host: spark.client.host, port: spark.client.port),
+        transportSecurity: .plaintext
+      )
+    ) { client in
+      let service = Spark_Connect_SparkConnectService.Client(wrapping: client)
+      let response = try await service.analyzePlan(spark.client.getTreeString(spark.sessionID, plan, level))
+      print(response.treeString.treeString)
+    }
+  }
 }

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -294,6 +294,18 @@ public actor SparkConnectClient {
       })
   }
 
+  func getTreeString(_ sessionID: String, _ plan: Plan, _ level: Int32) async -> AnalyzePlanRequest
+  {
+    return analyze(
+      sessionID,
+      {
+        var treeString = AnalyzePlanRequest.TreeString()
+        treeString.plan = plan
+        treeString.level = level
+        return OneOf_Analyze.treeString(treeString)
+      })
+  }
+
   static func getProject(_ child: Relation, _ cols: [String]) -> Plan {
     var project = Project()
     project.input = child

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -71,6 +71,14 @@ struct DataFrameTests {
   }
 
   @Test
+  func printSchema() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    try await spark.sql("SELECT struct(1, 2)").printSchema()
+    try await spark.sql("SELECT struct(1, 2)").printSchema(1)
+    await spark.stop()
+  }
+
+  @Test
   func explain() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     try await spark.range(1).explain()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `printSchema` for `DataFrame`.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No, this is a new addition to the unreleased version.

### How was this patch tested?

Pass the CIs and do the manual check from the log. Or, manually.
```
$ swift test --filter DataFrameTests.printSchema
...
􀟈  Test printSchema() started.
root
 |-- struct(1, 2): struct (nullable = false)
 |    |-- col1: integer (nullable = false)
 |    |-- col2: integer (nullable = false)

root
 |-- struct(1, 2): struct (nullable = false)

􁁛  Test printSchema() passed after 0.044 seconds.
􁁛  Suite DataFrameTests passed after 0.044 seconds.
􁁛  Test run with 1 test passed after 0.044 seconds.
```

### Was this patch authored or co-authored using generative AI tooling?

No.