### PR TITLE
[SPARK-56668] Upgrade `actions/setup-java` to v5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -203,7 +203,7 @@ jobs:
     - name: Select Xcode 26.4
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17
@@ -230,7 +230,7 @@ jobs:
     - name: Select Xcode 26.4
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17
@@ -258,7 +258,7 @@ jobs:
     - name: Select Xcode 26.4
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `actions/setup-java` to `v5` like Apache Spark main repository.
- https://github.com/apache/spark/pull/54377

### Why are the changes needed?

To keep up with the latest major version of `actions/setup-java` (the current latest release is `v5.2.0`).

- https://github.com/actions/setup-java/releases/tag/v5.0.0
- https://github.com/actions/setup-java/releases/tag/v5.1.0
- https://github.com/actions/setup-java/releases/tag/v5.2.0

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7