### PR TITLE
[SPARK-56517] Upgrade `gRPC Swift NIO Transport` to 2.7.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.3.0"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.2.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.6.2"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.7.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.6.4")
   ],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Swift 6.3 (April 2026)](https://swift.org)
 - [gRPC Swift 2.3 (March 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.3.0)
 - [gRPC Swift Protobuf 2.2.1 (March 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.2.1)
-- [gRPC Swift NIO Transport 2.6.2 (March 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.6.2)
+- [gRPC Swift NIO Transport 2.7.0 (April 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.7.0)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `grpc-swift-nio-transport` dependency to `2.7.0`.

### Why are the changes needed?

To adopt the latest `grpc-swift-nio-transport` release (`2.7.0`) which is tested with Swift 6.3 officially.
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.7.0
  - https://github.com/grpc/grpc-swift-nio-transport/pull/170
  - https://github.com/grpc/grpc-swift-nio-transport/pull/172
  - https://github.com/grpc/grpc-swift-nio-transport/pull/171

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing test suites.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4