### PR TITLE
[SPARK-56515] Upgrade `grpc-swift-2` to 2.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.3.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.2.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.6.2"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19-2026-02-06-03fffb2"),

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 
 - [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
 - [Swift 6.3 (April 2026)](https://swift.org)
-- [gRPC Swift 2.3 (March 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.3.0)
+- [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
 - [gRPC Swift Protobuf 2.2.1 (March 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.2.1)
 - [gRPC Swift NIO Transport 2.6.2 (March 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.6.2)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `grpc-swift-2` dependency to `2.4.0`.

### Why are the changes needed?

To stay current with the latest patch release of `grpc-swift-2` which is tested with Swift 6.3 officially.
- https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0
  - https://github.com/grpc/grpc-swift-2/pull/44
  - https://github.com/grpc/grpc-swift-2/pull/45

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4