### PR TITLE
[SPARK-56788] Add `integration-test-ubuntu-spark42` GitHub Actions job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,6 +108,21 @@ jobs:
         docker run swift:6.3.1 uname -a
         docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
 
+  integration-test-ubuntu-spark42:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Start Spark Connect Server
+      run: |
+        docker run -d --name spark -p 15003:15002 -e SPARK_NO_DAEMONIZE=1 \
+          --entrypoint /opt/spark/sbin/start-connect-server.sh \
+          apache/spark:4.2.0-preview5-scala \
+          -c spark.sql.timeType.enabled=true
+    - name: Test
+      run: |
+        docker run swift:6.3.1 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
+
   integration-test-mac-spark41:
     runs-on: macos-26
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new GitHub Actions job, `integration-test-ubuntu-spark42`, that runs the Swift Spark Connect client integration test suite against an Apache Spark `4.2.0-preview5` server on Linux/Docker.

### Why are the changes needed?

Currently, Spark `4.2.0-preview5` is only exercised on macOS (`integration-test-mac-spark42`).

- This PR extends coverage to Linux/Docker, matching the existing pattern where both `integration-test-ubuntu` (4.0.2) and `integration-test-ubuntu-spark41` (4.1.1) accompany their macOS counterparts. This catches Linux/JVM-specific regressions earlier in CI.

- The new job starts the Spark Connect server from the official `apache/spark:4.2.0-preview5-scala` Docker image with `-c spark.sql.timeType.enabled=true`, mirroring the configuration used by the existing `integration-test-mac-spark42` job. Unlike `integration-test-ubuntu-spark41`, which uses GitHub Actions' `services:` block, this job starts the container explicitly with `docker run -d` because GitHub Actions `services:` does not support passing CMD arguments (such as `-c spark.sql.timeType.enabled=true`) to the entrypoint.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test coverage.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7