### PR TITLE
[SPARK-53371] Upgrade `gRPC Swift NIO Transport` to 2.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.0.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ So far, this library project is tracking the upstream changes of [Apache Arrow](
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
 - [gRPC Swift 2 (May 2025)](https://github.com/grpc/grpc-swift-2/releases/tag/2.0.0)
 - [gRPC Swift Protobuf 2.0 (May 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.0.0)
-- [gRPC Swift NIO Transport 2.0 (May 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.0.0)
+- [gRPC Swift NIO Transport 2.1 (August 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.1.0)
 - [FlatBuffers v25.2.10 (February 2025)](https://github.com/google/flatbuffers/releases/tag/v25.2.10)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift NIO Transport` to 2.1.0.

### Why are the changes needed?

To bring the latest improvements.
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.1.0
  - https://github.com/grpc/grpc-swift-nio-transport/pull/122
  - https://github.com/grpc/grpc-swift-nio-transport/pull/120
  - https://github.com/grpc/grpc-swift-nio-transport/pull/115

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.