### PR TITLE
[SPARK-56419] Use consistent `CaseInsensitiveDictionary` initialization style

### DIFF
--- a/Sources/SparkConnect/DataFrameReader.swift
+++ b/Sources/SparkConnect/DataFrameReader.swift
@@ -29,7 +29,7 @@ public actor DataFrameReader: Sendable {
 
   var paths: [String] = []
 
-  var extraOptions: CaseInsensitiveDictionary = CaseInsensitiveDictionary([:])
+  var extraOptions: CaseInsensitiveDictionary = CaseInsensitiveDictionary()
 
   var userSpecifiedSchemaDDL: String? = nil
 

--- a/Sources/SparkConnect/DataStreamReader.swift
+++ b/Sources/SparkConnect/DataStreamReader.swift
@@ -29,7 +29,7 @@ public actor DataStreamReader: Sendable {
 
   var paths: [String] = []
 
-  var extraOptions: CaseInsensitiveDictionary = CaseInsensitiveDictionary([:])
+  var extraOptions: CaseInsensitiveDictionary = CaseInsensitiveDictionary()
 
   var userSpecifiedSchemaDDL: String? = nil
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR unifies `CaseInsensitiveDictionary` initialization style by replacing `CaseInsensitiveDictionary([:])` with `CaseInsensitiveDictionary()` in `DataFrameReader` and `DataStreamReader`.

### Why are the changes needed?

The codebase had inconsistent initialization styles: `DataFrameReader` and `DataStreamReader` used `CaseInsensitiveDictionary([:])`, while `DataFrameWriter`, `DataFrameWriterV2`, and `DataStreamWriter` used `CaseInsensitiveDictionary()`. Since the initializer has a default parameter (`= [:]`), both are functionally identical. This PR adopts the more concise `CaseInsensitiveDictionary()` style consistently.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6, 1M context)