### PR TITLE
[SPARK-51841] Support `isLocal` and `isStreaming` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -556,4 +556,24 @@ public actor SparkConnectClient {
     plan.opType = .root(relation)
     return plan
   }
+
+  func getIsLocal(_ sessionID: String, _ plan: Plan) async -> AnalyzePlanRequest {
+    return analyze(
+      sessionID,
+      {
+        var isLocal = AnalyzePlanRequest.IsLocal()
+        isLocal.plan = plan
+        return OneOf_Analyze.isLocal(isLocal)
+      })
+  }
+
+  func getIsStreaming(_ sessionID: String, _ plan: Plan) async -> AnalyzePlanRequest {
+    return analyze(
+      sessionID,
+      {
+        var isStreaming = AnalyzePlanRequest.IsStreaming()
+        isStreaming.plan = plan
+        return OneOf_Analyze.isStreaming(isStreaming)
+      })
+  }
 }

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -252,6 +252,22 @@ struct DataFrameTests {
     await spark.stop()
   }
 
+  @Test
+  func isLocal() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.sql("SHOW DATABASES").isLocal())
+    #expect(try await spark.sql("SHOW TABLES").isLocal())
+    #expect(try await spark.range(1).isLocal() == false)
+    await spark.stop()
+  }
+
+  @Test
+  func isStreaming() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.range(1).isStreaming() == false)
+    await spark.stop()
+  }
+
 #if !os(Linux)
   @Test
   func sort() async throws {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `isLocal` and `isStreaming` for `DataFrame`.

### Why are the changes needed?

For feature parity. In addition, these APIs are required during other API implementations.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.