### PR TITLE
[SPARK-54756] Use `4.1.0` instead of `preview` in GitHub Action CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -93,7 +93,7 @@ jobs:
       SPARK_REMOTE: "sc://localhost:15003"
     services:
       spark:
-        image: apache/spark:4.1.0-preview4-java21
+        image: apache/spark:4.1.0-scala
         env:
           SPARK_NO_DAEMONIZE: 1
         ports:
@@ -117,9 +117,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview4/spark-4.1.0-preview4-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.1.0-preview4-bin-hadoop3.tgz && rm spark-4.1.0-preview4-bin-hadoop3.tgz
-        mv spark-4.1.0-preview4-bin-hadoop3 /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0/spark-4.1.0-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.1.0-bin-hadoop3.tgz && rm spark-4.1.0-bin-hadoop3.tgz
+        mv spark-4.1.0-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -
@@ -156,9 +156,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0-preview4/spark-4.1.0-preview4-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.1.0-preview4-bin-hadoop3.tgz && rm spark-4.1.0-preview4-bin-hadoop3.tgz
-        mv spark-4.1.0-preview4-bin-hadoop3 /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.0/spark-4.1.0-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.1.0-bin-hadoop3.tgz && rm spark-4.1.0-bin-hadoop3.tgz
+        mv spark-4.1.0-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -

--- a/Tests/SparkConnectTests/SQLTests.swift
+++ b/Tests/SparkConnectTests/SQLTests.swift
@@ -99,7 +99,7 @@ struct SQLTests {
     "variant.sql",
   ]
 
-  let queriesForSpark41Only: [String] = [
+  let queriesForSpark42Only: [String] = [
     "time.sql"
   ]
 
@@ -114,8 +114,8 @@ struct SQLTests {
         print("Skip query \(name) due to the difference between Spark 3 and 4.")
         continue
       }
-      if await !spark.version.starts(with: "4.1") && queriesForSpark41Only.contains(name) {
-        print("Skip query \(name) due to the difference between Spark 4.0 and 4.1")
+      if await !spark.version.starts(with: "4.2") && queriesForSpark42Only.contains(name) {
+        print("Skip query \(name) due to the difference between Spark 4.1 and 4.2")
         continue
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Spark 4.1.0 instead of `preview` versions in GitHub Action CIs.

### Why are the changes needed?

Apache Spark 4.1.0 is released officially.

- https://github.com/apache/spark/releases/tag/v4.1.0
- https://spark.apache.org/docs/4.1.0/
- https://dist.apache.org/repos/dist/release/spark/spark-4.1.0/

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.