### PR TITLE
[SPARK-53571] Add `integration-test-mac-spark4-iceberg` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -225,7 +225,7 @@ jobs:
         cd -
         swift test --no-parallel -c release
 
-  integration-test-mac-iceberg:
+  integration-test-mac-spark3-iceberg:
     runs-on: macos-15
     timeout-minutes: 20
     env:
@@ -250,6 +250,35 @@ jobs:
         mv spark-3.5.6-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.6,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.9.0 -c spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog -c spark.sql.catalog.local.type=hadoop -c spark.sql.catalog.local.warehouse=/tmp/spark/warehouse -c spark.sql.defaultCatalog=local
+        cd -
+        swift test --filter DataFrameWriterV2Tests -c release
+        swift test --filter IcebergTest -c release
+
+  integration-test-mac-spark4-iceberg:
+    runs-on: macos-15
+    timeout-minutes: 20
+    env:
+      SPARK_LOCAL_IP: localhost
+      SPARK_ICEBERG_TEST_ENABLED: "true"
+    steps:
+    - uses: actions/checkout@v5
+    - uses: swift-actions/setup-swift@d10500c1ac8822132eebbd74c48c3372c71d7ff5
+      with:
+        swift-version: "6.1"
+    - name: Install Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 17
+    - name: Build
+      run: swift test --filter NOTHING -c release
+    - name: Test
+      run: |
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.1/spark-4.0.1-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.0.1-bin-hadoop3.tgz && rm spark-4.0.1-bin-hadoop3.tgz
+        mv spark-4.0.1-bin-hadoop3 /tmp/spark
+        cd /tmp/spark/sbin
+        ./start-connect-server.sh --packages org.apache.spark:spark-connect_2.13:4.0.1,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0 -c spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog -c spark.sql.catalog.local.type=hadoop -c spark.sql.catalog.local.warehouse=/tmp/spark/warehouse -c spark.sql.defaultCatalog=local
         cd -
         swift test --filter DataFrameWriterV2Tests -c release
         swift test --filter IcebergTest -c release


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `integration-test-mac-spark4-iceberg` GitHub Action job. In addition, the existing GitHub Action job `integration-test-mac-iceberg` is renamed to `integration-test-mac-spark3-iceberg` to be clear.

### Why are the changes needed?

Apache Iceberg 1.10 is released with Apache Spark 4 support. We need to have a test coverage for this combination.

https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.10.0

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.