### PR TITLE
[SPARK-52155] Update `.asf.yaml` to show Spark Connect Swift website

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,12 +17,13 @@
 ---
 github:
   description: "Apache Spark Connect Client for Swift"
-  homepage: https://spark.apache.org/
+  homepage: https://apache.github.io/spark-connect-swift/
   labels:
     - swift
     - big-data
     - sql
     - spark
+    - streaming
   enabled_merge_buttons:
     merge: false
     squash: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `.asf.yaml` to show https://apache.github.io/spark-connect-swift/ link in `About` page.

### Why are the changes needed?

It's very difficult to find relevant materials about `Spark Connect Swift Client` in Apache Spark main page. We had better show https://apache.github.io/spark-connect-swift/ as a landing page.

<img width="307" alt="Screenshot 2025-05-14 at 22 02 46" src="https://github.com/user-attachments/assets/1a96e3d0-3c1d-4965-a9c7-24bbd6c382fb" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.