### PR TITLE
[SPARK-56497] Upgrade the minimum `Swift` requirement to 6.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 ## Requirement
 
 - [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
-- [Swift 6.2 (September 2025)](https://swift.org)
+- [Swift 6.3 (April 2026)](https://swift.org)
 - [gRPC Swift 2.3 (March 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.3.0)
 - [gRPC Swift Protobuf 2.2.1 (March 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.2.1)
 - [gRPC Swift NIO Transport 2.6.2 (March 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.6.2)

--- a/Sources/SparkConnect/Documentation.docc/GettingStarted.md
+++ b/Sources/SparkConnect/Documentation.docc/GettingStarted.md
@@ -25,7 +25,7 @@ targets: [
 
 ## Prerequisites
 
-- Swift 6.2 or later
+- Swift 6.3 or later
 - macOS 15+, iOS 18+, watchOS 11+, or tvOS 18+
 - A running Apache Spark cluster with Spark Connect enabled
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the minimum Swift requirement from 6.2 to 6.3.

### Why are the changes needed?

Swift 6.3 was released in April 2026. `SwiftPackageIndex` starts to show `Swift 6.2` finally from today.

<img width="684" height="132" alt="Screenshot 2026-04-15 at 15 26 04" src="https://github.com/user-attachments/assets/5d760d72-501e-44bf-bf62-038fc8f42aca" />

We are ready to move on like the following. This PR keeps the project up to date with the latest Swift version.

- #342
- #344

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the existing CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)