### PR TITLE
[SPARK-52248] Use `exact` versions of dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,9 +34,9 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "2.2.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "1.2.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "1.1.0"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.2.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `exact` versions of dependency.

### Why are the changes needed?

To prevent the unintended compilation failure. Currently, all builds are broken like the following due to the latest release issue.
- #165 

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs (recovering from the failure).

### Was this patch authored or co-authored using generative AI tooling?

No.