### PR TITLE
[SPARK-52758] Support `defineSqlGraphElements`

### DIFF
--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -164,4 +164,22 @@ struct SparkConnectClientTests {
     }
     await client.stop()
   }
+
+  @Test
+  func defineSqlGraphElements() async throws {
+    let client = SparkConnectClient(remote: TEST_REMOTE)
+    let response = try await client.connect(UUID().uuidString)
+
+    try await #require(throws: SparkConnectError.InvalidArgument) {
+      try await client.defineSqlGraphElements("not-a-uuid-format", "path", "sql")
+    }
+
+    if response.sparkVersion.version.starts(with: "4.1") {
+      let dataflowGraphID = try await client.createDataflowGraph()
+      let sqlText = "CREATE MATERIALIZED VIEW mv1 AS SELECT 1"
+      #expect(UUID(uuidString: dataflowGraphID) != nil)
+      #expect(try await client.defineSqlGraphElements(dataflowGraphID, "path", sqlText))
+    }
+    await client.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `defineSqlGraphElements ` API in order to support `Declarative Pipelines` (SPARK-51727) of Apache Spark `4.1.0-preview1`.

### Why are the changes needed?

To support the new feature incrementally.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Pass the CIs with `4.1.0-preview1` test pipeline.
- #210 

### Was this patch authored or co-authored using generative AI tooling?

No.