### PR TITLE
[SPARK-51736] Make `SparkConnectError` and `StorageLevel` fields public

### DIFF
--- a/Sources/SparkConnect/SparkConnectError.swift
+++ b/Sources/SparkConnect/SparkConnectError.swift
@@ -18,7 +18,7 @@
 //
 
 /// A enum for ``SparkConnect`` package errors
-enum SparkConnectError: Error {
+public enum SparkConnectError: Error {
   case UnsupportedOperationException
   case InvalidSessionIDException
   case InvalidTypeException

--- a/Sources/SparkConnect/StorageLevel.swift
+++ b/Sources/SparkConnect/StorageLevel.swift
@@ -23,19 +23,19 @@
 /// to replicate the `RDD` partitions on multiple nodes.
 public struct StorageLevel: Sendable {
   /// Whether the cache should use disk or not.
-  var useDisk: Bool
+  public var useDisk: Bool
 
   /// Whether the cache should use memory or not.
-  var useMemory: Bool
+  public var useMemory: Bool
 
   /// Whether the cache should use off-heap or not.
-  var useOffHeap: Bool
+  public var useOffHeap: Bool
 
   /// Whether the cached data is deserialized or not.
-  var deserialized: Bool
+  public var deserialized: Bool
 
   /// The number of replicas.
-  var replication: Int32
+  public var replication: Int32
 
   init(useDisk: Bool, useMemory: Bool, useOffHeap: Bool, deserialized: Bool, replication: Int32 = 1)
   {

--- a/Tests/SparkConnectTests/DataFrameReaderTests.swift
+++ b/Tests/SparkConnectTests/DataFrameReaderTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Testing
 
-@testable import SparkConnect
+import SparkConnect
 
 /// A test suite for `DataFrameReader`
 struct DataFrameReaderTests {

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -19,7 +19,7 @@
 
 import Testing
 
-@testable import SparkConnect
+import SparkConnect
 
 /// A test suite for `DataFrame`
 struct DataFrameTests {

--- a/Tests/SparkConnectTests/DataFrameWriterTests.swift
+++ b/Tests/SparkConnectTests/DataFrameWriterTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Testing
 
-@testable import SparkConnect
+import SparkConnect
 
 /// A test suite for `DataFrameWriter`
 struct DataFrameWriterTests {

--- a/Tests/SparkConnectTests/SQLTests.swift
+++ b/Tests/SparkConnectTests/SQLTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Testing
 
-@testable import SparkConnect
+import SparkConnect
 
 /// A test suite for various SQL statements.
 struct SQLTests {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to change the visibility of the following.
- `enum SparkConnectError`
- `StorageLevel` fields

In addition, this PR changes the following test suite to use only `public` APIs of `SparkConnect` by changing the import statement. This will help us validate the visibility change easily.
- `DataFrameTests`
- `DataFrameReaderTests`
- `DataFrameWriterTests`
- `SQLTests`

### Why are the changes needed?

To allow users to use `SparkConnectError` and `StorageLevel`.

### Does this PR introduce _any_ user-facing change?

No. This is a visibility change on the unreleased versions.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.