### PR TITLE
[SPARK-52061] Add `getOption/isModifiable` and `set` variants to `RuntimeConf`

### DIFF
--- a/Sources/SparkConnect/RuntimeConf.swift
+++ b/Sources/SparkConnect/RuntimeConf.swift
@@ -35,6 +35,22 @@ public actor RuntimeConf {
     try await client.setConf(map: [key: value])
   }
 
+  /// Set a new configuration.
+  /// - Parameters:
+  ///   - key: A string for the configuration key.
+  ///   - value: A boolean value for the configuration.
+  public func set(_ key: String, _ value: Bool) async throws {
+    try await client.setConf(map: [key: String(value)])
+  }
+
+  /// Set a new configuration.
+  /// - Parameters:
+  ///   - key: A string for the configuration key.
+  ///   - value: A Int64 value for the configuration.
+  public func set(_ key: String, _ value: Int64) async throws {
+    try await client.setConf(map: [key: String(value)])
+  }
+
   /// Reset a configuration.
   /// - Parameters:
   ///   - key: A string for the configuration key.
@@ -42,16 +58,46 @@ public actor RuntimeConf {
     try await client.unsetConf(keys: [key])
   }
 
-  /// Get a configuration.
+  /// Returns the value of Spark runtime configuration property for the given key. If the key is
+  /// not set yet, return its default value if possible, otherwise `NoSuchElementException` will be
+  /// thrown.
   /// - Parameter key: A string for the configuration look-up.
   /// - Returns: A string for the configuration.
   public func get(_ key: String) async throws -> String {
     return try await client.getConf(key)
   }
 
+  /// Returns the value of Spark runtime configuration property for the given key. If the key is
+  /// not set yet, return the user given `value`. This is useful when its default value defined
+  /// by Apache Spark is not the desired one.
+  /// - Parameters:
+  ///   - key: A string for the configuration key.
+  ///   - value: A default string value for the configuration.
+  public func get(_ key: String, _ value: String) async throws -> String {
+    return try await client.getConfWithDefault(key, value)
+  }
+
   /// Get all configurations.
   /// - Returns: A map of configuration key-values.
   public func getAll() async throws -> [String: String] {
     return try await client.getConfAll()
+  }
+
+  /// Returns the value of Spark runtime configuration property for the given key. If the key is
+  /// not set yet, return its default value if possible, otherwise `nil` will be returned.
+  /// - Parameter key: A string for the configuration look-up.
+  /// - Returns: A string for the configuration or nil.
+  public func getOption(_ key: String) async throws -> String? {
+    return try await client.getConfOption(key)
+  }
+
+  /// Indicates whether the configuration property with the given key is modifiable in the current
+  /// session.
+  /// - Parameter key: A string for the configuration look-up.
+  /// - Returns: `true` if the configuration property is modifiable. For static SQL, Spark Core, invalid
+  /// (not existing) and other non-modifiable configuration properties, the returned value is
+  /// `false`.
+  public func isModifiable(_ key: String) async throws -> Bool {
+    return try await client.isModifiable(key)
   }
 }

--- a/Tests/SparkConnectTests/RuntimeConfTests.swift
+++ b/Tests/SparkConnectTests/RuntimeConfTests.swift
@@ -43,6 +43,26 @@ struct RuntimeConfTests {
   }
 
   @Test
+  func getWithDefault() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    try await client.connect(UUID().uuidString)
+    let conf = RuntimeConf(client)
+    #expect(try await conf.get("spark.sql.adaptive.customCostEvaluatorClass", "XYZ") == "XYZ")
+    #expect(try await conf.get("spark.test.non-exist", "my_default") == "my_default")
+    await client.stop()
+  }
+
+  @Test
+  func getOption() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    try await client.connect(UUID().uuidString)
+    let conf = RuntimeConf(client)
+    #expect(try await conf.getOption("spark.app.name") != nil)
+    #expect(try await conf.getOption("spark.test.non-exist") == nil)
+    await client.stop()
+  }
+
+  @Test
   func set() async throws {
     let client = SparkConnectClient(remote: TEST_REMOTE)
     try await client.connect(UUID().uuidString)
@@ -84,6 +104,17 @@ struct RuntimeConfTests {
     #expect(map["spark.app.startTime"] != nil)
     #expect(map["spark.executor.id"] == "driver")
     #expect(map["spark.master"] != nil)
+    await client.stop()
+  }
+
+  @Test
+  func isModifiable() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    try await client.connect(UUID().uuidString)
+    let conf = RuntimeConf(client)
+    #expect(try await conf.isModifiable("spark.sql.adaptive.customCostEvaluatorClass"))
+    #expect(try await conf.isModifiable("spark.sql.warehouse.dir") == false)
+    #expect(try await conf.isModifiable("spark.test.non-exist") == false)
     await client.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `getOption`, `isModifiable` and more `set` API variants to `RuntimeConf`.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.