### PR TITLE
[SPARK-52059] Fix `DataFrame` to use SparkSession's `transportSecurity`

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -279,7 +279,7 @@ public actor DataFrame: Sendable {
     try await withGRPCClient(
       transport: .http2NIOPosix(
         target: .dns(host: spark.client.host, port: spark.client.port),
-        transportSecurity: .plaintext
+        transportSecurity: spark.client.transportSecurity
       ),
       interceptors: spark.client.getIntercepters()
     ) { client in


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `DataFrame` to use `SparkSession`'s `transportSecurity`.

### Why are the changes needed?

To support TLS correctly. This issue was reported during `v0.1.0 RC1` vote.

### Does this PR introduce _any_ user-facing change?

Yes, but it's a bug fix which the previous behavior is not proper.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.