### PR TITLE
[SPARK-53466] Use Spark `4.0.1` instead of `4.0.0`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,7 +99,7 @@ jobs:
       SPARK_REMOTE: "sc://localhost:15003"
     services:
       spark:
-        image: apache/spark:4.0.0
+        image: apache/spark:4.0.1
         env:
           SPARK_NO_DAEMONIZE: 1
         ports:
@@ -148,9 +148,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.0.0-bin-hadoop3.tgz && rm spark-4.0.0-bin-hadoop3.tgz
-        mv spark-4.0.0-bin-hadoop3 /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.1/spark-4.0.1-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.0.1-bin-hadoop3.tgz && rm spark-4.0.1-bin-hadoop3.tgz
+        mv spark-4.0.1-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade CI to use Spark `4.0.1` instead of `4.0.0`.

### Why are the changes needed?

To test against on the latest Spark 4.0.1 version.

### Does this PR introduce _any_ user-facing change?

No, this is a change of test infra.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.