### PR TITLE
[SPARK-52370] Update `Requirement` section to point the official Apache Arrow Swift repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ So far, this library project is tracking the upstream changes of [Apache Arrow](
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
 - [gRPC Swift 2.2 (May 2025)](https://github.com/grpc/grpc-swift/releases/tag/2.2.1)
 - [gRPC Swift Protobuf 1.3 (May 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/1.3.0)
-- [gRPC Swift NIO Transport 1.1 (May 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.1.0)
+- [gRPC Swift NIO Transport 1.2 (May 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/1.2.2)
 - [FlatBuffers v25.2.10 (February 2025)](https://github.com/google/flatbuffers/releases/tag/v25.2.10)
-- [Apache Arrow Swift](https://github.com/apache/arrow/tree/main/swift)
+- [Apache Arrow Swift](https://github.com/apache/arrow-swift)
 
 ## How to use in your apps
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Requirement` section to point the official Apache Arrow Swift repository.

### Why are the changes needed?

Apache Arrow community moves one step forward to make an official release by creating a dedicated repo.
- New: https://github.com/apache/arrow-swift
- Old: https://github.com/apache/arrow/tree/main/swift (A subdirectory of Apache Arrow repo)

We need to lead the users to the official Apache Arrow repository always in order to migrate easily.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.