### PR TITLE
[SPARK-56722] Upgrade Docker GitHub Actions in `publish_image.yml`

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -21,11 +21,11 @@ jobs:
         example: ${{ fromJSON( inputs.example || '["app", "pi", "pyspark-connect", "spark-sql", "stream", "web"]' ) }}
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
       with:
         ref: main
     - name: Build and push
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
       with:
         # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
         cache-from: type=gha


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the Docker actions used in `publish_image.yml` to their latest major versions.

| Action | Current SHA (version) | New SHA (version) |
|---|---|---|
| `docker/setup-qemu-action` | `29109295f81e9208d7d86ff1c6c12d2833863392` (v3.6.0) | `ce360397dd3f832beb865e1373c09c0e9f86d70a` (v4.0.0) |
| `docker/setup-buildx-action` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` (v3.12.0) | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` (v4.0.0) |
| `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` (v3.7.0) | `4907a6ddec9925e35a0a9e82d7399ccc52663121` (v4.1.0) |
| `docker/build-push-action` | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` (v6.19.2) | `bcafcacb16a39f128d818304e6c9c0c18556b85f` (v7.1.0) |

All four new SHAs are already registered in [apache/infrastructure-actions `approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml).

### Why are the changes needed?

To keep CI dependencies up-to-date and adopt the latest improvements:

- `setup-qemu-action` v4 / `setup-buildx-action` v4 — Node 24 as default runtime, ESM module format, and removal of deprecated inputs/outputs.
- `login-action` v4.1.0 — fix for scoped Docker Hub cleanup path when registry is omitted.
- `build-push-action` v7.1.0 — Git context query format support and various dependency updates.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)