### PR TITLE
[SPARK-53724] Update `Examples` and documentations to use `4.0.1`

### DIFF
--- a/Examples/app/README.md
+++ b/Examples/app/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to use Apache Spark Connect Swi
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -23,7 +23,7 @@ Run `app` docker image.
 
 ```bash
 $ docker run --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 apache/spark-connect-swift:app
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT) USING ORC
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)
@@ -52,7 +52,7 @@ Run from source code.
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT) USING ORC
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)

--- a/Examples/pi/README.md
+++ b/Examples/pi/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to use Apache Spark Connect Swi
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.

--- a/Examples/spark-sql/README.md
+++ b/Examples/spark-sql/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to develop a Spark SQL REPL(Rea
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run -it --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run -it --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -23,7 +23,7 @@ Run `spark-sql` docker image.
 
 ```bash
 $ docker run -it --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 apache/spark-connect-swift:spark-sql
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 spark-sql (default)> SHOW DATABASES;
 +---------+
 |namespace|
@@ -85,13 +85,13 @@ spark-sql (default)> DROP DATABASE db1 CASCADE;
 spark-sql (default)> exit;
 ```
 
-Apache Spark 4 supports [SQL Pipe Syntax](https://spark.apache.org/docs/4.0.0/sql-pipe-syntax.html).
+Apache Spark 4 supports [SQL Pipe Syntax](https://spark.apache.org/docs/4.0.1/sql-pipe-syntax.html).
 
 ```bash
 $ swift run
 ...
 Build of product 'SparkSQLRepl' complete! (2.33s)
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 spark-sql (default)>
 FROM ORC.`/opt/spark/examples/src/main/resources/users.orc`
 |> AGGREGATE COUNT(*) cnt
@@ -113,6 +113,6 @@ Run from source code.
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 spark-sql (default)>
 ```

--- a/Examples/stream/README.md
+++ b/Examples/stream/README.md
@@ -5,7 +5,7 @@ This is an example Swift stream processing application to show how to count word
 ## Run `Spark Connect Server`
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
+docker run --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
 ```
 
 ## Run `Netcat` as a streaming input server
@@ -81,5 +81,5 @@ Batch: 2
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 ```

--- a/Examples/web/README.md
+++ b/Examples/web/README.md
@@ -90,7 +90,7 @@ index 2edcc8f..dd918a9 100644
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -116,7 +116,7 @@ $ curl http://127.0.0.1:8080/
 Welcome to the Swift world. Say hello!%
 
 $ curl http://127.0.0.1:8080/hello
-Hi, this is powered by the Apache Spark 4.0.0.%
+Hi, this is powered by the Apache Spark 4.0.1.%
 ```
 
 Run from source code.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ So far, this library project is tracking the upstream changes of [Apache Arrow](
 
 ## Requirement
 
-- [Apache Spark 4.0.0 (May 2025)](https://github.com/apache/spark/releases/tag/v4.0.0)
+- [Apache Spark 4.0.1 (September 2025)](https://github.com/apache/spark/releases/tag/v4.0.1)
 - [Swift 6.0/6.1/6.2 (September 2025)](https://swift.org)
 - [gRPC Swift 2.1 (July 2025)](https://github.com/grpc/grpc-swift-2/releases/tag/2.1.0)
 - [gRPC Swift Protobuf 2.1 (August 2025)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.1.1)
@@ -91,7 +91,7 @@ Run your Swift application.
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.0.0 Server
+Connected to Apache Spark 4.0.1 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT)
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)

--- a/Sources/SparkConnect/Documentation.docc/Examples.md
+++ b/Sources/SparkConnect/Documentation.docc/Examples.md
@@ -7,7 +7,7 @@ This document provides an overview of the example applications inside [Examples]
 Start a Spark Connect Server:
 
 ```bash
-docker run -it --rm -p 15002:15002 apache/spark:4.0.0 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
+docker run -it --rm -p 15002:15002 apache/spark:4.0.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
 ```
 
 ## Basic Application Example
@@ -154,7 +154,7 @@ Welcome to the Swift world. Say hello!%
 
 # Spark-powered endpoint
 curl http://127.0.0.1:8080/hello
-Hi, this is powered by the Apache Spark 4.0.0.%
+Hi, this is powered by the Apache Spark 4.0.1.%
 ```
 
 ## Development Environment
@@ -166,4 +166,4 @@ All examples include:
 - A README.md with detailed instructions
 - Source code in the Sources directory
 
-These examples are designed to be used with Apache Spark 4.0.0 or newer, using the Spark Connect protocol for client-server interaction.
+These examples are designed to be used with Apache Spark 4.0 or newer, using the Spark Connect protocol for client-server interaction.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Examples` and documentations to use `4.0.1`.

### Why are the changes needed?

Apache Spark community highly recommends to use `4.0.1` for all Spark 4.0 users.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.