### PR TITLE
[SPARK-52371] Update `Example` projects to use the latest `main` branch always

### DIFF
--- a/Examples/app/Package.swift
+++ b/Examples/app/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .macOS(.v15)
   ],
   dependencies: [
-    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "v0.1.0")
+    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main")
   ],
   targets: [
     .executableTarget(

--- a/Examples/web/Package.swift
+++ b/Examples/web/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
     // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
-    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "v0.1.0"),
+    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main"),
   ],
   targets: [
     .executableTarget(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Example` projects to use the latest `main` branch always.

```swift
-    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "v0.1.0"),
+    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main"),
```

### Why are the changes needed?

Until we have `1.0.0` release, this will lead a user to use the latest bug fixed version.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an example update.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Pass the CIs.