### PR TITLE
[SPARK-51977] Improve `SparkSQLRepl` to support multiple lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,29 @@ spark-sql (default)> DROP DATABASE db1 CASCADE;
 spark-sql (default)> exit;
 ```
 
+Apache Spark 4 supports [SQL Pipe Syntax](https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc4-docs/_site/sql-pipe-syntax.html).
+
+```
+$ swift run
+...
+Build of product 'SparkSQLRepl' complete! (2.33s)
+Connected to Apache Spark 4.0.0 Server
+spark-sql (default)>
+FROM ORC.`/opt/spark/examples/src/main/resources/users.orc`
+|> AGGREGATE COUNT(*) cnt
+   GROUP BY name
+|> ORDER BY cnt DESC, name ASC
+;
++------+---+
+|  name|cnt|
++------+---+
+|Alyssa|  1|
+|   Ben|  1|
++------+---+
+
+Time taken: 159 ms
+```
+
 You can use `SPARK_REMOTE` to specify the [Spark Connect connection string](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) in order to provide more options.
 
 ```bash

--- a/Sources/SparkSQLRepl/main.swift
+++ b/Sources/SparkSQLRepl/main.swift
@@ -26,15 +26,20 @@ let spark = try await SparkSession.builder.getOrCreate()
 print("Connected to Apache Spark \(await spark.version) Server")
 
 var isRunning = true
+var lines = ""
 while isRunning {
-  print("spark-sql (\(try await spark.catalog.currentDatabase()))> ", terminator: "")
+  if lines.isEmpty {
+    print("spark-sql (\(try await spark.catalog.currentDatabase()))> ", terminator: "")
+  }
   guard let input = readLine() else {
     isRunning = false
     break
   }
+  lines += input + " "
 
-  let matches = input.matches(of: statement)
+  let matches = lines.matches(of: statement)
   for match in matches {
+    lines = ""
     switch match.1 {
     case "exit":
       isRunning = false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SparkSQLRepl` example to support multiple lines.

### Why are the changes needed?

To help users to check complex queries easily. As an example, SQL Pipe Syntax is added to the `README.md`.

```sql
FROM ORC.`/opt/spark/examples/src/main/resources/users.orc`
|> AGGREGATE COUNT(*) cnt
   GROUP BY name
|> ORDER BY cnt DESC, name ASC
;
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

After passing the CIs, do manual check. 

### Was this patch authored or co-authored using generative AI tooling?

No.