### PR TITLE
[SPARK-54998] Disable `ConstraintTests`

### DIFF
--- a/Tests/SparkConnectTests/ConstraintTests.swift
+++ b/Tests/SparkConnectTests/ConstraintTests.swift
@@ -22,8 +22,9 @@ import SparkConnect
 import Testing
 
 /// A test suite for new syntaxes from SPARK-51207 (SPIP: Constraints in DSv2)
-/// For now, only syntax test is here because Apache Spark 4.1 and the corresponding Apache Iceberg is not released yet.
-@Suite(.serialized)
+/// For now, this suite is disabled due to SPARK-54761 because the corresponding Apache Iceberg
+/// is not released yet. We will revise this to DSv2 table when Iceberg starts to support Spark 4.1
+@Suite(.disabled("TODO(SPARK-54999): Re-enable ConstraintTests when Iceberg supports Spark 4.1)"))
 struct ConstraintTests {
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable `ConstraintTests` until Apache Iceberg supports Apache Spark 4.1.0.

### Why are the changes needed?

We have had `Constraint` syntax test coverage for Spark 4.1.0+.

https://github.com/apache/spark-connect-swift/blob/2e2ef6e8f7ec162eba3b59abb91b39e65633d347/Tests/SparkConnectTests/ConstraintTests.swift#L32

However, Spark 4.1.1 starts to throw exceptions on `Constraint` syntax for DSv1 tables after SPARK-54761.
- https://github.com/apache/spark/pull/53532

We need to revisit this later. SPARK-54999 is filed to re-enable this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.