### PR TITLE
[SPARK-56725] Upgrade Swift to 6.3.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,8 +57,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3 swift build -c release
+        docker run swift:6.3.1 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.1 swift build -c release
 
   build-ubuntu-arm:
     runs-on: ubuntu-24.04-arm
@@ -67,8 +67,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3 swift build -c release
+        docker run swift:6.3.1 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.1 swift build -c release
 
   integration-test-ubuntu:
     runs-on: ubuntu-latest
@@ -86,8 +86,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3 swift test --no-parallel -c release
+        docker run swift:6.3.1 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
 
   integration-test-ubuntu-spark41:
     runs-on: ubuntu-latest
@@ -105,8 +105,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3 swift test --no-parallel -c release
+        docker run swift:6.3.1 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
 
   integration-test-mac-spark41:
     runs-on: macos-26

--- a/Examples/app/Dockerfile
+++ b/Examples/app/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3 AS builder
+FROM swift:6.3.1 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/app/Package.swift
+++ b/Examples/app/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/pi/Dockerfile
+++ b/Examples/pi/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3 AS builder
+FROM swift:6.3.1 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/pi/Package.swift
+++ b/Examples/pi/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/spark-sql/Dockerfile
+++ b/Examples/spark-sql/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3 AS builder
+FROM swift:6.3.1 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/spark-sql/Package.swift
+++ b/Examples/spark-sql/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/stream/Dockerfile
+++ b/Examples/stream/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3 AS builder
+FROM swift:6.3.1 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/stream/Package.swift
+++ b/Examples/stream/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/web/Dockerfile
+++ b/Examples/web/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3 AS builder
+FROM swift:6.3.1 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3-release/static-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/web/Package.swift
+++ b/Examples/web/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.3.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 ## Requirement
 
 - [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
-- [Swift 6.3 (April 2026)](https://swift.org)
+- [Swift 6.3.1 (April 2026)](https://swift.org)
 - [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
 - [gRPC Swift Protobuf 2.3.0 (April 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.3.0)
 - [gRPC Swift NIO Transport 2.7.0 (April 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.7.0)

--- a/Sources/SparkConnect/Documentation.docc/GettingStarted.md
+++ b/Sources/SparkConnect/Documentation.docc/GettingStarted.md
@@ -25,7 +25,7 @@ targets: [
 
 ## Prerequisites
 
-- Swift 6.3 or later
+- Swift 6.3.1 or later
 - macOS 15+, iOS 18+, watchOS 11+, or tvOS 18+
 - A running Apache Spark cluster with Spark Connect enabled
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Swift 6.3.1` instead of `Swift 6.3`.

### Why are the changes needed?

To pick up [Swift 6.3.1 (2026-04-16)](https://forums.swift.org/t/announcing-swift-6-3-1/86080), which fixes a stack-allocation bug in async functions causing `"freed pointer was not the last allocation"` crashes around `swift_asyncLet_finish` ([swiftlang/swift#88389](https://github.com/swiftlang/swift/pull/88389)) — directly relevant to this async-heavy project.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)