### PR TITLE
[SPARK-51784] Support `xml` in `DataFrame(Reader/Writer)`

### DIFF
--- a/Sources/SparkConnect/DataFrameReader.swift
+++ b/Sources/SparkConnect/DataFrameReader.swift
@@ -160,6 +160,22 @@ public actor DataFrameReader: Sendable {
     return load(paths)
   }
 
+  /// Loads an XML file and returns the result as a `DataFrame`.
+  /// - Parameter path: A path string
+  /// - Returns: A `DataFrame`.
+  public func xml(_ path: String) -> DataFrame {
+    self.source = "xml"
+    return load(path)
+  }
+
+  /// Loads XML files and returns the result as a `DataFrame`.
+  /// - Parameter paths: Path strings
+  /// - Returns: A `DataFrame`.
+  public func xml(_ paths: String...) -> DataFrame {
+    self.source = "xml"
+    return load(paths)
+  }
+
   /// Loads an ORC file and returns the result as a `DataFrame`.
   /// - Parameter path: A path string
   /// - Returns: A `DataFrame`.

--- a/Sources/SparkConnect/DataFrameWriter.swift
+++ b/Sources/SparkConnect/DataFrameWriter.swift
@@ -171,6 +171,14 @@ public actor DataFrameWriter: Sendable {
     return try await save(path)
   }
 
+  /// Saves the content of the `DataFrame` in XML format at the specified path.
+  /// - Parameter path: A path string
+  /// - Returns: A `DataFrame`.
+  public func xml(_ path: String) async throws {
+    self.source = "xml"
+    return try await save(path)
+  }
+
   /// Saves the content of the `DataFrame` in ORC format at the specified path.
   /// - Parameter path: A path string
   /// - Returns: A `DataFrame`.

--- a/Tests/SparkConnectTests/DataFrameReaderTests.swift
+++ b/Tests/SparkConnectTests/DataFrameReaderTests.swift
@@ -46,6 +46,16 @@ struct DataFrameReaderTests {
   }
 
   @Test
+  func xml() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let path = "../examples/src/main/resources/people.xml"
+    #expect(try await spark.read.option("rowTag", "person").format("xml").load(path).count() == 3)
+    #expect(try await spark.read.option("rowTag", "person").xml(path).count() == 3)
+    #expect(try await spark.read.option("rowTag", "person").xml(path, path).count() == 6)
+    await spark.stop()
+  }
+
+  @Test
   func orc() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let path = "../examples/src/main/resources/users.orc"

--- a/Tests/SparkConnectTests/DataFrameWriterTests.swift
+++ b/Tests/SparkConnectTests/DataFrameWriterTests.swift
@@ -44,6 +44,15 @@ struct DataFrameWriterTests {
   }
 
   @Test
+  func xml() async throws {
+    let tmpDir = "/tmp/" + UUID().uuidString
+    let spark = try await SparkSession.builder.getOrCreate()
+    try await spark.range(2025).write.option("rowTag", "person").xml(tmpDir)
+    #expect(try await spark.read.option("rowTag", "person").xml(tmpDir).count() == 2025)
+    await spark.stop()
+  }
+
+  @Test
   func orc() async throws {
     let tmpDir = "/tmp/" + UUID().uuidString
     let spark = try await SparkSession.builder.getOrCreate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `xml` API in `DataFrameReader` and `DataFrameWriter`.

### Why are the changes needed?

`xml` API is newly added at `Apache Spark 4.0.0`. We had better support this for the feature parity.

https://github.com/apache/spark/blob/e0801d9d8e33cd8835f3e3beed99a3588c16b776/sql/api/src/main/scala/org/apache/spark/sql/DataFrameReader.scala#L394-L403

```scala
  /**
   * Loads a XML file and returns the result as a `DataFrame`. See the documentation on the other
   * overloaded `xml()` method for more details.
   *
   * @since 4.0.0
   */
  def xml(path: String): DataFrame = {
    // This method ensures that calls that explicit need single argument works, see SPARK-16009
    xml(Seq(path): _*)
  }
```

### Does this PR introduce _any_ user-facing change?

No, this is a new addition.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.