### PR TITLE
[SPARK-51995] Support `toDF`, `distinct` and `dropDuplicates(WithinWatermark)?` in `DataFrame`

### DIFF
--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -455,6 +455,25 @@ public actor SparkConnectClient {
     return plan
   }
 
+  static func getDropDuplicates(
+    _ child: Relation,
+    _ columnNames: [String],
+    withinWatermark: Bool = false
+  ) -> Plan {
+    var deduplicate = Spark_Connect_Deduplicate()
+    deduplicate.input = child
+    if columnNames.isEmpty {
+      deduplicate.allColumnsAsKeys = true
+    } else {
+      deduplicate.columnNames = columnNames
+    }
+    var relation = Relation()
+    relation.deduplicate = deduplicate
+    var plan = Plan()
+    plan.opType = .root(relation)
+    return plan
+  }
+
   static func getSort(_ child: Relation, _ cols: [String]) -> Plan {
     var sort = Sort()
     sort.input = child

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -660,7 +660,7 @@ struct DataFrameTests {
   func distinct() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
-    #expect(try await df.distinct().collect() == [Row(1), Row(2), Row(3)])
+    #expect(try await df.distinct().count() == 3)
     await spark.stop()
   }
 
@@ -668,8 +668,8 @@ struct DataFrameTests {
   func dropDuplicates() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
-    #expect(try await df.dropDuplicates().collect() == [Row(1), Row(2), Row(3)])
-    #expect(try await df.dropDuplicates("a").collect() == [Row(1), Row(2), Row(3)])
+    #expect(try await df.dropDuplicates().count() == 3)
+    #expect(try await df.dropDuplicates("a").count() == 3)
     await spark.stop()
   }
 
@@ -677,8 +677,8 @@ struct DataFrameTests {
   func dropDuplicatesWithinWatermark() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
-    #expect(try await df.dropDuplicatesWithinWatermark().collect() == [Row(1), Row(2), Row(3)])
-    #expect(try await df.dropDuplicatesWithinWatermark("a").collect() == [Row(1), Row(2), Row(3)])
+    #expect(try await df.dropDuplicatesWithinWatermark().count() == 3)
+    #expect(try await df.dropDuplicatesWithinWatermark("a").count() == 3)
     await spark.stop()
   }
 

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -183,11 +183,20 @@ struct DataFrameTests {
   @Test
   func select() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.range(1).select().columns.isEmpty)
     let schema = try await spark.range(1).select("id").schema
     #expect(
       schema
         == #"{"struct":{"fields":[{"name":"id","dataType":{"long":{}}}]}}"#
     )
+    await spark.stop()
+  }
+
+  @Test
+  func toDF() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.range(1).toDF().columns == ["id"])
+    #expect(try await spark.range(1).toDF("id").columns == ["id"])
     await spark.stop()
   }
 
@@ -644,6 +653,32 @@ struct DataFrameTests {
     }
     try await spark.range(1).coalesce(10).write.mode("overwrite").orc(tmpDir)
     #expect(try await spark.read.orc(tmpDir).inputFiles().count < 10)
+    await spark.stop()
+  }
+
+  @Test
+  func distinct() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
+    #expect(try await df.distinct().collect() == [Row(1), Row(2), Row(3)])
+    await spark.stop()
+  }
+
+  @Test
+  func dropDuplicates() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
+    #expect(try await df.dropDuplicates().collect() == [Row(1), Row(2), Row(3)])
+    #expect(try await df.dropDuplicates("a").collect() == [Row(1), Row(2), Row(3)])
+    await spark.stop()
+  }
+
+  @Test
+  func dropDuplicatesWithinWatermark() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (1), (3) T(a)")
+    #expect(try await df.dropDuplicatesWithinWatermark().collect() == [Row(1), Row(2), Row(3)])
+    #expect(try await df.dropDuplicatesWithinWatermark("a").collect() == [Row(1), Row(2), Row(3)])
     await spark.stop()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following APIs in `DataFrame`.

- `toDF`
- `distinct`
- `dropDuplicates`
- `dropDuplicatesWithinWatermark`

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.