### PR TITLE
[SPARK-54935] Improve `Row.==` to support array types

### DIFF
--- a/Sources/SparkConnect/Row.swift
+++ b/Sources/SparkConnect/Row.swift
@@ -75,6 +75,20 @@ public struct Row: Sendable, Equatable {
         return a == b
       } else if let a = x as? String, let b = y as? String {
         return a == b
+      } else if let a = x as? [Bool], let b = y as? [Bool] {
+        return a == b
+      } else if let a = x as? [any FixedWidthInteger], let b = y as? [any FixedWidthInteger] {
+        return a.map { Int64($0) } == b.map { Int64($0) }
+      } else if let a = x as? [Float], let b = y as? [Float] {
+        return a == b
+      } else if let a = x as? [Double], let b = y as? [Double] {
+        return a == b
+      } else if let a = x as? [Decimal], let b = y as? [Decimal] {
+        return a == b
+      } else if let a = x as? [Date], let b = y as? [Date] {
+        return a == b
+      } else if let a = x as? [String], let b = y as? [String] {
+        return a == b
       } else {
         return false
       }

--- a/Tests/SparkConnectTests/RowTests.swift
+++ b/Tests/SparkConnectTests/RowTests.swift
@@ -97,4 +97,27 @@ struct RowTests {
     #expect([Row(1), Row(2)] == [Row(1), Row(2)])
     #expect([Row(1), Row(2)] != [Row(1), Row(3)])
   }
+
+  @Test
+  func compareArray() {
+    #expect([Row([1, 2])] == [Row([1, 2])])
+    #expect([Row([1, 2])] != [Row([1, 3])])
+    #expect([Row([1, 2])] != [Row([1])])
+
+    #expect([Row([1.0, 2.0])] == [Row([1.0, 2.0])])
+    #expect([Row([1.0, 2.0])] != [Row([1.0, 3.0])])
+    #expect([Row([1.0, 2.0])] != [Row([1.0])])
+
+    #expect([Row([Decimal(1.0), Decimal(2.0)])] == [Row([Decimal(1.0), Decimal(2.0)])])
+    #expect([Row([Decimal(1.0), Decimal(2.0)])] != [Row([Decimal(1.0), Decimal(3.0)])])
+    #expect([Row([Decimal(1.0), Decimal(2.0)])] != [Row([Decimal(1.0)])])
+
+    #expect([Row(["a", "b"])] == [Row(["a", "b"])])
+    #expect([Row(["a", "b"])] != [Row(["a", "c"])])
+    #expect([Row(["a", "b"])] != [Row(["a"])])
+
+    #expect([Row([true, false])] == [Row([true, false])])
+    #expect([Row([true, false])] != [Row([true, true])])
+    #expect([Row([true, false])] != [Row([true])])
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `Row.==` to support array types.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, this was not supported.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.