### PR TITLE
[SPARK-51852] Support `SPARK_CONNECT_AUTHENTICATE_TOKEN`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,3 +88,21 @@ jobs:
         ./start-connect-server.sh
         cd ../..
         swift test --no-parallel
+
+  integration-test-token:
+    runs-on: macos-15
+    env:
+      SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: swift-actions/setup-swift@v2.3.0
+      with:
+        swift-version: "6.1"
+    - name: Test
+      run: |
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc4-bin/spark-4.0.0-bin-hadoop3.tgz
+        tar xvfz spark-4.0.0-bin-hadoop3.tgz
+        cd spark-4.0.0-bin-hadoop3/sbin
+        ./start-connect-server.sh
+        cd ../..
+        swift test --no-parallel

--- a/Sources/SparkConnect/BearerTokenInterceptor.swift
+++ b/Sources/SparkConnect/BearerTokenInterceptor.swift
@@ -1,0 +1,44 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+import GRPCCore
+
+struct BearerTokenInterceptor: ClientInterceptor {
+  let token: String
+
+  init(token: String) {
+    self.token = token
+  }
+
+  func intercept<Input: Sendable, Output: Sendable>(
+    request: StreamingClientRequest<Input>,
+    context: ClientContext,
+    next: (
+      _ request: StreamingClientRequest<Input>,
+      _ context: ClientContext
+    ) async throws -> StreamingClientResponse<Output>
+  ) async throws -> StreamingClientResponse<Output> {
+    var request = request
+    request.metadata.addString("Bearer \(self.token)", forKey: "Authorization")
+
+    // Forward the request to the next interceptor.
+    return try await next(request, context)
+  }
+}

--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -117,7 +117,8 @@ public actor DataFrame: Sendable {
       transport: .http2NIOPosix(
         target: .dns(host: spark.client.host, port: spark.client.port),
         transportSecurity: .plaintext
-      )
+      ),
+      interceptors: spark.client.getIntercepters()
     ) { client in
       return try await f(client)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `SPARK_CONNECT_AUTHENTICATE_TOKEN`.

### Why are the changes needed?

To provide a secure connection between Spark Connect server and `Swift` client.

### Does this PR introduce _any_ user-facing change?

No, this will enable to connect to the secured server.

### How was this patch tested?

Pass the CIs
- Unsecured environment with the existing test pipelines.
- Secured environment with the newly added `integration-test-token` test pipeline.

### Was this patch authored or co-authored using generative AI tooling?

No.