### PR TITLE
[SPARK-51808] Use Swift 6.1 in GitHub Action CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,9 +49,9 @@ jobs:
           - macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.2.0
+    - uses: swift-actions/setup-swift@v2.3.0
       with:
-        swift-version: "6"
+        swift-version: "6.1"
     - name: Build
       run: swift build -v
 
@@ -67,9 +67,9 @@ jobs:
         options: --entrypoint /opt/spark/sbin/start-connect-server.sh
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.2.0
+    - uses: swift-actions/setup-swift@v2.3.0
       with:
-        swift-version: "6"
+        swift-version: "6.1"
     - name: Test
       run: swift test --no-parallel
 
@@ -77,9 +77,9 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.2.0
+    - uses: swift-actions/setup-swift@v2.3.0
       with:
-        swift-version: "6"
+        swift-version: "6.1"
     - name: Test
       run: |
         curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc4-bin/spark-4.0.0-bin-hadoop3.tgz


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Swift` 6.1 in GitHub Action CIs while keeping the minimum version is still 6.0.

### Why are the changes needed?

Swift community released 6.1 on March 31, 2025. We had better use the latest version to have a test coverage.
- https://www.swift.org/blog/swift-6.1-released/
  - [ST-0007: Testing Scope Traits](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0007-test-scoping-traits.md)

To bring Swift 6.1, `setup-swift` is upgraded to `v2.3.0`.
- https://github.com/swift-actions/setup-swift/releases/tag/v2.3.0
  - https://github.com/swift-actions/setup-swift/pull/693

### Does this PR introduce _any_ user-facing change?

No, this is a test infra only change.

### How was this patch tested?

Pass the CIs and check the CI log manually.
```
Apple Swift version 6.1 (swift-6.1-RELEASE)
```

### Was this patch authored or co-authored using generative AI tooling?

No.