### PR TITLE
[SPARK-52094][FOLLOWUP] Fix the test case to respect SPARK_REMOTE env variable

### DIFF
--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -54,8 +54,8 @@ struct SparkSessionTests {
   func sessionID() async throws {
     let spark1 = try await SparkSession.builder.getOrCreate()
     await spark1.stop()
-    let remote = "sc://localhost/;session_id=\(spark1.sessionID)"
-    let spark2 = try await SparkSession.builder.remote(remote).getOrCreate()
+    let remote = ProcessInfo.processInfo.environment["SPARK_REMOTE"] ?? "sc://localhost"
+    let spark2 = try await SparkSession.builder.remote("\(remote)/;session_id=\(spark1.sessionID)").getOrCreate()
     await spark2.stop()
     #expect(spark1.sessionID == spark2.sessionID)
     #expect(spark1 == spark2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following to fix the test case to respect `SPARK_REMOTE` env variable.
- #139 

### Why are the changes needed?

To recover linux CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.