### PR TITLE
[SPARK-52658] Add `Swift 6.2` build test CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,6 +83,16 @@ jobs:
         docker run swift:6.1 uname -a
         docker run -v $PWD:/spark -w /spark swift:6.1 swift build -c release
 
+  build-ubuntu-swift62:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker run swiftlang/swift:nightly-6.2-noble uname -a
+        docker run -v $PWD:/spark -w /spark swiftlang/swift:nightly-6.2-noble swift build -c release
+
   integration-test-mac:
     runs-on: macos-15
     timeout-minutes: 20

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Build
       run: |
         docker run swiftlang/swift:nightly-6.2-noble uname -a
-        docker run -v $PWD:/spark -w /spark swiftlang/swift:nightly-6.2-noble swift build -c release
+        docker run -v $PWD:/spark -w /spark swiftlang/swift:nightly-6.2-noble swift build
 
   integration-test-mac:
     runs-on: macos-15


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Swift 6.2` build test CI.

### Why are the changes needed?

To be ready for the upcoming Swift 6.2.
- https://forums.swift.org/t/swift-6-2-release-process/78371

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.