### PR TITLE
[SPARK-53763] Update `integration-test-ubuntu-spark41` to use Spark `4.1.0-preview2`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -126,7 +126,7 @@ jobs:
       SPARK_REMOTE: "sc://localhost:15003"
     services:
       spark:
-        image: apache/spark:4.1.0-preview1
+        image: apache/spark:4.1.0-preview2
         env:
           SPARK_NO_DAEMONIZE: 1
         ports:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `integration-test-ubuntu-spark41` to use Spark `4.1.0-preview2`.

### Why are the changes needed?

Since `4.1.0-preview2` image was published yesterday, we had better use it.
- https://github.com/apache/spark-docker/pull/96

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.