### PR TITLE
[SPARK-56857] Upgrade Swift to 6.3.2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,8 +57,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.1 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3.1 swift build -c release
+        docker run swift:6.3.2 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.2 swift build -c release
 
   build-ubuntu-arm:
     runs-on: ubuntu-24.04-arm
@@ -67,8 +67,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.1 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3.1 swift build -c release
+        docker run swift:6.3.2 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.2 swift build -c release
 
   integration-test-ubuntu:
     runs-on: ubuntu-latest
@@ -86,8 +86,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.1 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
+        docker run swift:6.3.2 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
 
   integration-test-ubuntu-spark41:
     runs-on: ubuntu-latest
@@ -105,8 +105,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.1 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
+        docker run swift:6.3.2 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
 
   integration-test-ubuntu-spark42:
     runs-on: ubuntu-latest
@@ -120,8 +120,8 @@ jobs:
           -c spark.sql.timeType.enabled=true
     - name: Test
       run: |
-        docker run swift:6.3.1 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.1 swift test --no-parallel -c release
+        docker run swift:6.3.2 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
 
   integration-test-mac-spark41:
     runs-on: macos-26

--- a/Examples/app/Dockerfile
+++ b/Examples/app/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.1 AS builder
+FROM swift:6.3.2 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/app/Package.swift
+++ b/Examples/app/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/pi/Dockerfile
+++ b/Examples/pi/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.1 AS builder
+FROM swift:6.3.2 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/pi/Package.swift
+++ b/Examples/pi/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/spark-sql/Dockerfile
+++ b/Examples/spark-sql/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.1 AS builder
+FROM swift:6.3.2 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/spark-sql/Package.swift
+++ b/Examples/spark-sql/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/stream/Dockerfile
+++ b/Examples/stream/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.1 AS builder
+FROM swift:6.3.2 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/stream/Package.swift
+++ b/Examples/stream/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Examples/web/Dockerfile
+++ b/Examples/web/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.1 AS builder
+FROM swift:6.3.2 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.1-release/static-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/web/Package.swift
+++ b/Examples/web/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3.1
+// swift-tools-version: 6.3.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 ## Requirements
 
 - [Apache Spark 4.1.2 (May 2026)](https://github.com/apache/spark/releases/tag/v4.1.2)
-- [Swift 6.3.1 (April 2026)](https://swift.org)
+- [Swift 6.3.2 (May 2026)](https://swift.org)
 - [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
 - [gRPC Swift Protobuf 2.4.0 (May 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.0)
 - [gRPC Swift NIO Transport 2.7.0 (April 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.7.0)

--- a/Sources/SparkConnect/Documentation.docc/GettingStarted.md
+++ b/Sources/SparkConnect/Documentation.docc/GettingStarted.md
@@ -25,7 +25,7 @@ targets: [
 
 ## Prerequisites
 
-- Swift 6.3.1 or later
+- Swift 6.3.2 or later
 - macOS 15+, iOS 18+, watchOS 11+, or tvOS 18+
 - A running Apache Spark cluster with Spark Connect enabled
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Swift 6.3.2` instead of `Swift 6.3.1`.

### Why are the changes needed?

To pick up [Swift 6.3.2 (2026-05-11)](https://github.com/swiftlang/swift/releases/tag/swift-6.3.2-RELEASE), which contains 91 commits on top of 6.3.1, with a heavy focus on concurrency and stack-nesting correctness — directly relevant to this async-heavy project. Notable fixes include:

- Follow-up SIL/IRGen work hardening `async let` stack allocation (e.g. *"Fix a bug involving two async lets on the stack at once"*, *"Don't delay stack deallocation of non-nested allocations"*), continuing the line of fixes started in 6.3.1 ([swiftlang/swift#87896](https://github.com/swiftlang/swift/pull/87896), [#88254](https://github.com/swiftlang/swift/pull/88254)).
- *"[Concurrency] Fix `stripConcurrency` to avoid dropping parameter isolation"*.
- *"[SILOptimizer] fix an erroneous `hop_to_executor` removal"* and *"Prevent function signature optimization from removing implicit leading isolation parameter"*.
- *"[IRGen] Sign protocol witnesses in relative witness table access"* / ptrauth discriminator cache fix ([#88105](https://github.com/swiftlang/swift/pull/88105), [#88135](https://github.com/swiftlang/swift/pull/88135)).
- *"COWOpts: Don't look through `struct_extract` for multi-field structs"*.

Full commit range: [swift-6.3.1-RELEASE...swift-6.3.2-RELEASE](https://github.com/swiftlang/swift/compare/swift-6.3.1-RELEASE...swift-6.3.2-RELEASE).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)