### PR TITLE
[SPARK-52359] Upgrade `gRPC Swift NIO Transport` to 1.2.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.3.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.1.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.2.2"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift NIO Transport` to 1.2.2 from 1.1.0.

### Why are the changes needed?

This brings the following improvements and bug fixes. Previously, 1.2.0 and 1.2.1 causes a crash in GitHub Action CI.
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.2.2
    - https://github.com/grpc/grpc-swift-nio-transport/pull/110
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.2.1
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.2.0
    - https://github.com/grpc/grpc-swift-nio-transport/pull/101
    - https://github.com/grpc/grpc-swift-nio-transport/pull/103
    - https://github.com/grpc/grpc-swift-nio-transport/pull/104

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.