### PR TITLE
[SPARK-51787] Remove `sessionID` parameter from `getExecutePlanRequest`

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -139,7 +139,7 @@ public actor DataFrame: Sendable {
       )
     ) { client in
       let service = Spark_Connect_SparkConnectService.Client(wrapping: client)
-      try await service.executePlan(spark.client.getExecutePlanRequest(spark.sessionID, plan)) {
+      try await service.executePlan(spark.client.getExecutePlanRequest(plan)) {
         response in
         for try await m in response.messages {
           counter.add(m.arrowBatch.rowCount, ordering: .relaxed)
@@ -158,7 +158,7 @@ public actor DataFrame: Sendable {
       )
     ) { client in
       let service = Spark_Connect_SparkConnectService.Client(wrapping: client)
-      try await service.executePlan(spark.client.getExecutePlanRequest(spark.sessionID, plan)) {
+      try await service.executePlan(spark.client.getExecutePlanRequest(plan)) {
         response in
         for try await m in response.messages {
           if m.hasSchema {

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -222,7 +222,7 @@ public actor SparkConnectClient {
   /// - Parameters:
   ///   - plan: A plan to execute.
   /// - Returns: An ``ExecutePlanRequest`` instance.
-  func getExecutePlanRequest(_ sessionID: String, _ plan: Plan) async
+  func getExecutePlanRequest(_ plan: Plan) async
     -> ExecutePlanRequest
   {
     var request = ExecutePlanRequest()
@@ -402,7 +402,7 @@ public actor SparkConnectClient {
       let service = SparkConnectService.Client(wrapping: client)
       var plan = Plan()
       plan.opType = .command(command)
-      try await service.executePlan(getExecutePlanRequest(sessionID, plan)) {
+      try await service.executePlan(getExecutePlanRequest(plan)) {
         response in
         for try await m in response.messages {
           await self.addResponse(m)

--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -50,17 +50,16 @@ struct SparkConnectClientTests {
   @Test
   func tags() async throws {
     let client = SparkConnectClient(remote: "sc://localhost", user: "test")
-    let sessionID = UUID().uuidString
-    let _ = try await client.connect(sessionID)
+    let _ = try await client.connect(UUID().uuidString)
     let plan = await client.getPlanRange(0, 1, 1)
 
-    #expect(await client.getExecutePlanRequest(sessionID, plan).tags.isEmpty)
+    #expect(await client.getExecutePlanRequest(plan).tags.isEmpty)
     try await client.addTag(tag: "tag1")
 
-    #expect(await client.getExecutePlanRequest(sessionID, plan).tags == ["tag1"])
+    #expect(await client.getExecutePlanRequest(plan).tags == ["tag1"])
     await client.clearTags()
 
-    #expect(await client.getExecutePlanRequest(sessionID, plan).tags.isEmpty)
+    #expect(await client.getExecutePlanRequest(plan).tags.isEmpty)
     await client.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes unused parameter `sessionID` from `getExecutePlanRequest`.

### Why are the changes needed?

We use the existing `self.sessionID` in this method. `sessionID` parameter is a leftover during refactoring.

### Does this PR introduce _any_ user-facing change?

No. This is an internal API change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.