### PR TITLE
[SPARK-56858] Use `Xcode 26.5` in CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,8 +45,8 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Build
       run: swift build -c release
 
@@ -130,8 +130,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -151,8 +151,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -172,8 +172,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -194,8 +194,8 @@ jobs:
       SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -215,8 +215,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Install Java
       uses: actions/setup-java@v5
       with:
@@ -242,8 +242,8 @@ jobs:
       SPARK_ICEBERG_TEST_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Install Java
       uses: actions/setup-java@v5
       with:
@@ -270,8 +270,8 @@ jobs:
       SPARK_ICEBERG_TEST_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.4
-      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
     - name: Install Java
       uses: actions/setup-java@v5
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Xcode to `26.5` in GitHub Actions.

### Why are the changes needed?

To validate Apache Spark Connect Swift with the latest Xcode toolchain on CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7