### PR TITLE
[SPARK-56828] Upgrade `grpc-swift-2` to 2.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.3.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.7.0"),
     .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19-2026-02-06-03fffb2"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `grpc-swift-2` dependency to `2.4.1`.

### Why are the changes needed?

To stay current with the latest patch release of `grpc-swift-2`.
- https://github.com/grpc/grpc-swift-2/releases/tag/2.4.1
  - https://github.com/grpc/grpc-swift-2/pull/46

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7