### PR TITLE
[SPARK-52138] Upgrade `gRPC Swift NIO Transport` to 1.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.2.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.2.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.0.3"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ So far, this library project is tracking the upstream changes like the [Apache S
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
 - [gRPC Swift 2.2 (May 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.2.0)
 - [gRPC Swift Protobuf 1.2 (April 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.2.0)
-- [gRPC Swift NIO Transport 1.0 (March 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.0.3)
+- [gRPC Swift NIO Transport 1.1 (May 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.1.0)
 - [FlatBuffers v25.2.10 (February 2025)](https://github.com/google/flatbuffers/releases/tag/v25.2.10)
 - [Apache Arrow Swift](https://github.com/apache/arrow/tree/main/swift)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift NIO Transport` library to 1.1.0.

### Why are the changes needed?

To bring the latest big fixes with the official Swift 6.1 tested version.
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.1.0
  - https://github.com/grpc/grpc-swift-nio-transport/pull/88
  - https://github.com/grpc/grpc-swift-nio-transport/pull/94
  - https://github.com/grpc/grpc-swift-nio-transport/pull/89

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.
