### PR TITLE
[SPARK-52743] Support `startRun`

### DIFF
--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -107,4 +107,21 @@ struct SparkConnectClientTests {
     }
     await client.stop()
   }
+
+  @Test
+  func startRun() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    let response = try await client.connect(UUID().uuidString)
+
+    try await #require(throws: SparkConnectError.InvalidArgument) {
+      try await client.startRun("not-a-uuid-format")
+    }
+
+    if response.sparkVersion.version.starts(with: "4.1") {
+      let dataflowGraphID = try await client.createDataflowGraph()
+      #expect(UUID(uuidString: dataflowGraphID) != nil)
+      #expect(try await client.startRun(dataflowGraphID))
+    }
+    await client.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `startRun ` API in order to support `Declarative Pipelines` (SPARK-51727) of Apache Spark `4.1.0-preview1`.

### Why are the changes needed?

To support the new feature incrementally.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Manually run `Apache Spark 4.1.0-preview1` RC1 .

```
$ sbin/start-connect-server.sh
```

Run the newly added unit test.

<img width="1443" alt="Screenshot 2025-07-09 at 20 20 14" src="https://github.com/user-attachments/assets/4ba9e118-d993-48e2-bdd2-df49d5ddfaca" />

### Was this patch authored or co-authored using generative AI tooling?

No.