### PR TITLE
[SPARK-52360] Upgrade `gRPC Swift` to 2.2.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.1"),
+    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.2"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.3.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift` to 2.2.2 from 2.2.1.

### Why are the changes needed?

To bring the latest bug fix.
- https://github.com/grpc/grpc-swift/releases/tag/2.2.2
    - https://github.com/grpc/grpc-swift/pull/2243

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.