### PR TITLE
[SPARK-52627] Improve `SQLTests` to handle `userName`

### DIFF
--- a/Tests/SparkConnectTests/Resources/queries/describe_database.sql.answer
+++ b/Tests/SparkConnectTests/Resources/queries/describe_database.sql.answer
@@ -5,5 +5,5 @@
 |Namespace Name|                                 default|
 |       Comment|                        default database|
 |      Location|*|
-|         Owner|                                     *|
+|         Owner|                                   spark|
 +--------------+----------------------------------------+

--- a/Tests/SparkConnectTests/SQLTests.swift
+++ b/Tests/SparkConnectTests/SQLTests.swift
@@ -36,7 +36,7 @@ struct SQLTests {
   let regexOwner = /(runner|185)/
 
   private func cleanUp(_ str: String) -> String {
-    return removeOwner(removeID(removeLocation(str)))
+    return removeOwner(removeID(removeLocation(replaceUserName(str))))
   }
 
   private func removeID(_ str: String) -> String {
@@ -49,6 +49,14 @@ struct SQLTests {
 
   private func removeOwner(_ str: String) -> String {
     return str.replacing(regexOwner, with: "*")
+  }
+
+  private func replaceUserName(_ str: String) -> String {
+    #if os(macOS) || os(Linux)
+      return str.replacing(ProcessInfo.processInfo.userName, with: "spark")
+    #else
+      return str
+    #endif
   }
 
   private func normalize(_ str: String) -> String {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SQLTests` to handle `userName` additionally.

### Why are the changes needed?

This is helpful in case of running `Spark Connect Server` without docker images. For example, when building and running from the source instead of Docker image.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

**Build and run from the source**
```
$ build/sbt package
$ cd sbin/
$ SPARK_NO_DAEMONIZE=1 ./start-connect-server.sh
```

**Test**
```
$ swift test --filter SQLTests
...
✔ Test runAll() passed after 2.719 seconds.
✔ Suite SQLTests passed after 2.723 seconds.
✔ Test run with 5 tests passed after 2.723 seconds.
```

### Was this patch authored or co-authored using generative AI tooling?

No.