### PR TITLE
[SPARK-54981] Improve `DataFrame.collect` to support `Bool|Int|Float|Double` types via `[any Sendable]` cast

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -449,7 +449,7 @@ public actor DataFrame: Sendable {
             case .complexInfo(.strct):
               values.append((array as! AsString).asString(i))
             case .complexInfo(.list):
-              values.append(array.asAny(i) as? [String])
+              values.append(array.asAny(i) as? [any Sendable])
             default:
               values.append(array.asAny(i) as? String)
             }

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -131,6 +131,17 @@ struct DataFrameTests {
   }
 
   @Test
+  func array() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.sql("SELECT array('a')").collect() == [Row(Array(["a"]))])
+    #expect(try await spark.sql("SELECT array(true)").collect() == [Row(Array([true]))])
+    #expect(try await spark.sql("SELECT array(1)").collect() == [Row(Array([1]))])
+    #expect(try await spark.sql("SELECT array(1.0F)").collect() == [Row(Array([Float(1.0)]))])
+    #expect(try await spark.sql("SELECT array(1.0D)").collect() == [Row(Array([1.0]))])
+    await spark.stop()
+  }
+
+  @Test
   func sameSemantics() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let df1 = try await spark.range(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `DataFrame.collect` to support `Bool|Int|Float|Double` types more properly via `[any Sendable]` cast.

### Why are the changes needed?

To support more types properly.

### Does this PR introduce _any_ user-facing change?

No behavior change because `list` type support is a new unreleased feature.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.