### PR TITLE
[SPARK-54430] Use `4.1.0-preview4` instead of `RC1`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.0-preview4-rc1-bin/spark-4.1.0-preview4-bin-hadoop3.tgz
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview4/spark-4.1.0-preview4-bin-hadoop3.tgz?action=download
         tar xvfz spark-4.1.0-preview4-bin-hadoop3.tgz && rm spark-4.1.0-preview4-bin-hadoop3.tgz
         mv spark-4.1.0-preview4-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
@@ -156,7 +156,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.0-preview4-rc1-bin/spark-4.1.0-preview4-bin-hadoop3.tgz
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview4/spark-4.1.0-preview4-bin-hadoop3.tgz?action=download
         tar xvfz spark-4.1.0-preview4-bin-hadoop3.tgz && rm spark-4.1.0-preview4-bin-hadoop3.tgz
         mv spark-4.1.0-preview4-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `4.1.0-preview4` instead of `RC1`.

### Why are the changes needed?

Apache Spark 4.1.0-preview4 arrived.
- https://spark.apache.org/docs/4.1.0-preview4/
- https://archive.apache.org/dist/spark/spark-4.1.0-preview4/

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a test-infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.