### PR TITLE
[SPARK-52523] Update `arrow-swift` code for Timestamp

### DIFF
--- a/Sources/SparkConnect/ArrowArrayBuilder.swift
+++ b/Sources/SparkConnect/ArrowArrayBuilder.swift
@@ -129,6 +129,12 @@ public class Decimal128ArrayBuilder: ArrowArrayBuilder<FixedBufferBuilder<Decima
   }
 }
 
+public class TimestampArrayBuilder: ArrowArrayBuilder<FixedBufferBuilder<Int64>, TimestampArray> {
+  fileprivate convenience init(_ unit: ArrowTimestampUnit, timezone: String? = nil) throws {
+    try self.init(ArrowTypeTimestamp(unit, timezone: timezone))
+  }
+}
+
 public class StructArrayBuilder: ArrowArrayBuilder<StructBufferBuilder, StructArray> {
   let builders: [any ArrowArrayHolderBuilder]
   let fields: [ArrowField]
@@ -293,6 +299,11 @@ public class ArrowArrayBuilders {
         throw ArrowError.invalid("Expected ArrowTypeDecimal128 for decimal128 type")
       }
       return try Decimal128ArrayBuilder(precision: decimalType.precision, scale: decimalType.scale)
+    case .timestamp:
+      guard let timestampType = arrowType as? ArrowTypeTimestamp else {
+        throw ArrowError.invalid("Expected arrow type for \(arrowType.id) not found")
+      }
+      return try TimestampArrayBuilder(timestampType.unit)
     default:
       throw ArrowError.unknownType("Builder not found for arrow type: \(arrowType.id)")
     }
@@ -353,6 +364,12 @@ public class ArrowArrayBuilders {
 
   public static func loadTime64ArrayBuilder(_ unit: ArrowTime64Unit) throws -> Time64ArrayBuilder {
     return try Time64ArrayBuilder(unit)
+  }
+
+  public static func loadTimestampArrayBuilder(_ unit: ArrowTimestampUnit, timezone: String? = nil)
+    throws -> TimestampArrayBuilder
+  {
+    return try TimestampArrayBuilder(unit, timezone: timezone)
   }
 
   public static func loadDecimal128ArrayBuilder(

--- a/Sources/SparkConnect/ArrowWriterHelper.swift
+++ b/Sources/SparkConnect/ArrowWriterHelper.swift
@@ -41,6 +41,8 @@ func toFBTypeEnum(_ arrowType: ArrowType) -> Result<org_apache_arrow_flatbuf_Typ
     return .success(org_apache_arrow_flatbuf_Type_.date)
   case .time32, .time64:
     return .success(org_apache_arrow_flatbuf_Type_.time)
+  case .timestamp:
+    return .success(org_apache_arrow_flatbuf_Type_.timestamp)
   case .strct:
     return .success(org_apache_arrow_flatbuf_Type_.struct_)
   default:
@@ -114,6 +116,32 @@ func toFBType(  // swiftlint:disable:this cyclomatic_complexity function_body_le
     }
 
     return .failure(.invalid("Unable to case to Time64"))
+  case .timestamp:
+    if let timestampType = arrowType as? ArrowTypeTimestamp {
+      let startOffset = org_apache_arrow_flatbuf_Timestamp.startTimestamp(&fbb)
+
+      let fbUnit: org_apache_arrow_flatbuf_TimeUnit
+      switch timestampType.unit {
+      case .seconds:
+        fbUnit = .second
+      case .milliseconds:
+        fbUnit = .millisecond
+      case .microseconds:
+        fbUnit = .microsecond
+      case .nanoseconds:
+        fbUnit = .nanosecond
+      }
+      org_apache_arrow_flatbuf_Timestamp.add(unit: fbUnit, &fbb)
+
+      if let timezone = timestampType.timezone {
+        let timezoneOffset = fbb.create(string: timezone)
+        org_apache_arrow_flatbuf_Timestamp.add(timezone: timezoneOffset, &fbb)
+      }
+
+      return .success(org_apache_arrow_flatbuf_Timestamp.endTimestamp(&fbb, start: startOffset))
+    }
+
+    return .failure(.invalid("Unable to cast to Timestamp"))
   case .strct:
     let startOffset = org_apache_arrow_flatbuf_Struct_.startStruct_(&fbb)
     return .success(org_apache_arrow_flatbuf_Struct_.endStruct_(&fbb, start: startOffset))

--- a/Sources/SparkConnect/ProtoUtil.swift
+++ b/Sources/SparkConnect/ProtoUtil.swift
@@ -73,6 +73,22 @@ func fromProto(  // swiftlint:disable:this cyclomatic_complexity function_body_l
       let arrowUnit: ArrowTime64Unit = timeType.unit == .microsecond ? .microseconds : .nanoseconds
       arrowType = ArrowTypeTime64(arrowUnit)
     }
+  case .timestamp:
+    let timestampType = field.type(type: org_apache_arrow_flatbuf_Timestamp.self)!
+    let arrowUnit: ArrowTimestampUnit
+    switch timestampType.unit {
+    case .second:
+      arrowUnit = .seconds
+    case .millisecond:
+      arrowUnit = .milliseconds
+    case .microsecond:
+      arrowUnit = .microseconds
+    case .nanosecond:
+      arrowUnit = .nanoseconds
+    }
+
+    let timezone = timestampType.timezone
+    arrowType = ArrowTypeTimestamp(arrowUnit, timezone: timezone?.isEmpty == true ? nil : timezone)
   case .struct_:
     var children = [ArrowField]()
     for index in 0..<field.childrenCount {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to sync with the upstream `arrow-swift` code for `Timestamp`.
- https://github.com/apache/arrow-swift/commit/476d1c0a44a460c0c50357618e63c89240088e9c

### Why are the changes needed?

Minimize the difference in order to prepare to migrate to `arrow-swift`.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.