### PR TITLE
[SPARK-53379] Add `integration-test-ubuntu` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -93,6 +93,25 @@ jobs:
         docker run swiftlang/swift:nightly-6.2-amazonlinux2 uname -a
         docker run -v $PWD:/spark -w /spark swiftlang/swift:nightly-6.2-amazonlinux2 swift build
 
+  integration-test-ubuntu:
+    runs-on: ubuntu-latest
+    env:
+      SPARK_REMOTE: "sc://localhost:15003"
+    services:
+      spark:
+        image: apache/spark:4.0.0
+        env:
+          SPARK_NO_DAEMONIZE: 1
+        ports:
+          - 15003:15002
+        options: --entrypoint /opt/spark/sbin/start-connect-server.sh
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker run swift:6.1 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.1 swift test --no-parallel -c release
+
   integration-test-mac-spark41:
     runs-on: macos-15
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `integration-test-ubuntu` GitHub Action job.

### Why are the changes needed?

We had `integration-test-linux` before and moved it to daily job due to the flakiness.
- #146

This is the current daily linux integration test coverage.
- https://github.com/apache/spark-connect-swift/actions/workflows/integration_test_linux.yml

Since all `integration test (on MacOS)` jobs are failing currently, this PR aims to bring `Linux` integration test job back to `main` CI to have an integration test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Newly added linux integration test job should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.