### PR TITLE
[SPARK-56420] Introduce `toExpression` method to deduplicate literal conversions

### DIFF
--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -35,33 +35,35 @@ extension String {
     return plan
   }
 
+  private func toExpression(_ value: Sendable) -> Spark_Connect_Expression {
+    var literal = ExpressionLiteral()
+    switch value {
+    case let value as Bool:
+      literal.boolean = value
+    case let value as Int8:
+      literal.byte = Int32(value)
+    case let value as Int16:
+      literal.short = Int32(value)
+    case let value as Int32:
+      literal.integer = value
+    case let value as Int64:
+      literal.long = value
+    case let value as Int:
+      literal.long = Int64(value)
+    case let value as String:
+      literal.string = value
+    default:
+      literal.string = value as! String
+    }
+    var expr = Spark_Connect_Expression()
+    expr.literal = literal
+    return expr
+  }
+
   func toSparkConnectPlan(_ posArguments: [Sendable]) -> Plan {
     var sql = Spark_Connect_SQL()
     sql.query = self
-    sql.posArguments = posArguments.map {
-      var literal = ExpressionLiteral()
-      switch $0 {
-      case let value as Bool:
-        literal.boolean = value
-      case let value as Int8:
-        literal.byte = Int32(value)
-      case let value as Int16:
-        literal.short = Int32(value)
-      case let value as Int32:
-        literal.integer = value
-      case let value as Int64:
-        literal.long = value
-      case let value as Int:
-        literal.long = Int64(value)
-      case let value as String:
-        literal.string = value
-      default:
-        literal.string = $0 as! String
-      }
-      var expr = Spark_Connect_Expression()
-      expr.literal = literal
-      return expr
-    }
+    sql.posArguments = posArguments.map { toExpression($0) }
     var relation = Relation()
     relation.sql = sql
     var plan = Plan()
@@ -72,30 +74,7 @@ extension String {
   func toSparkConnectPlan(_ namedArguments: [String: Sendable]) -> Plan {
     var sql = Spark_Connect_SQL()
     sql.query = self
-    sql.namedArguments = namedArguments.mapValues { value in
-      var literal = ExpressionLiteral()
-      switch value {
-      case let value as Bool:
-        literal.boolean = value
-      case let value as Int8:
-        literal.byte = Int32(value)
-      case let value as Int16:
-        literal.short = Int32(value)
-      case let value as Int32:
-        literal.integer = value
-      case let value as Int64:
-        literal.long = value
-      case let value as Int:
-        literal.long = Int64(value)
-      case let value as String:
-        literal.string = value
-      default:
-        literal.string = value as! String
-      }
-      var expr = Spark_Connect_Expression()
-      expr.literal = literal
-      return expr
-    }
+    sql.namedArguments = namedArguments.mapValues { toExpression($0) }
     var relation = Relation()
     relation.sql = sql
     var plan = Plan()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extracts a common `toExpression(_ value: Sendable) -> Spark_Connect_Expression` helper method to deduplicate the identical `Sendable` → `ExpressionLiteral` switch statements in `toSparkConnectPlan(_ posArguments:)` and `toSparkConnectPlan(_ namedArguments:)`.

### Why are the changes needed?

The two `toSparkConnectPlan` overloads in `Extension.swift` contained identical 15-line switch statements for converting `Sendable` values to `ExpressionLiteral`. Extracting this into a shared private helper improves maintainability and reduces the risk of the two copies diverging in future changes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)