### PR TITLE
[SPARK-52322] Add `publish_image` GitHub Action job

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -1,0 +1,45 @@
+name: Publish Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      example:
+        description: 'list of examples to publish (JSON)'
+        required: true
+        # keep in sync with default value of strategy matrix 'example'
+        default: '["pi"]'
+
+jobs:
+  publish-image:
+    if: ${{ startsWith(github.repository, 'apache/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # keep in sync with default value of workflow_dispatch input 'example'
+        example: ${{ fromJSON( inputs.example || '["pi"]' ) }}
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: Examples/${{ matrix.example }}
+        file: Examples/${{ matrix.example }}/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: apache/spark-connect-swift:${{ matrix.example }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `publish_image` GitHub Action job.

### Why are the changes needed?

To publish the example docker images like `apache/spark-connect-swift:pi`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.