### PR TITLE
[SPARK-52756] Support `defineFlow`

### DIFF
--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -146,4 +146,22 @@ struct SparkConnectClientTests {
     }
     await client.stop()
   }
+
+  @Test
+  func defineFlow() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    let response = try await client.connect(UUID().uuidString)
+
+    try await #require(throws: SparkConnectError.InvalidArgument) {
+      try await client.defineFlow("not-a-uuid-format", "f1", "ds1", Relation())
+    }
+
+    if response.sparkVersion.version.starts(with: "4.1") {
+      let dataflowGraphID = try await client.createDataflowGraph()
+      #expect(UUID(uuidString: dataflowGraphID) != nil)
+      let relation = await client.getLocalRelation().root
+      #expect(try await client.defineFlow(dataflowGraphID, "f1", "ds1", relation))
+    }
+    await client.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `defineFlow ` API in order to support `Declarative Pipelines` (SPARK-51727) of Apache Spark `4.1.0-preview1`.

### Why are the changes needed?

To support the new feature incrementally.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Pass the CIs with `4.1.0-preview1` test pipeline.
- #210 

<img width="1000" height="373" alt="Screenshot 2025-07-10 at 07 25 37" src="https://github.com/user-attachments/assets/b4e214f6-de6c-4c31-8482-58e8de1dd4ff" />

### Was this patch authored or co-authored using generative AI tooling?

No.