### PR TITLE
[SPARK-51702] Revise `sparkSession/read/write/columns/schema/dtypes/storageLevel` API

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -75,7 +75,7 @@ public actor SparkSession {
   var serverSideSessionID: String = ""
 
   /// A variable for ``SparkContext``. This is designed to throw exceptions by Apache Spark.
-  var sparkContext: SparkContext {
+  public var sparkContext: SparkContext {
     get throws {
       // SQLSTATE: 0A000
       // [UNSUPPORTED_CONNECT_FEATURE.SESSION_SPARK_CONTEXT]
@@ -119,7 +119,7 @@ public actor SparkSession {
 
   /// Returns a ``DataFrameReader`` that can be used to read non-streaming data in as a
   /// `DataFrame`
-  var read: DataFrameReader {
+  public var read: DataFrameReader {
     get {
       return DataFrameReader(sparkSession: self)
     }
@@ -140,7 +140,7 @@ public actor SparkSession {
   /// This is defined as the return type of `SparkSession.sparkContext` method.
   /// This is an empty `Struct` type because `sparkContext` method is designed to throw
   /// `UNSUPPORTED_CONNECT_FEATURE.SESSION_SPARK_CONTEXT`.
-  struct SparkContext {
+  public struct SparkContext: Sendable {
   }
 
   /// A builder to create ``SparkSession``

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -26,7 +26,7 @@ struct DataFrameTests {
   @Test
   func sparkSession() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    #expect(try await spark.range(1).sparkSession() == spark)
+    #expect(try await spark.range(1).sparkSession == spark)
     await spark.stop()
   }
 
@@ -42,10 +42,10 @@ struct DataFrameTests {
   @Test
   func columns() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    #expect(try await spark.sql("SELECT 1 as col1").columns() == ["col1"])
-    #expect(try await spark.sql("SELECT 1 as col1, 2 as col2").columns() == ["col1", "col2"])
-    #expect(try await spark.sql("SELECT CAST(null as STRING) col1").columns() == ["col1"])
-    #expect(try await spark.sql("DROP TABLE IF EXISTS nonexistent").columns() == [])
+    #expect(try await spark.sql("SELECT 1 as col1").columns == ["col1"])
+    #expect(try await spark.sql("SELECT 1 as col1, 2 as col2").columns == ["col1", "col2"])
+    #expect(try await spark.sql("SELECT CAST(null as STRING) col1").columns == ["col1"])
+    #expect(try await spark.sql("DROP TABLE IF EXISTS nonexistent").columns == [])
     await spark.stop()
   }
 
@@ -53,19 +53,19 @@ struct DataFrameTests {
   func schema() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
 
-    let schema1 = try await spark.sql("SELECT 'a' as col1").schema()
+    let schema1 = try await spark.sql("SELECT 'a' as col1").schema
     #expect(
       schema1
         == #"{"struct":{"fields":[{"name":"col1","dataType":{"string":{"collation":"UTF8_BINARY"}}}]}}"#
     )
 
-    let schema2 = try await spark.sql("SELECT 'a' as col1, 'b' as col2").schema()
+    let schema2 = try await spark.sql("SELECT 'a' as col1, 'b' as col2").schema
     #expect(
       schema2
         == #"{"struct":{"fields":[{"name":"col1","dataType":{"string":{"collation":"UTF8_BINARY"}}},{"name":"col2","dataType":{"string":{"collation":"UTF8_BINARY"}}}]}}"#
     )
 
-    let emptySchema = try await spark.sql("DROP TABLE IF EXISTS nonexistent").schema()
+    let emptySchema = try await spark.sql("DROP TABLE IF EXISTS nonexistent").schema
     #expect(emptySchema == #"{"struct":{}}"#)
     await spark.stop()
   }
@@ -136,7 +136,7 @@ struct DataFrameTests {
   @Test
   func selectNone() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    let emptySchema = try await spark.range(1).select().schema()
+    let emptySchema = try await spark.range(1).select().schema
     #expect(emptySchema == #"{"struct":{}}"#)
     await spark.stop()
   }
@@ -144,7 +144,7 @@ struct DataFrameTests {
   @Test
   func select() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    let schema = try await spark.range(1).select("id").schema()
+    let schema = try await spark.range(1).select("id").schema
     #expect(
       schema
         == #"{"struct":{"fields":[{"name":"id","dataType":{"long":{}}}]}}"#
@@ -155,7 +155,7 @@ struct DataFrameTests {
   @Test
   func selectMultipleColumns() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    let schema = try await spark.sql("SELECT * FROM VALUES (1, 2)").select("col2", "col1").schema()
+    let schema = try await spark.sql("SELECT * FROM VALUES (1, 2)").select("col2", "col1").schema
     #expect(
       schema
         == #"{"struct":{"fields":[{"name":"col2","dataType":{"integer":{}}},{"name":"col1","dataType":{"integer":{}}}]}}"#
@@ -167,7 +167,7 @@ struct DataFrameTests {
   func selectInvalidColumn() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     try await #require(throws: Error.self) {
-      let _ = try await spark.range(1).select("invalid").schema()
+      let _ = try await spark.range(1).select("invalid").schema
     }
     await spark.stop()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise `sparkSession/read/write/columns/schema/dtypes/storageLevel` API to resemble the other language clients' APIs.

### Why are the changes needed?

To provide a consistent UX to the users.

### Does this PR introduce _any_ user-facing change?

- Change `func` to `var` like the following.
```swift
- public func schema() async throws -> String {
+ public var schema: String {
+   get async throws {
```

- Add `public` explicitly.
- Revise test cases accordingly.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.