### PR TITLE
[SPARK-51749] Add `MacOS` integration test with Apache Spark 4.0.0 RC3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Build
       run: swift build -v
 
-  integration-test:
+  integration-test-linux:
     runs-on: ubuntu-latest
     services:
       spark:
@@ -72,3 +72,19 @@ jobs:
         swift-version: "6"
     - name: Test
       run: swift test --no-parallel
+
+  integration-test-mac:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: swift-actions/setup-swift@v2.2.0
+      with:
+        swift-version: "6"
+    - name: Test
+      run: |
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc3-bin/spark-4.0.0-bin-hadoop3.tgz
+        tar xvfz spark-4.0.0-bin-hadoop3.tgz
+        cd spark-4.0.0-bin-hadoop3/sbin
+        ./start-connect-server.sh
+        cd ../..
+        swift test --no-parallel


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS` integration test with Apache Spark 4.0.0 RC3.

- While adding this, `SQLTests` test suite is revised by implementing `removeLocation` and `removeOwner` feature.
- This will be replaced with the official 4.0.0 release when it's ready.

### Why are the changes needed?

Newly added `MacOS` integration test will provide a full test coverage while `Linux` integration test continues to provide a partial test coverage on `Linux`.

### Does this PR introduce _any_ user-facing change?

No, this is a test improvement .

### How was this patch tested?

Pass the CIs with newly added `integration-test-mac` job.

### Was this patch authored or co-authored using generative AI tooling?

No.