### PR TITLE
[SPARK-52390] Upgrade `gRPC Swift` libraries to `grpc-swift-2`-based ones

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,16 +34,16 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.2"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.3.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.2.2"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.0.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [
     .target(
       name: "SparkConnect",
       dependencies: [
-        .product(name: "GRPCCore", package: "grpc-swift"),
+        .product(name: "GRPCCore", package: "grpc-swift-2"),
         .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
         .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
         .product(name: "FlatBuffers", package: "flatbuffers"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift` libraries to `grpc-swift-2`-based ones like the following.

```swift
- .package(url: "https://github.com/grpc/grpc-swift.git", exact: "2.2.2"),
- .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "1.3.0"),
- .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "1.2.2"),
+ .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.0.0"),
+ .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.0.0"),
+ .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.0.0"),
```

### Why are the changes needed?

To use the latest dependencies.

- https://github.com/grpc/grpc-swift-2/releases/tag/2.0.0
- https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.0.0
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.0.0

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.