### PR TITLE
[SPARK-52271] Upgrade Spark to 4.0.0 in CIs and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -87,7 +87,7 @@ jobs:
         swift-version: "6.1"
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc7-bin/spark-4.0.0-bin-hadoop3.tgz
+        curl -LO https://dist.apache.org/repos/dist/release/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
         tar xvfz spark-4.0.0-bin-hadoop3.tgz
         mv spark-4.0.0-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
@@ -106,7 +106,7 @@ jobs:
         swift-version: "6.1"
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc7-bin/spark-4.0.0-bin-hadoop3.tgz
+        curl -LO https://dist.apache.org/repos/dist/release/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
         tar xvfz spark-4.0.0-bin-hadoop3.tgz
         mv spark-4.0.0-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin

--- a/Examples/spark-sql/README.md
+++ b/Examples/spark-sql/README.md
@@ -85,7 +85,7 @@ spark-sql (default)> DROP DATABASE db1 CASCADE;
 spark-sql (default)> exit;
 ```
 
-Apache Spark 4 supports [SQL Pipe Syntax](https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc7-docs/_site/sql-pipe-syntax.html).
+Apache Spark 4 supports [SQL Pipe Syntax](https://spark.apache.org/docs/4.0.0/sql-pipe-syntax.html).
 
 ```
 $ swift run

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ So far, this library project is tracking the upstream changes like the [Apache S
 
 ## Requirement
 
-- [Apache Spark 4.0.0 RC7 (May 2025)](https://dist.apache.org/repos/dist/dev/spark/v4.0.0-rc7-bin/)
+- [Apache Spark 4.0.0 RC7 (May 2025)](https://github.com/apache/spark/releases/tag/v4.0.0)
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
 - [gRPC Swift 2.2 (May 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.2.1)
 - [gRPC Swift Protobuf 1.3 (May 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.3.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Spark to 4.0.0 in GitHub Action CIs and docs.

### Why are the changes needed?

To recommend the official release of Apache Spark.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.