### PR TITLE
[SPARK-51968] Support `(cache|uncache|refresh)Table`, `refreshByPath`, `isCached`, `clearCache` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/SparkFileUtils.swift
+++ b/Sources/SparkConnect/SparkFileUtils.swift
@@ -64,6 +64,7 @@ public enum SparkFileUtils {
   /// Create a directory given the abstract pathname
   /// - Parameter url: An URL location.
   /// - Returns: Return true if the directory is successfully created; otherwise, return false.
+  @discardableResult
   static func createDirectory(at url: URL) -> Bool {
     let fileManager = FileManager.default
     do {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following APIs of `Catalog`.
- `cacheTable`
- `uncacheTable`
- `refreshTable`
- `refreshByPath`
- `isCached`
- `clearCache`

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.