### PR TITLE
[SPARK-52748] Support `defineDataset`

### DIFF
--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -181,6 +181,18 @@ extension String {
     default: .UNRECOGNIZED(-1)
     }
   }
+
+  var toDatasetType: DatasetType {
+    let mode =
+      switch self {
+      case "unspecified": DatasetType.unspecified
+      case "materializedView": DatasetType.materializedView
+      case "table": DatasetType.table
+      case "temporaryView": DatasetType.temporaryView
+      default: DatasetType.UNRECOGNIZED(-1)
+      }
+    return mode
+  }
 }
 
 extension [String: String] {

--- a/Sources/SparkConnect/SparkConnectError.swift
+++ b/Sources/SparkConnect/SparkConnectError.swift
@@ -22,6 +22,7 @@ public enum SparkConnectError: Error {
   case CatalogNotFound
   case ColumnNotFound
   case DataSourceNotFound
+  case DatasetTypeUnspecified
   case InvalidArgument
   case InvalidSessionID
   case InvalidType

--- a/Sources/SparkConnect/TypeAliases.swift
+++ b/Sources/SparkConnect/TypeAliases.swift
@@ -23,6 +23,7 @@ typealias AnalyzePlanResponse = Spark_Connect_AnalyzePlanResponse
 typealias Command = Spark_Connect_Command
 typealias ConfigRequest = Spark_Connect_ConfigRequest
 typealias DataSource = Spark_Connect_Read.DataSource
+typealias DatasetType = Spark_Connect_DatasetType
 typealias DataType = Spark_Connect_DataType
 typealias DayTimeInterval = Spark_Connect_DataType.DayTimeInterval
 typealias Drop = Spark_Connect_Drop


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `defineDataset ` API in order to support `Declarative Pipelines` (SPARK-51727) of Apache Spark `4.1.0-preview1`.

### Why are the changes needed?

To support the new feature incrementally.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Pass the CIs with `4.1.0-preview1` test pipeline because we added it.
- #210 

### Was this patch authored or co-authored using generative AI tooling?

No.