### PR TITLE
[SPARK-51864] Rename parameters and support case-insensitively

### DIFF
--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -49,7 +49,7 @@ public actor SparkConnectClient {
 #endif
     for param in self.url.path.split(separator: ";").dropFirst().filter({ !$0.isEmpty }) {
       let kv = param.split(separator: "=")
-      switch String(kv[0]) {
+      switch String(kv[0]).lowercased() {
       case URIParams.PARAM_USER_AGENT:
         clientType = String(kv[1])
       case URIParams.PARAM_TOKEN:
@@ -596,11 +596,11 @@ public actor SparkConnectClient {
   }
 
   private enum URIParams {
-    static let PARAM_USER_ID = "userId"
-    static let PARAM_USER_AGENT = "userAgent"
+    static let PARAM_GRPC_MAX_MESSAGE_SIZE = "grpc_max_message_size"
+    static let PARAM_SESSION_ID = "session_id"
     static let PARAM_TOKEN = "token"
-    static let PARAM_USE_SSL = "useSsl"
-    static let PARAM_SESSION_ID = "sessionId"
-    static let PARAM_GRPC_MAX_MESSAGE_SIZE = "grpcMaxMessageSize"
+    static let PARAM_USER_AGENT = "user_agent"
+    static let PARAM_USER_ID = "user_id"
+    static let PARAM_USE_SSL = "use_ssl"
   }
 }

--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -35,7 +35,7 @@ struct SparkConnectClientTests {
 
   @Test
   func parameters() async throws {
-    let client = SparkConnectClient(remote: "sc://host1:123/;token=abcd;userId=test;userAgent=myagent")
+    let client = SparkConnectClient(remote: "sc://host1:123/;tOkeN=abcd;user_ID=test;USER_agent=myagent")
     #expect(await client.token == "abcd")
     #expect(await client.userContext.userID == "test")
     #expect(await client.clientType == "myagent")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename parameters and support it case-insensitively according to the documentation.
- https://github.com/apache/spark/blob/master/sql/connect/docs/client-connection-string.md

### Why are the changes needed?

To match with the documentation.

### Does this PR introduce _any_ user-facing change?

No, this is a change on the unreleased version.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.