### PR TITLE
[SPARK-53404] Make `Build` step to verify test compilation too

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -123,7 +123,7 @@ jobs:
       with:
         swift-version: "6.1"
     - name: Build
-      run: swift build -c release
+      run: swift test --filter NOTHING -c release
     - name: Test
       run: |
         curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.0-preview1-rc1-bin/spark-4.1.0-preview1-bin-hadoop3.tgz
@@ -145,7 +145,7 @@ jobs:
       with:
         swift-version: "6.1"
     - name: Build
-      run: swift build -c release
+      run: swift test --filter NOTHING -c release
     - name: Test
       run: |
         curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz?action=download
@@ -168,7 +168,7 @@ jobs:
       with:
         swift-version: "6.1"
     - name: Build
-      run: swift build -c release
+      run: swift test --filter NOTHING -c release
     - name: Test
       run: |
         curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz?action=download
@@ -195,7 +195,7 @@ jobs:
         distribution: zulu
         java-version: 17
     - name: Build
-      run: swift build -c release
+      run: swift test --filter NOTHING -c release
     - name: Test
       run: |
         curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz?action=download
@@ -223,7 +223,7 @@ jobs:
         distribution: zulu
         java-version: 17
     - name: Build
-      run: swift build -c release
+      run: swift test --filter NOTHING -c release
     - name: Test
       run: |
         curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz?action=download


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `Build` step to verify test compilation too.

### Why are the changes needed?

Like Apache Spark main repo, SPARK-53376 added the `Build` step before running the actual test.
- https://github.com/apache/spark-connect-swift/pull/222

However, it turns out that the test code building is not verified correctly. So, this PR aims to use the following workaround to verify test code fully without running any test.

```yaml
- run: swift build -c release
+ run: swift test --filter NOTHING -c release
```

In addition, this reduces the total runtime of CIs like the following example.

- BEFORE: 13m 43s
    - https://github.com/apache/spark-connect-swift/actions/runs/17244668737/job/48932508796
- AFTER: 11m 35s
    - https://github.com/apache/spark-connect-swift/actions/runs/17252163531/job/48956652819?pr=225

### Does this PR introduce _any_ user-facing change?

No. This is a test infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.