### PR TITLE
[SPARK-51846] Upgrade `gRPC Swift Protobuf` to 1.2 and `gRPC Swift NIO Transport` to 1.0.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.1.2"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.1.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.2"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.2.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.3"),
     .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift Protobuf` to 1.2.0 and `gRPC Swift NIO Transport` to 1.0.3.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.2.0
  - https://github.com/grpc/grpc-swift-protobuf/pull/58
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.0.3

### Does this PR introduce _any_ user-facing change?

No, there is no behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.