### PR TITLE
[SPARK-51994] Fix `ArrowType.Info.==` to support complex types

### DIFF
--- a/Sources/SparkConnect/ArrowType.swift
+++ b/Sources/SparkConnect/ArrowType.swift
@@ -388,6 +388,8 @@ extension ArrowType.Info: Equatable {
       return lhsId == rhsId
     case (.timeInfo(let lhsId), .timeInfo(let rhsId)):
       return lhsId == rhsId
+    case (.complexInfo(let lhsId), .complexInfo(let rhsId)):
+        return lhsId == rhsId
     default:
       return false
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ArrowType.Info.==` to support complex types.

### Why are the changes needed?

Previously, it returns false for the complex types like `struct`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.