### PR TITLE
[SPARK-51912] Support `semanticHash` and `sameSemantics` in `DataFrame`

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -468,6 +468,20 @@ public actor DataFrame: Sendable {
     }
   }
 
+  /// Returns a `hashCode` of the logical query plan against this ``DataFrame``.
+  /// - Returns: A hashcode value.
+  public func semanticHash() async throws -> Int32 {
+    return try await self.spark.semanticHash(self.plan)
+  }
+
+  /// Returns `true` when the logical query plans inside both ``Dataset``s are equal and therefore
+  /// return same results.
+  /// - Parameter other: A ``DataFrame`` to compare.
+  /// - Returns: Whether the both logical plans are equal.
+  public func sameSemantics(other: DataFrame) async throws -> Bool {
+    return try await self.spark.sameSemantics(self.plan, other.getPlan() as! Plan)
+  }
+
   /// Prints the physical plan to the console for debugging purposes.
   public func explain() async throws {
     try await explain("simple")

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -568,6 +568,33 @@ public actor SparkConnectClient {
     }
   }
 
+  func sameSemantics(_ plan: Plan, _ otherPlan: Plan) async throws -> Bool {
+    try await withGPRC { client in
+      let service = SparkConnectService.Client(wrapping: client)
+      let request = analyze(self.sessionID!, {
+        var sameSemantics = AnalyzePlanRequest.SameSemantics()
+        sameSemantics.targetPlan = plan
+        sameSemantics.otherPlan = otherPlan
+        return OneOf_Analyze.sameSemantics(sameSemantics)
+      })
+      let response = try await service.analyzePlan(request)
+      return response.sameSemantics.result
+    }
+  }
+
+  func semanticHash(_ plan: Plan) async throws -> Int32 {
+    try await withGPRC { client in
+      let service = SparkConnectService.Client(wrapping: client)
+      let request = analyze(self.sessionID!, {
+        var semanticHash = AnalyzePlanRequest.SemanticHash()
+        semanticHash.plan = plan
+        return OneOf_Analyze.semanticHash(semanticHash)
+      })
+      let response = try await service.analyzePlan(request)
+      return response.semanticHash.result
+    }
+  }
+
   static func getJoin(
     _ left: Relation, _ right: Relation, _ joinType: JoinType,
     joinCondition: String? = nil, usingColumns: [String]? = nil

--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -171,6 +171,14 @@ public actor SparkSession {
     await client.clearTags()
   }
 
+  func sameSemantics(_ plan: Plan, _ otherPlan: Plan) async throws -> Bool {
+    return try await client.sameSemantics(plan, otherPlan)
+  }
+
+  func semanticHash(_ plan: Plan) async throws -> Int32 {
+    return try await client.semanticHash(plan)
+  }
+
   /// This is defined as the return type of `SparkSession.sparkContext` method.
   /// This is an empty `Struct` type because `sparkContext` method is designed to throw
   /// `UNSUPPORTED_CONNECT_FEATURE.SESSION_SPARK_CONTEXT`.

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -125,6 +125,16 @@ struct DataFrameTests {
   }
 
   @Test
+  func sameSemantics() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df1 = try await spark.range(1)
+    let df2 = try await spark.range(1)
+    #expect(try await df1.sameSemantics(other: df2))
+    #expect(try await df1.semanticHash() == df2.semanticHash())
+    await spark.stop()
+  }
+
+  @Test
   func explain() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     try await spark.range(1).explain()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
