### PR TITLE
[SPARK-51793] Support `ddlParse` and `jsonToDdl` in `SparkConnectClient`

### DIFF
--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -62,4 +62,22 @@ struct SparkConnectClientTests {
     #expect(await client.getExecutePlanRequest(plan).tags.isEmpty)
     await client.stop()
   }
+
+  @Test
+  func ddlParse() async throws {
+    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let _ = try await client.connect(UUID().uuidString)
+    #expect(try await client.ddlParse("a int").simpleString == "struct<a:int>")
+    await client.stop()
+  }
+
+  @Test
+  func jsonToDdl() async throws {
+    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let _ = try await client.connect(UUID().uuidString)
+    let json =
+      #"{"type":"struct","fields":[{"name":"id","type":"long","nullable":false,"metadata":{}}]}"#
+    #expect(try await client.jsonToDdl(json) == "id BIGINT NOT NULL")
+    await client.stop()
+  }
 }

--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -71,6 +71,7 @@ struct SparkConnectClientTests {
     await client.stop()
   }
 
+#if !os(Linux) // TODO: Enable this with the offical Spark 4 docker image
   @Test
   func jsonToDdl() async throws {
     let client = SparkConnectClient(remote: "sc://localhost", user: "test")
@@ -80,4 +81,5 @@ struct SparkConnectClientTests {
     #expect(try await client.jsonToDdl(json) == "id BIGINT NOT NULL")
     await client.stop()
   }
+#endif
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `ddlParse` and `jsonToDdl` in `SparkConnectClient`.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No, these will be used internally.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.