### PR TITLE
[SPARK-56516] Upgrade `gRPC Swift Protobuf` to 2.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.3.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.2.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.3.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.6.2"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.6.4")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
 - [Swift 6.3 (April 2026)](https://swift.org)
 - [gRPC Swift 2.3 (March 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.3.0)
-- [gRPC Swift Protobuf 2.2.1 (March 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.2.1)
+- [gRPC Swift Protobuf 2.3.0 (April 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.3.0)
 - [gRPC Swift NIO Transport 2.6.2 (March 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.6.2)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `grpc-swift-protobuf` dependency to `2.3.0`.

### Why are the changes needed?

To bring the latest bug fixes and improvements from `grpc-swift-protobuf` 2.3.0 which is tested with Swift 6.3 officially.

- https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.3.0
  - https://github.com/grpc/grpc-swift-protobuf/pull/97
  - https://github.com/grpc/grpc-swift-protobuf/pull/98

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4