### PR TITLE
[SPARK-52125] Create a daily linux integration test GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,25 +78,6 @@ jobs:
         docker run swift:6.1 uname -a
         docker run -v $PWD:/spark -w /spark swift:6.1 swift build -c release
 
-  integration-test-linux:
-    runs-on: ubuntu-latest
-    env:
-      SPARK_REMOTE: "sc://localhost:15003"
-    services:
-      spark:
-        image: apache/spark:4.0.0-preview2
-        env:
-          SPARK_NO_DAEMONIZE: 1
-        ports:
-          - 15003:15002
-        options: --entrypoint /opt/spark/sbin/start-connect-server.sh
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: |
-        docker run swift:6.1 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.1 swift test --no-parallel -c release
-
   integration-test-mac:
     runs-on: macos-15
     steps:

--- a/.github/workflows/integration_test_linux.yml
+++ b/.github/workflows/integration_test_linux.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Integration Test (linux)
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  integration-test-linux:
+    runs-on: ubuntu-latest
+    env:
+      SPARK_REMOTE: "sc://localhost:15003"
+    services:
+      spark:
+        image: apache/spark:4.0.0-preview2
+        env:
+          SPARK_NO_DAEMONIZE: 1
+        ports:
+          - 15003:15002
+        options: --entrypoint /opt/spark/sbin/start-connect-server.sh
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker run swift:6.1 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.1 swift test --no-parallel -c release


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a daily linux integration test GitHub Action job in order to move `linux-integration-test` into it while keeping `build-ubuntu-latest` and `build-ubuntu-arm`.

### Why are the changes needed?

To isolate the linux flakiness from the main PR builder and commit builder. Instead, this dedicated GitHub Action job will focus on the linux integration independently.

### Does this PR introduce _any_ user-facing change?

No. This is a test-infra change.

### How was this patch tested?

This PR will not trigger `integration-test-linux` job.

<img width="576" alt="Screenshot 2025-05-13 at 20 50 14" src="https://github.com/user-attachments/assets/f24e9835-73d0-42a4-bd04-8c9049e9d444" />

### Was this patch authored or co-authored using generative AI tooling?

No.