### PR TITLE
[SPARK-53570] Update `integration-test-token` to use Spark `4.1.0-preview1`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -190,9 +190,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.0.0-bin-hadoop3.tgz && rm spark-4.0.0-bin-hadoop3.tgz
-        mv spark-4.0.0-bin-hadoop3 /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview1/spark-4.1.0-preview1-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.1.0-preview1-bin-hadoop3.tgz && rm spark-4.1.0-preview1-bin-hadoop3.tgz
+        mv spark-4.1.0-preview1-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Spark `4.1.0-preview1` during `integration-test-token` GitHub Action job.

### Why are the changes needed?

To test with Spark 4.1 related code more.

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.