### PR TITLE
[SPARK-52073] Add `pi` example

### DIFF
--- a/Examples/pi/Package.swift
+++ b/Examples/pi/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import PackageDescription
+
+let package = Package(
+  name: "SparkConnectSwiftPi",
+  platforms: [
+    .macOS(.v15)
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main")
+  ],
+  targets: [
+    .executableTarget(
+      name: "SparkConnectSwiftPi",
+      dependencies: [.product(name: "SparkConnect", package: "spark-connect-swift")]
+    )
+  ]
+)

--- a/Examples/pi/README.md
+++ b/Examples/pi/README.md
@@ -1,0 +1,14 @@
+# A Swift Application computing an approximation to pi with Apache Spark Connect Swift Client
+
+This is an example Swift application to show how to use Apache Spark Connect Swift Client library.
+
+## How to run
+
+Run this Swift application.
+
+```
+$ swift run SparkConnectSwiftPi 1000000
+...
+Connected to Apache Spark 4.0.0 Server
+Pi is roughly 3.1423711423711422
+```

--- a/Examples/pi/Sources/main.swift
+++ b/Examples/pi/Sources/main.swift
@@ -1,0 +1,35 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import SparkConnect
+
+let spark = try await SparkSession.builder.getOrCreate()
+
+let n: Int64 = CommandLine.arguments.count > 1 ? Int64(CommandLine.arguments[1])! : 1_000_000
+
+let count =
+  try await spark
+  .range(n)
+  .selectExpr("(pow(rand() * 2 - 1, 2) + pow(rand() * 2 - 1, 2)) as v")
+  .where("v <= 1")
+  .count()
+
+print("Pi is roughly \(4.0 * Double(count) / (Double(n) - 1))")
+
+await spark.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi` example.

### Why are the changes needed?

This is a Swift Pi example corresponding to `SparkDataFramePi.scala`. 
- https://github.com/apache/spark/blob/master/examples/src/main/scala/org/apache/spark/examples/sql/SparkDataFramePi.scala

```
$ swift run SparkConnectSwiftPi 1000000
...
Connected to Apache Spark 4.0.0 Server
Pi is roughly 3.1423711423711422
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.