### PR TITLE
[SPARK-56951] Use 4.1.2 RC1 for Spark 4.1 integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,9 +136,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.1/spark-4.1.1-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.1.1-bin-hadoop3.tgz && rm spark-4.1.1-bin-hadoop3.tgz
-        mv spark-4.1.1-bin-hadoop3 /tmp/spark
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.2-rc1-bin/spark-4.1.2-bin-hadoop3.tgz
+        tar xvfz spark-4.1.2-bin-hadoop3.tgz && rm spark-4.1.2-bin-hadoop3.tgz
+        mv spark-4.1.2-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `integration-test-mac-spark41` CI job to use `Apache Spark 4.1.2` RC1.

### Why are the changes needed?

To test against the latest `Apache Spark 4.1.2` release candidate.
- [[VOTE] Release Spark 4.1.2 (RC1)](https://lists.apache.org/thread/locxv3h4tkbsvcf8t600kyvx16xw6xl3)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7