### PR TITLE
[SPARK-56423] Remove manual `Equatable` implementation from `StorageLevel`

### DIFF
--- a/Sources/SparkConnect/StorageLevel.swift
+++ b/Sources/SparkConnect/StorageLevel.swift
@@ -21,7 +21,7 @@
 /// or `ExternalBlockStore`, whether to drop the `RDD` to disk if it falls out of memory or
 /// `ExternalBlockStore`, whether to keep the data in memory in a serialized format, and whether
 /// to replicate the `RDD` partitions on multiple nodes.
-public struct StorageLevel: Sendable {
+public struct StorageLevel: Sendable, Equatable {
   /// Whether the cache should use disk or not.
   public var useDisk: Bool
 
@@ -79,11 +79,6 @@ extension StorageLevel {
     return level
   }
 
-  public static func == (lhs: StorageLevel, rhs: StorageLevel) -> Bool {
-    return lhs.useDisk == rhs.useDisk && lhs.useMemory == rhs.useMemory
-      && lhs.useOffHeap == rhs.useOffHeap && lhs.deserialized == rhs.deserialized
-      && lhs.replication == rhs.replication
-  }
 }
 
 extension StorageLevel: CustomStringConvertible {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the manual `Equatable` implementation from `StorageLevel` and uses Swift's automatic synthesis instead.

### Why are the changes needed?

The manual `==` operator compares all stored properties, which is identical to what Swift synthesizes automatically for `Equatable` structs. The manual implementation is unnecessary boilerplate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)