### PR TITLE
[SPARK-52436] Update CIs to use `actions/checkout@v4` consistently

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CIs to use `actions/checkout@v4` consistently.

### Why are the changes needed?

**BEFORE**

```
$ git grep actions/checkout | awk '{print $NF}' | sort | uniq -c
   1 actions/checkout@v3
  11 actions/checkout@v4
```

**AFTER**

```
$ git grep actions/checkout | awk '{print $NF}' | sort | uniq -c
  12 actions/checkout@v4
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manually check with `git grep actions/checkout`.

### Was this patch authored or co-authored using generative AI tooling?

No.