### PR TITLE
[SPARK-52063] Support `newSession` in `SparkSession`

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -46,6 +46,13 @@ public actor SparkSession {
   /// The Spark version of Spark Connect Servier. This is supposed to be overwritten during establishing connections.
   public var version: String = ""
 
+  /// Start a new session with isolated SQL configurations, temporary tables, registered functions
+  /// are isolated, but sharing the underlying `SparkContext` and cached data.
+  /// - Returns: a new ``SparkSession`` instance.
+  public func newSession() async throws -> SparkSession {
+    return try await SparkSession.builder.create()
+  }
+
   func setVersion(_ version: String) {
     self.version = version
   }

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -40,6 +40,16 @@ struct SparkSessionTests {
     await spark.stop()
   }
 
+  @Test
+  func newSession() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    await spark.stop()
+    let newSpark = try await spark.newSession()
+    #expect(newSpark != spark)
+    #expect(try await newSpark.range(1).count() == 1)
+    await newSpark.stop()
+  }
+
   @Test func userContext() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
 #if os(macOS) || os(Linux)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `newSession` API in `SparkSession`.

### Why are the changes needed?

For feature parity. 

### Does this PR introduce _any_ user-facing change?

No. This is an addition API.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.