### PR TITLE
[SPARK-51782] Add `build-ubuntu-arm` test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,23 +83,6 @@ jobs:
     - name: Test
       run: swift test --no-parallel
 
-  integration-test-linux-arm:
-    runs-on: ubuntu-24.04-arm
-    services:
-      spark:
-        image: apache/spark:4.0.0-preview2
-        env:
-          SPARK_NO_DAEMONIZE: 1
-        ports:
-          - 15002:15002
-        options: --entrypoint /opt/spark/sbin/start-connect-server.sh
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test
-      run: |
-        docker run swift:6.1 uname -a
-        docker run -v $PWD:/orc -w /orc swift:6.1 swift test --no-parallel
-
   integration-test-mac:
     runs-on: macos-15
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,6 +55,16 @@ jobs:
     - name: Build
       run: swift build -v
 
+  # setup-swift doesn't support ARM linux yet.
+  build-ubuntu-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker run swift:6.1 uname -a
+        docker run -v $PWD:/orc -w /orc swift:6.1 swift build -v
+
   integration-test-linux:
     runs-on: ubuntu-latest
     services:
@@ -72,6 +82,23 @@ jobs:
         swift-version: "6.1"
     - name: Test
       run: swift test --no-parallel
+
+  integration-test-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    services:
+      spark:
+        image: apache/spark:4.0.0-preview2
+        env:
+          SPARK_NO_DAEMONIZE: 1
+        ports:
+          - 15002:15002
+        options: --entrypoint /opt/spark/sbin/start-connect-server.sh
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test
+      run: |
+        docker run swift:6.1 uname -a
+        docker run -v $PWD:/orc -w /orc swift:6.1 swift test --no-parallel
 
   integration-test-mac:
     runs-on: macos-15


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `build-ubuntu-arm` test pipeline.

### Why are the changes needed?

`Linux` arm64 architecture becomes public preview as a new GitHub Action runner. We had better utilize this resource in our test infra.
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Since `setup-swift` GitHub Action doesn't support `ubuntu-24.04-arm` yet, this PR runs the `Swift` docker image on `ubuntu-24.04-arm` GitHub Action runner.
- https://github.com/swift-actions/setup-swift/issues/705

`Swift` Docker images support both `AMD64` and `ARM64` architectures.
- https://hub.docker.com/layers/library/swift/6.1.0/images/sha256-e0ce72c88f5f446d5e0c149d34c7b6d29a33d6410b228d55b575988f9e02e15a

    <img width="426" alt="Screenshot 2025-04-21 at 16 59 50" src="https://github.com/user-attachments/assets/b40146de-db98-4a90-9954-2a44439ee9db" />

### How was this patch tested?

After passing the CIs and check the following in the CI logs.

```
Linux 114e749feb29 6.8.0-1021-azure #25-Ubuntu SMP Wed Jan 15 20:23:05 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
```

### Was this patch authored or co-authored using generative AI tooling?

No.