### PR TITLE
[SPARK-53465] Use `4.1.0-preview1` instead of `RC1`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -126,7 +126,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.0-preview1-rc1-bin/spark-4.1.0-preview1-bin-hadoop3.tgz
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview1/spark-4.1.0-preview1-bin-hadoop3.tgz?action=download
         tar xvfz spark-4.1.0-preview1-bin-hadoop3.tgz && rm spark-4.1.0-preview1-bin-hadoop3.tgz
         mv spark-4.1.0-preview1-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `4.1.0-preview1` instead of `RC1`.

### Why are the changes needed?

Apache Spark 4.1.0-preview1 is available in `release` directory from Today.

https://dist.apache.org/repos/dist/release/spark/spark-4.1.0-preview1/

Since the `integration-test-mac-spark41` CI uses the RC1 location, it is broken currently.

https://github.com/apache/spark-connect-swift/actions/runs/17418942070/job/49453317669

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs on this PR.
- https://github.com/apache/spark-connect-swift/actions/runs/17421252072/job/49459694212?pr=233

<img width="580" height="44" alt="Screenshot 2025-09-02 at 19 42 48" src="https://github.com/user-attachments/assets/f032c2ca-d671-49af-b711-c5a9c173973f" />


### Was this patch authored or co-authored using generative AI tooling?

No.