### PR TITLE
[SPARK-52376] Support `addArtifact(s)?` in `SparkSession`

### DIFF
--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -267,6 +267,36 @@ public actor SparkSession {
     return await read.table(tableName)
   }
 
+  /// Add a single artifact to the current session.
+  /// Currently only local files with extensions .jar supported.
+  /// - Parameter url: A url to the artifact
+  public func addArtifact(_ url: URL) async throws {
+    try await self.client.addArtifact(url)
+  }
+
+  /// Add a single artifact to the current session.
+  /// Currently only local files with extensions .jar are supported.
+  /// - Parameter path: A path to the file.
+  public func addArtifact(_ path: String) async throws {
+    try await self.client.addArtifact(URL(fileURLWithPath: path))
+  }
+
+  /// Add one or more artifacts to the session.
+  /// - Parameter url: One or more URLs
+  public func addArtifacts(_ url: URL...) async throws {
+    for u in url {
+      try await self.client.addArtifact(u)
+    }
+  }
+
+  /// Execute an arbitrary string command inside an external execution engine rather than Spark.
+  /// This could be useful when user wants to execute some commands out of Spark. For example,
+  /// executing custom DDL/DML command for JDBC, creating index for ElasticSearch, creating cores
+  /// for Solr and so on.
+  /// - Parameters:
+  ///   - runner: The class name of the runner that implements `ExternalCommandRunner`.
+  ///   - command: The target command to be executed
+  ///   - options: The options for the runner.
   public func executeCommand(_ runner: String, _ command: String, _ options: [String: String])
     async throws -> DataFrame
   {

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -161,8 +161,10 @@ struct SparkSessionTests {
     await SparkSession.builder.clear()
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(fm.createFile(atPath: path, contents: "abc".data(using: .utf8)))
-    try await spark.addArtifact(path)
-    try await spark.addArtifact(url)
+    if await spark.version.starts(with: "4.") {
+      try await spark.addArtifact(path)
+      try await spark.addArtifact(url)
+    }
     try fm.removeItem(atPath: path)
     await spark.stop()
   }
@@ -176,7 +178,9 @@ struct SparkSessionTests {
     await SparkSession.builder.clear()
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(fm.createFile(atPath: path, contents: "abc".data(using: .utf8)))
-    try await spark.addArtifacts(url, url)
+    if await spark.version.starts(with: "4.") {
+      try await spark.addArtifacts(url, url)
+    }
     try fm.removeItem(atPath: path)
     await spark.stop()
   }

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -143,6 +143,45 @@ struct SparkSessionTests {
   }
 
   @Test
+  func addInvalidArtifact() async throws {
+    await SparkSession.builder.clear()
+    let spark = try await SparkSession.builder.getOrCreate()
+    await #expect(throws: SparkConnectError.InvalidArgument) {
+      try await spark.addArtifact("x.txt")
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func addArtifact() async throws {
+    let fm = FileManager()
+    let path = "my.jar"
+    let url = URL(fileURLWithPath: path)
+
+    await SparkSession.builder.clear()
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(fm.createFile(atPath: path, contents: "abc".data(using: .utf8)))
+    try await spark.addArtifact(path)
+    try await spark.addArtifact(url)
+    try fm.removeItem(atPath: path)
+    await spark.stop()
+  }
+
+  @Test
+  func addArtifacts() async throws {
+    let fm = FileManager()
+    let path = "my.jar"
+    let url = URL(fileURLWithPath: path)
+
+    await SparkSession.builder.clear()
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(fm.createFile(atPath: path, contents: "abc".data(using: .utf8)))
+    try await spark.addArtifacts(url, url)
+    try fm.removeItem(atPath: path)
+    await spark.stop()
+  }
+
+  @Test
   func executeCommand() async throws {
     await SparkSession.builder.clear()
     let spark = try await SparkSession.builder.getOrCreate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following APIs in `SparkSession`.
- `addArtifact(_ path: String)`
- `addArtifact(_ url: URL)`
- `addArtifacts(_ url: URL...)`

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.