### PR TITLE
[SPARK-56753] Fix typos and code sample bugs in documentation

### DIFF
--- a/Examples/spark-sql/README.md
+++ b/Examples/spark-sql/README.md
@@ -1,6 +1,6 @@
 # A `Spark SQL REPL` Application with Apache Spark Connect Swift Client
 
-This is an example Swift application to show how to develop a Spark SQL REPL(Read-eval-print Loop) with Apache Spark Connect Swift Client library.
+This is an example Swift application to show how to develop a Spark SQL REPL (Read-Eval-Print Loop) with Apache Spark Connect Swift Client library.
 
 ## How to run
 

--- a/Examples/stream/README.md
+++ b/Examples/stream/README.md
@@ -35,7 +35,7 @@ docker run --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 -e TARGET_HOST=h
 
 ## Send input and check output
 
-Then, any lines typed in the terminal running the `Netcat` server will be counted and printed on screen every second.
+Then, any lines typed in the terminal running the `Netcat` server will be counted and printed to the screen every second.
 
 ```bash
 $ nc -lk 9999

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Swift Package Index](https://swiftpackageindex.com/apache/spark-connect-swift/)
 - [Library Documentation](https://swiftpackageindex.com/apache/spark-connect-swift/main/documentation/sparkconnect)
 
-## Requirement
+## Requirements
 
 - [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
 - [Swift 6.3.1 (April 2026)](https://swift.org)

--- a/Sources/SparkConnect/Documentation.docc/Examples.md
+++ b/Sources/SparkConnect/Documentation.docc/Examples.md
@@ -39,7 +39,7 @@ docker run -it --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 apache/spark
 swift run
 ```
 
-## Spark SQL REPL(Read-Eval-Print Loop) Example
+## Spark SQL REPL (Read-Eval-Print Loop) Example
 
 The Spark SQL REPL application example demonstrates interactive operations with ad-hoc Spark SQL queries with Apache Spark Connect, including:
 
@@ -119,7 +119,7 @@ docker run --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 -e TARGET_HOST=h
 swift run
 ```
 
-Type text into the Netcat terminal to see real-time word counting from `Spark Connect Server` container.
+Type text into the Netcat terminal to see real-time word counting in the `Spark Connect Server` container output.
 
 ## Web Application Example
 

--- a/Sources/SparkConnect/Documentation.docc/GettingStarted.md
+++ b/Sources/SparkConnect/Documentation.docc/GettingStarted.md
@@ -8,7 +8,7 @@ Add SparkConnect to your Swift package dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apache/spark-connect-swift.git", from: "main")
+    .package(url: "https://github.com/apache/spark-connect-swift.git", branch: "main")
 ]
 ```
 
@@ -55,7 +55,7 @@ try await df1.show()
 // Select columns
 try await df1.select("id").show()
 
-let df2 = await df1.selectExpr("id", "id % 3 as value")
+let df2 = df1.selectExpr("id", "id % 3 as value")
 try await df2.show()
 
 // Filter data
@@ -82,7 +82,7 @@ let result = try await spark.sql("""
     ORDER BY value_sum DESC
 """)
 
-result.show()
+try await result.show()
 ```
 
 ### 4. Reading and Writing Data

--- a/Sources/SparkConnect/Documentation.docc/SparkSession.md
+++ b/Sources/SparkConnect/Documentation.docc/SparkSession.md
@@ -20,10 +20,10 @@ let spark = try await SparkSession
 
 ```swift
 // Create a DataFrame from a range
-let df = spark.range(1, 10)
+let df = try await spark.range(1, 10)
 
 // Execute SQL query
-let result = spark.sql("SELECT * FROM table")
+let result = try await spark.sql("SELECT * FROM table")
 
 // Read data from files
 let csvDf = spark.read.csv("path/to/file.csv")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes typos, awkward wording, and incorrect API usage in code samples across the project documentation:

- `README.md`: `## Requirement` -> `## Requirements`.
- `Examples/spark-sql/README.md` and `Sources/SparkConnect/Documentation.docc/Examples.md`: fix `REPL(Read-eval-print Loop)` spacing/capitalization to `REPL (Read-Eval-Print Loop)`.
- `Sources/SparkConnect/Documentation.docc/Examples.md`: reword the Netcat output sentence in the streaming section.
- `Examples/stream/README.md`: minor wording fix ("printed on screen" -> "printed to the screen").
- `Sources/SparkConnect/Documentation.docc/GettingStarted.md`:
  - `from: "main"` is invalid for SwiftPM (`from:` requires a `Version`); change to `branch: "main"` to match the root README.
  - Drop incorrect `await` on `selectExpr`, which is not `async`.
  - Add missing `try await` to `result.show()`.
- `Sources/SparkConnect/Documentation.docc/SparkSession.md`: add missing `try await` to `spark.range(...)` and `spark.sql(...)`, both of which are `async throws`.

### Why are the changes needed?

Documentation should be accurate. The code snippets in `GettingStarted.md` and `SparkSession.md` will not compile as written, which is misleading for new users following the docs. The other items are typos and wording polish.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only changes.

### How was this patch tested?

Manually reviewed the diffs and cross-checked the documented APIs against their definitions in `SparkSession.swift`, `DataFrame+Actions.swift`, and `DataFrame+Transformations.swift` to confirm the corrected `async`/`throws` annotations.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7