### PR TITLE
[SPARK-54899] Upgrade `FlatBuffers` to v25.12.19

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.2.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.1.2"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.4.0"),
-    .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.9.23"),
+    .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19"),
   ],
   targets: [
     .target(

--- a/Sources/SparkConnect/File_generated.swift
+++ b/Sources/SparkConnect/File_generated.swift
@@ -69,7 +69,7 @@ public struct org_apache_arrow_flatbuf_Block: NativeStruct, Verifiable, Flatbuff
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Block_Mutable: FlatBufferObject {
+public struct org_apache_arrow_flatbuf_Block_Mutable: FlatBufferStruct {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -86,7 +86,7 @@ public struct org_apache_arrow_flatbuf_Block_Mutable: FlatBufferObject {
 ///  Arrow File metadata
 ///
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Footer: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Footer: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -137,8 +137,8 @@ public struct org_apache_arrow_flatbuf_Footer: FlatBufferObject, Verifiable {
     let o = _accessor.offset(VTOFFSET.dictionaries.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_Block.self, offset: _accessor.vector(at: o) + index * 24)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_Block.self, position: Int(_accessor.vector(at: o) + index * 24))
   }
   public func mutableDictionaries(at index: Int32) -> org_apache_arrow_flatbuf_Block_Mutable? {
     let o = _accessor.offset(VTOFFSET.dictionaries.v)
@@ -159,8 +159,8 @@ public struct org_apache_arrow_flatbuf_Footer: FlatBufferObject, Verifiable {
     let o = _accessor.offset(VTOFFSET.recordBatches.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_Block.self, offset: _accessor.vector(at: o) + index * 24)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_Block.self, position: Int(_accessor.vector(at: o) + index * 24))
   }
   public func mutableRecordBatches(at index: Int32) -> org_apache_arrow_flatbuf_Block_Mutable? {
     let o = _accessor.offset(VTOFFSET.recordBatches.v)

--- a/Sources/SparkConnect/Message_generated.swift
+++ b/Sources/SparkConnect/Message_generated.swift
@@ -146,7 +146,7 @@ public struct org_apache_arrow_flatbuf_FieldNode: NativeStruct, Verifiable, Flat
 ///  would have {length: 5, null_count: 2} for its List node, and {length: 6,
 ///  null_count: 0} for its Int16 node, as separate FieldNode structs
 /// @nodoc
-public struct org_apache_arrow_flatbuf_FieldNode_Mutable: FlatBufferObject {
+public struct org_apache_arrow_flatbuf_FieldNode_Mutable: FlatBufferStruct {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -162,7 +162,7 @@ public struct org_apache_arrow_flatbuf_FieldNode_Mutable: FlatBufferObject {
 ///  bodies. Intended for use with RecordBatch but could be used for other
 ///  message types
 /// @nodoc
-public struct org_apache_arrow_flatbuf_BodyCompression: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_BodyCompression: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -245,7 +245,7 @@ public struct org_apache_arrow_flatbuf_BodyCompression: FlatBufferObject, Verifi
 ///  batch. Some systems call this a "row batch" internally and others a "record
 ///  batch".
 /// @nodoc
-public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -289,8 +289,8 @@ public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferObject, Verifiable
     let o = _accessor.offset(VTOFFSET.nodes.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_FieldNode.self, offset: _accessor.vector(at: o) + index * 16)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_FieldNode.self, position: Int(_accessor.vector(at: o) + index * 16))
   }
   public func mutableNodes(at index: Int32) -> org_apache_arrow_flatbuf_FieldNode_Mutable? {
     let o = _accessor.offset(VTOFFSET.nodes.v)
@@ -317,8 +317,8 @@ public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferObject, Verifiable
     let o = _accessor.offset(VTOFFSET.buffers.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_Buffer.self, offset: _accessor.vector(at: o) + index * 16)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_Buffer.self, position: Int(_accessor.vector(at: o) + index * 16))
   }
   public func mutableBuffers(at index: Int32) -> org_apache_arrow_flatbuf_Buffer_Mutable? {
     let o = _accessor.offset(VTOFFSET.buffers.v)
@@ -406,7 +406,7 @@ public struct org_apache_arrow_flatbuf_RecordBatch: FlatBufferObject, Verifiable
 ///  may be spread across multiple dictionary batches by using the isDelta
 ///  flag
 /// @nodoc
-public struct org_apache_arrow_flatbuf_DictionaryBatch: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_DictionaryBatch: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -494,7 +494,7 @@ public struct org_apache_arrow_flatbuf_DictionaryBatch: FlatBufferObject, Verifi
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Message: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Message: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }

--- a/Sources/SparkConnect/Schema_generated.swift
+++ b/Sources/SparkConnect/Schema_generated.swift
@@ -271,7 +271,7 @@ public struct org_apache_arrow_flatbuf_Buffer: NativeStruct, Verifiable, Flatbuf
 ///  ----------------------------------------------------------------------
 ///  A Buffer represents a single contiguous memory segment
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Buffer_Mutable: FlatBufferObject {
+public struct org_apache_arrow_flatbuf_Buffer_Mutable: FlatBufferStruct {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -285,7 +285,7 @@ public struct org_apache_arrow_flatbuf_Buffer_Mutable: FlatBufferObject {
 
 ///  These are stored in the flatbuffer in the Type union below
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Null: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Null: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -320,7 +320,7 @@ public struct org_apache_arrow_flatbuf_Null: FlatBufferObject, Verifiable {
 ///  (according to the physical memory layout). We used Struct_ here as
 ///  Struct is a reserved word in Flatbuffers
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Struct_: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Struct_: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -352,7 +352,7 @@ public struct org_apache_arrow_flatbuf_Struct_: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_List: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_List: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -386,7 +386,7 @@ public struct org_apache_arrow_flatbuf_List: FlatBufferObject, Verifiable {
 ///  Same as List, but with 64-bit offsets, allowing to represent
 ///  extremely large data values.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_LargeList: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_LargeList: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -418,7 +418,7 @@ public struct org_apache_arrow_flatbuf_LargeList: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_FixedSizeList: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_FixedSizeList: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -501,7 +501,7 @@ public struct org_apache_arrow_flatbuf_FixedSizeList: FlatBufferObject, Verifiab
 ///  for Map can make Map an alias for List. The "layout" attribute for the Map
 ///  field must have the same contents as a List.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Map: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Map: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -561,7 +561,7 @@ public struct org_apache_arrow_flatbuf_Map: FlatBufferObject, Verifiable {
 ///  optionally typeIds provides an indirection between the child offset and the type id
 ///  for each child `typeIds[offset]` is the id used in the type vector
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Union: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Union: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -602,7 +602,7 @@ public struct org_apache_arrow_flatbuf_Union: FlatBufferObject, Verifiable {
   public func typeIds(at index: Int32) -> Int32 {
     let o = _accessor.offset(VTOFFSET.typeIds.v)
     return o == 0
-      ? 0 : _accessor.directRead(of: Int32.self, offset: _accessor.vector(at: o) + index * 4)
+      ? 0 : _accessor.bb.read(def: Int32.self, position: Int(_accessor.vector(at: o) + index * 4))
   }
   public var typeIds: [Int32] { return _accessor.getVector(at: VTOFFSET.typeIds.v) ?? [] }
   public static func startUnion(_ fbb: inout FlatBufferBuilder) -> UOffset {
@@ -643,7 +643,7 @@ public struct org_apache_arrow_flatbuf_Union: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Int: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Int: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -710,7 +710,7 @@ public struct org_apache_arrow_flatbuf_Int: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_FloatingPoint: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_FloatingPoint: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -772,7 +772,7 @@ public struct org_apache_arrow_flatbuf_FloatingPoint: FlatBufferObject, Verifiab
 
 ///  Unicode with UTF-8 encoding
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Utf8: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Utf8: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -805,7 +805,7 @@ public struct org_apache_arrow_flatbuf_Utf8: FlatBufferObject, Verifiable {
 
 ///  Opaque binary data
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Binary: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Binary: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -839,7 +839,7 @@ public struct org_apache_arrow_flatbuf_Binary: FlatBufferObject, Verifiable {
 ///  Same as Utf8, but with 64-bit offsets, allowing to represent
 ///  extremely large data values.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_LargeUtf8: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_LargeUtf8: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -873,7 +873,7 @@ public struct org_apache_arrow_flatbuf_LargeUtf8: FlatBufferObject, Verifiable {
 ///  Same as Binary, but with 64-bit offsets, allowing to represent
 ///  extremely large data values.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_LargeBinary: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_LargeBinary: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -905,7 +905,7 @@ public struct org_apache_arrow_flatbuf_LargeBinary: FlatBufferObject, Verifiable
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_FixedSizeBinary: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_FixedSizeBinary: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -963,7 +963,7 @@ public struct org_apache_arrow_flatbuf_FixedSizeBinary: FlatBufferObject, Verifi
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Bool: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Bool: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1000,7 +1000,7 @@ public struct org_apache_arrow_flatbuf_Bool: FlatBufferObject, Verifiable {
 ///  each corresponding index in the values child array ends.
 ///  Like list/struct types, the value array can be of any type.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_RunEndEncoded: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_RunEndEncoded: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1038,7 +1038,7 @@ public struct org_apache_arrow_flatbuf_RunEndEncoded: FlatBufferObject, Verifiab
 ///  are used. The representation uses the endianness indicated
 ///  in the Schema.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Decimal: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Decimal: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1126,7 +1126,7 @@ public struct org_apache_arrow_flatbuf_Decimal: FlatBufferObject, Verifiable {
 ///    leap seconds), where the values are evenly divisible by 86400000
 ///  * Days (32 bits) since the UNIX epoch
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Date: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Date: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1199,7 +1199,7 @@ public struct org_apache_arrow_flatbuf_Date: FlatBufferObject, Verifiable {
 ///  measurements with leap seconds will need to be corrected when ingesting
 ///  into Arrow (for example by replacing the value 86400 with 86399).
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Time: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Time: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1375,7 +1375,7 @@ public struct org_apache_arrow_flatbuf_Time: FlatBufferObject, Verifiable {
 ///  was UTC; for example, the naive date-time "January 1st 1970, 00h00" would
 ///  be encoded as timestamp value 0.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Timestamp: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Timestamp: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1458,7 +1458,7 @@ public struct org_apache_arrow_flatbuf_Timestamp: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Interval: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Interval: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1517,7 +1517,7 @@ public struct org_apache_arrow_flatbuf_Interval: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Duration: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Duration: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1579,7 +1579,7 @@ public struct org_apache_arrow_flatbuf_Duration: FlatBufferObject, Verifiable {
 ///  user defined key value pairs to add custom metadata to arrow
 ///  key namespacing is the responsibility of the user
 /// @nodoc
-public struct org_apache_arrow_flatbuf_KeyValue: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_KeyValue: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1649,7 +1649,7 @@ public struct org_apache_arrow_flatbuf_KeyValue: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_DictionaryEncoding: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_DictionaryEncoding: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -1766,7 +1766,7 @@ public struct org_apache_arrow_flatbuf_DictionaryEncoding: FlatBufferObject, Ver
 ///  A field represents a named column in a record / row batch or child of a
 ///  nested type.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Field: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Field: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -2011,7 +2011,7 @@ public struct org_apache_arrow_flatbuf_Field: FlatBufferObject, Verifiable {
 ///  ----------------------------------------------------------------------
 ///  A Schema describes the columns in a row batch
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Schema: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Schema: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -2090,7 +2090,7 @@ public struct org_apache_arrow_flatbuf_Schema: FlatBufferObject, Verifiable {
     return o == 0
       ? org_apache_arrow_flatbuf_Feature.unused
       : org_apache_arrow_flatbuf_Feature(
-        rawValue: _accessor.directRead(of: Int64.self, offset: _accessor.vector(at: o) + index * 8))
+        rawValue: _accessor.bb.read(def: Int64.self, position: Int(_accessor.vector(at: o) + index * 8)))
   }
   public static func startSchema(_ fbb: inout FlatBufferBuilder) -> UOffset {
     fbb.startTable(with: 4)

--- a/Sources/SparkConnect/SparseTensor_generated.swift
+++ b/Sources/SparkConnect/SparseTensor_generated.swift
@@ -85,7 +85,7 @@ public enum org_apache_arrow_flatbuf_SparseTensorIndex: UInt8, UnionEnum {
 ///  (row-major order), and it does not have duplicated entries.  Otherwise,
 ///  the indices may not be sorted, or may have duplicated entries.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -130,7 +130,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferObject, V
   public func indicesStrides(at index: Int32) -> Int64 {
     let o = _accessor.offset(VTOFFSET.indicesStrides.v)
     return o == 0
-      ? 0 : _accessor.directRead(of: Int64.self, offset: _accessor.vector(at: o) + index * 8)
+      ? 0 : _accessor.bb.read(def: Int64.self, position: Int(_accessor.vector(at: o) + index * 8))
   }
   public var indicesStrides: [Int64] {
     return _accessor.getVector(at: VTOFFSET.indicesStrides.v) ?? []
@@ -216,7 +216,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCOO: FlatBufferObject, V
 
 ///  Compressed Sparse format, that is matrix-specific.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -384,7 +384,7 @@ public struct org_apache_arrow_flatbuf_SparseMatrixIndexCSX: FlatBufferObject, V
 
 ///  Compressed Sparse Fiber (CSF) sparse tensor index.
 /// @nodoc
-public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -473,8 +473,8 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
     let o = _accessor.offset(VTOFFSET.indptrBuffers.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_Buffer.self, offset: _accessor.vector(at: o) + index * 16)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_Buffer.self, position: Int(_accessor.vector(at: o) + index * 16))
   }
   public func mutableIndptrBuffers(at index: Int32) -> org_apache_arrow_flatbuf_Buffer_Mutable? {
     let o = _accessor.offset(VTOFFSET.indptrBuffers.v)
@@ -511,8 +511,8 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
     let o = _accessor.offset(VTOFFSET.indicesBuffers.v)
     return o == 0
       ? nil
-      : _accessor.directRead(
-        of: org_apache_arrow_flatbuf_Buffer.self, offset: _accessor.vector(at: o) + index * 16)
+      : _accessor.bb.read(
+        def: org_apache_arrow_flatbuf_Buffer.self, position: Int(_accessor.vector(at: o) + index * 16))
   }
   public func mutableIndicesBuffers(at index: Int32) -> org_apache_arrow_flatbuf_Buffer_Mutable? {
     let o = _accessor.offset(VTOFFSET.indicesBuffers.v)
@@ -538,7 +538,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
   public func axisOrder(at index: Int32) -> Int32 {
     let o = _accessor.offset(VTOFFSET.axisOrder.v)
     return o == 0
-      ? 0 : _accessor.directRead(of: Int32.self, offset: _accessor.vector(at: o) + index * 4)
+      ? 0 : _accessor.bb.read(def: Int32.self, position: Int(_accessor.vector(at: o) + index * 4))
   }
   public var axisOrder: [Int32] { return _accessor.getVector(at: VTOFFSET.axisOrder.v) ?? [] }
   public static func startSparseTensorIndexCSF(_ fbb: inout FlatBufferBuilder) -> UOffset {
@@ -619,7 +619,7 @@ public struct org_apache_arrow_flatbuf_SparseTensorIndexCSF: FlatBufferObject, V
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_SparseTensor: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_SparseTensor: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }

--- a/Sources/SparkConnect/Tensor_generated.swift
+++ b/Sources/SparkConnect/Tensor_generated.swift
@@ -25,7 +25,7 @@ import FlatBuffers
 ///  Data structures for dense tensors
 ///  Shape data for a single axis in a tensor
 /// @nodoc
-public struct org_apache_arrow_flatbuf_TensorDim: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_TensorDim: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -94,7 +94,7 @@ public struct org_apache_arrow_flatbuf_TensorDim: FlatBufferObject, Verifiable {
 }
 
 /// @nodoc
-public struct org_apache_arrow_flatbuf_Tensor: FlatBufferObject, Verifiable {
+public struct org_apache_arrow_flatbuf_Tensor: FlatBufferTable, Verifiable {
 
   static func validateVersion() { FlatBuffersVersion_23_1_4() }
   public var __buffer: ByteBuffer! { return _accessor.bb }
@@ -162,7 +162,7 @@ public struct org_apache_arrow_flatbuf_Tensor: FlatBufferObject, Verifiable {
   public func strides(at index: Int32) -> Int64 {
     let o = _accessor.offset(VTOFFSET.strides.v)
     return o == 0
-      ? 0 : _accessor.directRead(of: Int64.self, offset: _accessor.vector(at: o) + index * 8)
+      ? 0 : _accessor.bb.read(def: Int64.self, position: Int(_accessor.vector(at: o) + index * 8))
   }
   public var strides: [Int64] { return _accessor.getVector(at: VTOFFSET.strides.v) ?? [] }
   ///  The location and size of the tensor's data


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `FlatBuffers` to `v25.12.19`

### Why are the changes needed?

To bring the latest bug fixes and improvements
- https://github.com/google/flatbuffers/releases/tag/v25.12.19 (2025-12-19)
  - https://github.com/google/flatbuffers/pull/8758
  - https://github.com/google/flatbuffers/pull/8772
  - https://github.com/google/flatbuffers/pull/8755
  - https://github.com/google/flatbuffers/pull/8815
  - https://github.com/google/flatbuffers/pull/8752
  - https://github.com/google/flatbuffers/pull/8742

### Does this PR introduce _any_ user-facing change?

No. There is no behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)