### PR TITLE
[SPARK-52152] Fix `Catalog.databaseExists` to handle multi catalogs

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -197,7 +197,14 @@ public actor Catalog: Sendable {
   /// - Parameter dbName: name of the database to check existence
   /// - Returns: Indicating whether the database exists.
   public func databaseExists(_ dbName: String) async throws -> Bool {
-    return try await self.listDatabases(pattern: dbName).count > 0
+    let df = getDataFrame({
+      var databaseExists = Spark_Connect_DatabaseExists()
+      databaseExists.dbName = dbName
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .databaseExists(databaseExists)
+      return catalog
+    })
+    return try await df.collect().first![0] as! Bool
   }
 
   /// Creates a table from the given path and returns the corresponding ``DataFrame``.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Catalog.databaseExists` to handle multi-catalogs.

### Why are the changes needed?

To handle Iceberg catalog.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. Apache Iceberg CI will be added soon.

### Was this patch authored or co-authored using generative AI tooling?

No.