### PR TITLE
[SPARK-51854] Remove `SwiftyTextTable` dependency and unused `import` statements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,6 @@ let package = Package(
     .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.1.2"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.2.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.3"),
-    .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [
@@ -47,7 +46,6 @@ let package = Package(
         .product(name: "GRPCCore", package: "grpc-swift"),
         .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
         .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
-        .product(name: "SwiftyTextTable", package: "SwiftyTextTable"),
         .product(name: "FlatBuffers", package: "flatbuffers"),
       ]
     ),

--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -21,8 +21,6 @@ import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2
 import GRPCProtobuf
-import NIOCore
-import SwiftyTextTable
 import Synchronization
 
 /// A DataFrame which supports only SQL queries

--- a/Sources/SparkConnect/DataFrameReader.swift
+++ b/Sources/SparkConnect/DataFrameReader.swift
@@ -16,14 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-import Atomics
 import Foundation
-import GRPCCore
-import GRPCNIOTransportHTTP2
-import GRPCProtobuf
-import NIOCore
-import SwiftyTextTable
-import Synchronization
 
 /// An interface used to load a `DataFrame` from external storage systems
 /// (e.g. file systems, key-value stores, etc). Use `SparkSession.read` to access this.

--- a/Sources/SparkConnect/DataFrameWriter.swift
+++ b/Sources/SparkConnect/DataFrameWriter.swift
@@ -16,14 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-import Atomics
 import Foundation
-import GRPCCore
-import GRPCNIOTransportHTTP2
-import GRPCProtobuf
-import NIOCore
-import SwiftyTextTable
-import Synchronization
 
 /// An interface used to write a `DataFrame` to external storage systems
 /// (e.g. file systems, key-value stores, etc). Use `DataFrame.write` to access this.

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -20,7 +20,6 @@ import Foundation
 import GRPCCore
 import GRPCNIOTransportHTTP2
 import GRPCProtobuf
-import Synchronization
 
 /// Conceptually the remote spark session that communicates with the server
 public actor SparkConnectClient {

--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -19,10 +19,6 @@
 
 import Dispatch
 import Foundation
-import GRPCCore
-import GRPCNIOTransportHTTP2
-import GRPCProtobuf
-import Synchronization
 
 /// The entry point to programming Spark with ``DataFrame`` API.
 ///


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused `SwiftTextTable` dependency and unused `import` statements.

### Why are the changes needed?

To simplify project by removing the unused leftover dependency and `import` statement.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.