### PR TITLE
[SPARK-52030] Make all test suites serialized

### DIFF
--- a/Tests/SparkConnectTests/CaseInsensitiveDictionaryTests.swift
+++ b/Tests/SparkConnectTests/CaseInsensitiveDictionaryTests.swift
@@ -23,6 +23,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for `CaseInsensitiveDictionary`
+@Suite(.serialized)
 struct CaseInsensitiveDictionaryTests {
   @Test
   func empty() async throws {

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -23,6 +23,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for `Catalog`
+@Suite(.serialized)
 struct CatalogTests {
 #if !os(Linux)
   @Test

--- a/Tests/SparkConnectTests/DataFrameInternalTests.swift
+++ b/Tests/SparkConnectTests/DataFrameInternalTests.swift
@@ -22,6 +22,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for `DataFrame` internal APIs
+@Suite(.serialized)
 struct DataFrameInternalTests {
 
 #if !os(Linux)

--- a/Tests/SparkConnectTests/DataFrameReaderTests.swift
+++ b/Tests/SparkConnectTests/DataFrameReaderTests.swift
@@ -23,6 +23,7 @@ import Testing
 import SparkConnect
 
 /// A test suite for `DataFrameReader`
+@Suite(.serialized)
 struct DataFrameReaderTests {
 
   @Test

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -23,6 +23,7 @@ import Testing
 import SparkConnect
 
 /// A test suite for `DataFrame`
+@Suite(.serialized)
 struct DataFrameTests {
   let DEALER_TABLE =
     """

--- a/Tests/SparkConnectTests/DataFrameWriterTests.swift
+++ b/Tests/SparkConnectTests/DataFrameWriterTests.swift
@@ -23,6 +23,7 @@ import Testing
 import SparkConnect
 
 /// A test suite for `DataFrameWriter`
+@Suite(.serialized)
 struct DataFrameWriterTests {
 
   @Test

--- a/Tests/SparkConnectTests/DataFrameWriterV2Tests.swift
+++ b/Tests/SparkConnectTests/DataFrameWriterV2Tests.swift
@@ -22,6 +22,7 @@ import SparkConnect
 import Testing
 
 /// A test suite for `DataFrameWriterV2`
+@Suite(.serialized)
 struct DataFrameWriterV2Tests {
 
   @Test

--- a/Tests/SparkConnectTests/RowTests.swift
+++ b/Tests/SparkConnectTests/RowTests.swift
@@ -22,6 +22,7 @@ import SparkConnect
 import Testing
 
 /// A test suite for `Row`
+@Suite(.serialized)
 struct RowTests {
   @Test
   func empty() {

--- a/Tests/SparkConnectTests/SQLTests.swift
+++ b/Tests/SparkConnectTests/SQLTests.swift
@@ -23,6 +23,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for various SQL statements.
+@Suite(.serialized)
 struct SQLTests {
   let fm = FileManager.default
   let path = Bundle.module.path(forResource: "queries", ofType: "")!

--- a/Tests/SparkConnectTests/SparkFileUtilsTests.swift
+++ b/Tests/SparkConnectTests/SparkFileUtilsTests.swift
@@ -23,6 +23,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for `SparkFileUtils`
+@Suite(.serialized)
 struct SparkFileUtilsTests {
   let fm = FileManager.default
 

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -23,6 +23,7 @@ import Testing
 @testable import SparkConnect
 
 /// A test suite for `SparkSession`
+@Suite(.serialized)
 struct SparkSessionTests {
   @Test
   func sparkContext() async throws {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make all test suites serialized.

### Why are the changes needed?

To stabilize CI runs by introducing a deterministic test order.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.