### PR TITLE
[SPARK-56421] Introduce `IntervalType` protocol for `(DayTime|YearMonth)Interval`

### DIFF
--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -225,16 +225,13 @@ extension SparkSession: Equatable {
   }
 }
 
-extension YearMonthInterval {
-  func fieldToString(_ field: Int32) throws -> String {
-    return switch field {
-    case 0: "year"
-    case 1: "month"
-    default:
-      throw SparkConnectError.InvalidType
-    }
-  }
+protocol IntervalType {
+  var startField: Int32 { get }
+  var endField: Int32 { get }
+  func fieldToString(_ field: Int32) throws -> String
+}
 
+extension IntervalType {
   func toString() throws -> String {
     let startFieldName = try fieldToString(self.startField)
     let endFieldName = try fieldToString(self.endField)
@@ -250,7 +247,18 @@ extension YearMonthInterval {
   }
 }
 
-extension DayTimeInterval {
+extension YearMonthInterval: IntervalType {
+  func fieldToString(_ field: Int32) throws -> String {
+    return switch field {
+    case 0: "year"
+    case 1: "month"
+    default:
+      throw SparkConnectError.InvalidType
+    }
+  }
+}
+
+extension DayTimeInterval: IntervalType {
   func fieldToString(_ field: Int32) throws -> String {
     return switch field {
     case 0: "day"
@@ -260,20 +268,6 @@ extension DayTimeInterval {
     default:
       throw SparkConnectError.InvalidType
     }
-  }
-
-  func toString() throws -> String {
-    let startFieldName = try fieldToString(self.startField)
-    let endFieldName = try fieldToString(self.endField)
-    let interval =
-      if startFieldName == endFieldName {
-        "interval \(startFieldName)"
-      } else if startFieldName < endFieldName {
-        "interval \(startFieldName) to \(endFieldName)"
-      } else {
-        throw SparkConnectError.InvalidType
-      }
-    return interval
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces an `IntervalType` protocol to deduplicate the identical `toString()` logic in `YearMonthInterval` and `DayTimeInterval` extensions in `Extension.swift`.

### Why are the changes needed?

Both `YearMonthInterval` and `DayTimeInterval` had identical `toString()` implementations (differing only in `fieldToString` mappings), violating DRY principle. Extracting the shared logic into a protocol default implementation improves maintainability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)