### PR TITLE
[SPARK-52197] Upgrade `gRPC Swift` to 2.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.2.0"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.2.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.2.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ So far, this library project is tracking the upstream changes like the [Apache S
 
 - [Apache Spark 4.0.0 RC6 (May 2025)](https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc6-bin/)
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
-- [gRPC Swift 2.2 (May 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.2.0)
+- [gRPC Swift 2.2 (May 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.2.1)
 - [gRPC Swift Protobuf 1.2 (April 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.2.0)
 - [gRPC Swift NIO Transport 1.1 (May 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.1.0)
 - [FlatBuffers v25.2.10 (February 2025)](https://github.com/google/flatbuffers/releases/tag/v25.2.10)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift` to 2.2.1.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/grpc/grpc-swift/releases/tag/2.2.1
  - https://github.com/grpc/grpc-swift/pull/2234

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.