### PR TITLE
[SPARK-52374] Publish `apache/spark-connect-swift:web` docker image

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -7,7 +7,7 @@ on:
         description: 'list of examples to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'example'
-        default: '["pi"]'
+        default: '["pi", "web"]'
 
 jobs:
   publish-image:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'example'
-        example: ${{ fromJSON( inputs.example || '["pi"]' ) }}
+        example: ${{ fromJSON( inputs.example || '["pi", "web"]' ) }}
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/Examples/web/Package.swift
+++ b/Examples/web/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     // 💧 A server-side Swift web framework.
-    .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
+    .package(url: "https://github.com/vapor/vapor.git", from: "4.115.0"),
     // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main"),

--- a/Examples/web/README.md
+++ b/Examples/web/README.md
@@ -16,7 +16,7 @@ vapor new spark-connect-swift-web -n
 ```bash
 $ git diff HEAD
 diff --git a/Package.swift b/Package.swift
-index 477bcbd..3e7bb06 100644
+index 2edcc8f..dd918a9 100644
 --- a/Package.swift
 +++ b/Package.swift
 @@ -4,13 +4,14 @@ import PackageDescription
@@ -28,7 +28,7 @@ index 477bcbd..3e7bb06 100644
      ],
      dependencies: [
          // 💧 A server-side Swift web framework.
-         .package(url: "https://github.com/vapor/vapor.git", from: "4.110.1"),
+         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.0"),
          // 🔵 Non-blocking, event-driven networking for Swift. Used for custom executors
          .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
 +        .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main"),
@@ -43,17 +43,30 @@ index 477bcbd..3e7bb06 100644
              ],
              swiftSettings: swiftSettings
          ),
-diff --git a/Sources/SparkConnectSwiftWebapp/routes.swift b/Sources/SparkConnectSwiftWebapp/routes.swift
-index 2edcc8f..22313c8 100644
---- a/Sources/SparkConnectSwiftWebapp/routes.swift
-+++ b/Sources/SparkConnectSwiftWebapp/routes.swift
-@@ -1,4 +1,5 @@
+diff --git a/Sources/SparkConnectSwiftWeb/configure.swift b/Sources/SparkConnectSwiftWeb/configure.swift
+index 7715d7c..eea2f95 100644
+--- a/Sources/SparkConnectSwiftWeb/configure.swift
++++ b/Sources/SparkConnectSwiftWeb/configure.swift
+@@ -2,6 +2,7 @@ import Vapor
+
+ // configures your application
+ public func configure(_ app: Application) async throws {
++    app.http.server.configuration.hostname = "0.0.0.0"
+     // uncomment to serve files from /Public folder
+     // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
+
+diff --git a/Sources/SparkConnectSwiftWeb/routes.swift b/Sources/SparkConnectSwiftWeb/routes.swift
+index 2edcc8f..dd918a9 100644
+--- a/Sources/SparkConnectSwiftWeb/routes.swift
++++ b/Sources/SparkConnectSwiftWeb/routes.swift
+@@ -1,11 +1,21 @@
  import Vapor
 +import SparkConnect
 
  func routes(_ app: Application) throws {
      app.get { req async in
-@@ -6,6 +7,15 @@ func routes(_ app: Application) throws {
+-        "It works!"
++        "Welcome to the Swift world. Say hello!"
      }
 
      app.get("hello") { req async -> String in


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update and publish `apache/spark-connect-swift:web` docker image.

### Why are the changes needed?

To provide a working long-running example in addition to the previous `pi` example.

Note that currently `pi` example is used in both `Spark Connect Swift` and `Spark K8s Operator` website as K8s `Job` usage.
- https://apache.github.io/spark-connect-swift/
- https://apache.github.io/spark-kubernetes-operator/

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.