### PR TITLE
[SPARK-51750] Upgrade `FlatBuffers` to v25.2.10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.1.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.2"),
     .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
-    .package(url: "https://github.com/google/flatbuffers.git", branch: "v24.3.7"),
+    .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [
     .target(

--- a/Sources/SparkConnect/File_generated.swift
+++ b/Sources/SparkConnect/File_generated.swift
@@ -120,7 +120,7 @@ public struct org_apache_arrow_flatbuf_Footer: FlatBufferObject, Verifiable {
     let o = _accessor.offset(VTOFFSET.schema.v)
     return o == 0
       ? nil
-      : org_apache_arrow_flatbuf_Schema(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+      : org_apache_arrow_flatbuf_Schema(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   public var hasDictionaries: Bool {
     let o = _accessor.offset(VTOFFSET.dictionaries.v)

--- a/Sources/SparkConnect/Message_generated.swift
+++ b/Sources/SparkConnect/Message_generated.swift
@@ -326,7 +326,7 @@ public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferObject, Verifiable
     return o == 0
       ? nil
       : org_apache_arrow_flatbuf_BodyCompression(
-        _accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+        _accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   public static func startRecordBatch(_ fbb: inout FlatBufferBuilder) -> UOffset {
     fbb.startTable(with: 4)
@@ -433,7 +433,7 @@ public struct org_apache_arrow_flatbuf_DictionaryBatch: FlatBufferObject, Verifi
     return o == 0
       ? nil
       : org_apache_arrow_flatbuf_RecordBatch(
-        _accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+        _accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  If isDelta is true the values in the dictionary are to be appended to a
   ///  dictionary with the indicated id. If isDelta is false this dictionary

--- a/Sources/SparkConnect/Schema_generated.swift
+++ b/Sources/SparkConnect/Schema_generated.swift
@@ -1655,7 +1655,7 @@ public struct org_apache_arrow_flatbuf_DictionaryEncoding: FlatBufferObject, Ver
     let o = _accessor.offset(VTOFFSET.indexType.v)
     return o == 0
       ? nil
-      : org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+      : org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  By default, dictionaries are not ordered, or the order does not have
   ///  semantic meaning. In some statistical, applications, dictionary-encoding
@@ -1785,7 +1785,7 @@ public struct org_apache_arrow_flatbuf_Field: FlatBufferObject, Verifiable {
     return o == 0
       ? nil
       : org_apache_arrow_flatbuf_DictionaryEncoding(
-        _accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+        _accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  children apply only to nested data types like Struct, List and Union. For
   ///  primitive types children will have length 0.

--- a/Sources/SparkConnect/SparseTensor_generated.swift
+++ b/Sources/SparkConnect/SparseTensor_generated.swift
@@ -112,7 +112,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferObject, V
   ///  The type of values in indicesBuffer
   public var indicesType: org_apache_arrow_flatbuf_Int! {
     let o = _accessor.offset(VTOFFSET.indicesType.v)
-    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  Non-negative byte offsets to advance one value cell along each dimension
   ///  If omitted, default to row-major order (C-like).
@@ -139,7 +139,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferObject, V
   }
   public var mutableIndicesBuffer: org_apache_arrow_flatbuf_Buffer_Mutable! {
     let o = _accessor.offset(VTOFFSET.indicesBuffer.v)
-    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.postion)
+    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.position)
   }
   ///  This flag is true if and only if the indices matrix is sorted in
   ///  row-major order, and does not have duplicated entries.
@@ -251,7 +251,7 @@ public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferObject, V
   ///  The type of values in indptrBuffer
   public var indptrType: org_apache_arrow_flatbuf_Int! {
     let o = _accessor.offset(VTOFFSET.indptrType.v)
-    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  indptrBuffer stores the location and size of indptr array that
   ///  represents the range of the rows.
@@ -282,12 +282,12 @@ public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferObject, V
   }
   public var mutableIndptrBuffer: org_apache_arrow_flatbuf_Buffer_Mutable! {
     let o = _accessor.offset(VTOFFSET.indptrBuffer.v)
-    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.postion)
+    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.position)
   }
   ///  The type of values in indicesBuffer
   public var indicesType: org_apache_arrow_flatbuf_Int! {
     let o = _accessor.offset(VTOFFSET.indicesType.v)
-    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  indicesBuffer stores the location and size of the array that
   ///  contains the column indices of the corresponding non-zero values.
@@ -304,7 +304,7 @@ public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferObject, V
   }
   public var mutableIndicesBuffer: org_apache_arrow_flatbuf_Buffer_Mutable! {
     let o = _accessor.offset(VTOFFSET.indicesBuffer.v)
-    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.postion)
+    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.position)
   }
   public static func startSparseMatrixIndexCSX(_ fbb: inout FlatBufferBuilder) -> UOffset {
     fbb.startTable(with: 5)
@@ -440,7 +440,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
   ///  The type of values in indptrBuffers
   public var indptrType: org_apache_arrow_flatbuf_Int! {
     let o = _accessor.offset(VTOFFSET.indptrType.v)
-    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  indptrBuffers stores the sparsity structure.
   ///  Each two consecutive dimensions in a tensor correspond to a buffer in
@@ -481,7 +481,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
   ///  The type of values in indicesBuffers
   public var indicesType: org_apache_arrow_flatbuf_Int! {
     let o = _accessor.offset(VTOFFSET.indicesType.v)
-    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.postion))
+    return org_apache_arrow_flatbuf_Int(_accessor.bb, o: _accessor.indirect(o + _accessor.position))
   }
   ///  indicesBuffers stores values of nodes.
   ///  Each tensor dimension corresponds to a buffer in indicesBuffers.
@@ -696,7 +696,7 @@ public struct org_apache_arrow_flatbuf_SparseTensor: FlatBufferObject, Verifiabl
   }
   public var mutableData: org_apache_arrow_flatbuf_Buffer_Mutable! {
     let o = _accessor.offset(VTOFFSET.data.v)
-    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.postion)
+    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.position)
   }
   public static func startSparseTensor(_ fbb: inout FlatBufferBuilder) -> UOffset {
     fbb.startTable(with: 7)

--- a/Sources/SparkConnect/Tensor_generated.swift
+++ b/Sources/SparkConnect/Tensor_generated.swift
@@ -170,7 +170,7 @@ public struct org_apache_arrow_flatbuf_Tensor: FlatBufferObject, Verifiable {
   }
   public var mutableData: org_apache_arrow_flatbuf_Buffer_Mutable! {
     let o = _accessor.offset(VTOFFSET.data.v)
-    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.postion)
+    return org_apache_arrow_flatbuf_Buffer_Mutable(_accessor.bb, o: o + _accessor.position)
   }
   public static func startTensor(_ fbb: inout FlatBufferBuilder) -> UOffset {
     fbb.startTable(with: 5)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `FlatBuffers` to `v25.2.10` from `v24.3.7`.

### Why are the changes needed?

`FlatBuffers` `v24.3.7` was released over one year ago (on Mar 8, 2024), we had better use the latest version in order to support `Swift 6` officially.
- https://github.com/google/flatbuffers/releases/tag/v25.2.10 (2025-02-11)
    - https://github.com/google/flatbuffers/pull/8414
- https://github.com/google/flatbuffers/releases/tag/v25.1.24 (2025-01-25)
- https://github.com/google/flatbuffers/releases/tag/v25.1.21 (2025-01-22)
- https://github.com/google/flatbuffers/releases/tag/v24.12.23 (2024-12-24)
    - https://github.com/google/flatbuffers/pull/8330
- https://github.com/google/flatbuffers/releases/tag/v24.3.25 (2024-03-26)

### Does this PR introduce _any_ user-facing change?

No. There is no behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.