### PR TITLE
[SPARK-51850] Fix `DataFrame.execute` to reset previously received Arrow batch data

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -151,6 +151,9 @@ public actor DataFrame: Sendable {
 
   /// Execute the plan and try to fill `schema` and `batches`.
   private func execute() async throws {
+    // Clear all existing batches.
+    self.batches.removeAll()
+
     try await withGRPCClient(
       transport: .http2NIOPosix(
         target: .dns(host: spark.client.host, port: spark.client.port),

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -312,6 +312,15 @@ struct DataFrameTests {
   }
 
   @Test
+  func collectMultiple() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    #expect(try await df.collect().count == 1)
+    #expect(try await df.collect().count == 1)
+    await spark.stop()
+  }
+
+  @Test
   func head() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(try await spark.range(0).head().isEmpty)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `DataFrame.execute` to reset previously received Arrow batch data.

### Why are the changes needed?

To prevent wrong data duplication when repeating execution on the same `DataFrame`.

### Does this PR introduce _any_ user-facing change?

This, this is a bug fix.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.