### PR TITLE
[SPARK-56709] Use Apache Spark `4.2.0-preview5` in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -142,9 +142,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.2.0-preview4/spark-4.2.0-preview4-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.2.0-preview4-bin-hadoop3.tgz && rm spark-4.2.0-preview4-bin-hadoop3.tgz
-        mv spark-4.2.0-preview4-bin-hadoop3/ /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.2.0-preview5/spark-4.2.0-preview5-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.2.0-preview5-bin-hadoop3.tgz && rm spark-4.2.0-preview5-bin-hadoop3.tgz
+        mv spark-4.2.0-preview5-bin-hadoop3/ /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh -c spark.sql.timeType.enabled=true
         cd -


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Apache Spark 4.2.0-preview5` instead of `preview4` in the `integration-test-mac-spark42` CI job.

### Why are the changes needed?

To use the latest available preview release of Apache Spark 4.2 in our integration tests.
- https://spark.apache.org/docs/4.2.0-preview5/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7