### PR TITLE
[SPARK-51943] Upgrade `setup-swift` to `3.0` dev version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           - macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.3.0
+    - uses: swift-actions/setup-swift@next
       with:
         swift-version: "6.1"
     - name: Build
@@ -79,7 +79,7 @@ jobs:
         options: --entrypoint /opt/spark/sbin/start-connect-server.sh
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.3.0
+    - uses: swift-actions/setup-swift@next
       with:
         swift-version: "6.1"
     - name: Test
@@ -89,7 +89,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.3.0
+    - uses: swift-actions/setup-swift@next
       with:
         swift-version: "6.1"
     - name: Test
@@ -107,7 +107,7 @@ jobs:
       SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.3.0
+    - uses: swift-actions/setup-swift@next
       with:
         swift-version: "6.1"
     - name: Test
@@ -123,7 +123,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@v2.3.0
+    - uses: swift-actions/setup-swift@next
       with:
         swift-version: "6.1"
     - name: Install Java

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           - macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@next
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
     - name: Build
@@ -79,7 +79,7 @@ jobs:
         options: --entrypoint /opt/spark/sbin/start-connect-server.sh
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@next
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
     - name: Test
@@ -89,7 +89,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@next
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
     - name: Test
@@ -107,7 +107,7 @@ jobs:
       SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@next
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
     - name: Test
@@ -123,7 +123,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
-    - uses: swift-actions/setup-swift@next
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
     - name: Install Java


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `setup-swift` to `next` tag in order to test `setup-swift 3.0` dev version.
- https://github.com/swift-actions/setup-swift/pull/710

### Why are the changes needed?

To fix the flakiness issues during `Swift` installation on linux environment.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.