### PR TITLE
[SPARK-52913] Upgrade `grpc-swift-2` to 2.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.1.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.1.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.1.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ So far, this library project is tracking the upstream changes of [Apache Arrow](
 
 - [Apache Spark 4.0.0 (May 2025)](https://github.com/apache/spark/releases/tag/v4.0.0)
 - [Swift 6.0 (2024) or 6.1 (2025)](https://swift.org)
-- [gRPC Swift 2 (May 2025)](https://github.com/grpc/grpc-swift-2/releases/tag/2.0.0)
+- [gRPC Swift 2.1 (July 2025)](https://github.com/grpc/grpc-swift-2/releases/tag/2.1.0)
 - [gRPC Swift Protobuf 2.1 (August 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.1.1)
 - [gRPC Swift NIO Transport 2.1 (August 2025)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.1.0)
 - [FlatBuffers v25.2.10 (February 2025)](https://github.com/google/flatbuffers/releases/tag/v25.2.10)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `grpc-swift-2` to 2.1.0.

### Why are the changes needed?

To bring the latest improvements and bug fixes.
- https://github.com/grpc/grpc-swift-2/releases/tag/2.1.0
  - https://github.com/grpc/grpc-swift-2/pull/4
  - https://github.com/grpc/grpc-swift-2/pull/3
  - https://github.com/grpc/grpc-swift-2/pull/7

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.