### PR TITLE
[SPARK-52121] Enable `GitHub Pages`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,8 @@ github:
     merge: false
     squash: true
     rebase: true
+  ghp_branch: gh-pages
+  ghp_path: /
   autolink_jira: SPARK
 
 notifications:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `GitHub Pages` in `spark-connect-swift`.

### Why are the changes needed?

To provide `Apache Spark Connect Client for Swift` website at <https://apache.github.io/spark-connect-swift>

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.