### PR TITLE
[SPARK-56996] Use Spark 4.1.2 instead of RC1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,7 +136,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.1.2-rc1-bin/spark-4.1.2-bin-hadoop3.tgz
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.2/spark-4.1.2-bin-hadoop3.tgz?action=download
         tar xvfz spark-4.1.2-bin-hadoop3.tgz && rm spark-4.1.2-bin-hadoop3.tgz
         mv spark-4.1.2-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Apache Spark 4.1.2` instead of `4.1.2 RC1` for the `integration-test-mac-spark41` CI job.

### Why are the changes needed?

`Apache Spark 4.1.2` has been officially released.
- https://spark.apache.org/news/spark-4-1-2-released.html
- https://github.com/apache/spark/releases/tag/v4.1.2

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7