### PR TITLE
[SPARK-51857] Support `token/userId/userAgent` parameters in `SparkConnectClient`

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -17,7 +17,6 @@
 // under the License.
 //
 
-import Dispatch
 import Foundation
 
 /// The entry point to programming Spark with ``DataFrame`` API.
@@ -39,15 +38,8 @@ public actor SparkSession {
   /// Create a session that uses the specified connection string and userID.
   /// - Parameters:
   ///   - connection: a string in a patter, `sc://{host}:{port}`
-  ///   - userID: an optional user ID. If absent, `SPARK_USER` environment or ``ProcessInfo.processInfo.userName`` is used.
-  init(_ connection: String, _ userID: String? = nil) {
-    let processInfo = ProcessInfo.processInfo
-#if os(macOS) || os(Linux)
-    let userName = processInfo.environment["SPARK_USER"] ?? processInfo.userName
-#else
-    let userName = processInfo.environment["SPARK_USER"] ?? ""
-#endif
-    self.client = SparkConnectClient(remote: connection, user: userID ?? userName)
+  init(_ connection: String) {
+    self.client = SparkConnectClient(remote: connection)
     self.conf = RuntimeConf(self.client)
   }
 

--- a/Tests/SparkConnectTests/RuntimeConfTests.swift
+++ b/Tests/SparkConnectTests/RuntimeConfTests.swift
@@ -27,7 +27,7 @@ import Testing
 struct RuntimeConfTests {
   @Test
   func get() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     _ = try await client.connect(UUID().uuidString)
     let conf = RuntimeConf(client)
 
@@ -42,7 +42,7 @@ struct RuntimeConfTests {
 
   @Test
   func set() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     _ = try await client.connect(UUID().uuidString)
     let conf = RuntimeConf(client)
     try await conf.set("spark.test.key1", "value1")
@@ -52,7 +52,7 @@ struct RuntimeConfTests {
 
   @Test
   func reset() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     _ = try await client.connect(UUID().uuidString)
     let conf = RuntimeConf(client)
 
@@ -73,7 +73,7 @@ struct RuntimeConfTests {
 
   @Test
   func getAll() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     _ = try await client.connect(UUID().uuidString)
     let conf = RuntimeConf(client)
     let map = try await conf.getAll()

--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -27,13 +27,24 @@ import Testing
 struct SparkConnectClientTests {
   @Test
   func createAndStop() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
+    await client.stop()
+  }
+
+  @Test
+  func parameters() async throws {
+    let client = SparkConnectClient(remote: "sc://host1:123/;token=abcd;userId=test;userAgent=myagent")
+    #expect(await client.token == "abcd")
+    #expect(await client.userContext.userID == "test")
+    #expect(await client.clientType == "myagent")
+    #expect(await client.host == "host1")
+    #expect(await client.port == 123)
     await client.stop()
   }
 
   @Test
   func connectWithInvalidUUID() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     try await #require(throws: SparkConnectError.InvalidSessionIDException) {
       let _ = try await client.connect("not-a-uuid-format")
     }
@@ -42,14 +53,14 @@ struct SparkConnectClientTests {
 
   @Test
   func connect() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     let _ = try await client.connect(UUID().uuidString)
     await client.stop()
   }
 
   @Test
   func tags() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     let _ = try await client.connect(UUID().uuidString)
     let plan = await client.getPlanRange(0, 1, 1)
 
@@ -65,7 +76,7 @@ struct SparkConnectClientTests {
 
   @Test
   func ddlParse() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     let _ = try await client.connect(UUID().uuidString)
     #expect(try await client.ddlParse("a int").simpleString == "struct<a:int>")
     await client.stop()
@@ -74,7 +85,7 @@ struct SparkConnectClientTests {
 #if !os(Linux) // TODO: Enable this with the offical Spark 4 docker image
   @Test
   func jsonToDdl() async throws {
-    let client = SparkConnectClient(remote: "sc://localhost", user: "test")
+    let client = SparkConnectClient(remote: "sc://localhost")
     let _ = try await client.connect(UUID().uuidString)
     let json =
       #"{"type":"struct","fields":[{"name":"id","type":"long","nullable":false,"metadata":{}}]}"#


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `token/userId/userAgent` parameters in `SparkConnectClient`. After this PR, `SparkConnectClient` understands the following parameters in its `remote` argument.

```
sc://host1:123/;token=abcd;userId=test;userAgent=myagent
```

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.