### PR TITLE
[SPARK-53463] Upgrade `actions/checkout` to v5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:
@@ -44,7 +44,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.0"
@@ -55,7 +55,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: |
         docker run swift:6.1 uname -a
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: |
         docker run swift:6.1 uname -a
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: |
         docker run swiftlang/swift:nightly-6.2-amazonlinux2 uname -a
@@ -106,7 +106,7 @@ jobs:
           - 15003:15002
         options: --entrypoint /opt/spark/sbin/start-connect-server.sh
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: |
         docker run swift:6.1 uname -a
@@ -118,7 +118,7 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -140,7 +140,7 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -163,7 +163,7 @@ jobs:
       SPARK_LOCAL_IP: localhost
       SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -185,7 +185,7 @@ jobs:
     env:
       SPARK_LOCAL_IP: localhost
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -213,7 +213,7 @@ jobs:
       SPARK_LOCAL_IP: localhost
       SPARK_ICEBERG_TEST_ENABLED: "true"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
       with:
         swift-version: "6.1"
@@ -240,7 +240,7 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Super-Linter

--- a/.github/workflows/integration_test_linux.yml
+++ b/.github/workflows/integration_test_linux.yml
@@ -38,7 +38,7 @@ jobs:
           - 15003:15002
         options: --entrypoint /opt/spark/sbin/start-connect-server.sh
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: |
         docker run swift:6.1 uname -a

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -29,7 +29,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: main
     - name: Build and push


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `actions/checkout` to v5.

### Why are the changes needed?

`v5.0.0` was released 3 weeks ago with a major improvement upgrading `NodeJS` from `20` to `24`, which will be LTS soon.
- https://github.com/actions/checkout/releases/tag/v5.0.0
  - https://github.com/actions/checkout/pull/2226

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check manually.

**BEFORE**

```
$ git grep actions/checkout@v4 .github/ | wc -l
       15
```

**AFTER**

```
$ git grep actions/checkout@v4 .github/ | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

No.