### PR TITLE
[SPARK-53685] Upgrade `gRPC Swift NIO Transport` to 2.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.1.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.1.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.1.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.1.1"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
   ],
   targets: [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `gRPC Swift NIO Transport` to 2.1.1.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.1.1
  - https://github.com/grpc/grpc-swift-nio-transport/pull/123
  - https://github.com/grpc/grpc-swift-nio-transport/pull/124

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.