### PR TITLE
[SPARK-56432] Use `4.2.0-preview4` instead of `RC1`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -142,7 +142,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.2.0-preview4-rc1-bin/spark-4.2.0-preview4-bin-hadoop3.tgz
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.2.0-preview4/spark-4.2.0-preview4-bin-hadoop3.tgz?action=download
         tar xvfz spark-4.2.0-preview4-bin-hadoop3.tgz && rm spark-4.2.0-preview4-bin-hadoop3.tgz
         mv spark-4.2.0-preview4-bin-hadoop3/ /tmp/spark
         cd /tmp/spark/sbin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the Apache Spark binary download URL in the `integration-test` job of `.github/workflows/build_and_test.yml` from the developer staging path to the official mirror-based download URL:

- Before: `https://dist.apache.org/repos/dist/dev/spark/v4.2.0-preview4-rc1-bin/spark-4.2.0-preview4-bin-hadoop3.tgz`
- After: `https://www.apache.org/dyn/closer.lua/spark/spark-4.2.0-preview4/spark-4.2.0-preview4-bin-hadoop3.tgz?action=download`

### Why are the changes needed?

Apache Spark 4.2.0-preview4 has been officially released, so the integration test should pull the binary from the official Apache mirror distribution endpoint instead of the RC staging area under `dist.apache.org/.../dev/`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified via the `integration-test` job on GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6