### PR TITLE
[SPARK-53699] Add `MacOS 26` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,6 +62,14 @@ jobs:
     - name: Build
       run: swift build -c release
 
+  build-macos-26-swift62:
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v5
+    - name: Build
+      run: swift build -c release
+
   build-ubuntu-latest:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS 26` GitHub Action job. By default, the following are used.
- Xcode 26.0
- Swift 6.2

### Why are the changes needed?

`MacOS 26` is released on 2025-09-15. We need to have a test coverage for this environment.
- https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes

`GitHub Action` provides `MacOS 26 (ARM64)` with `Xcode 26.0` by default.
- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md

`Xcode 26.0` includes `Swift 6.2`.
- https://developer.apple.com/documentation/xcode-release-notes/xcode-26-release-notes

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.