### PR TITLE
[SPARK-53374] Use `release` build in Apache Spark `4.1.0-preview1` testing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,7 +109,7 @@ jobs:
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -
-        swift test --no-parallel
+        swift test --no-parallel -c release
 
   integration-test-mac:
     runs-on: macos-15


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `release` build in Apache Spark `4.1.0-preview1` testing.

### Why are the changes needed?

Although we used `release` build in CI since SPARK-52085, we missed to enable it when we add a new test job in SPARK-52744.
- #136
- #210

To be consistent, we need to use release build in CIs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.