### PR TITLE
[SPARK-57007] Use Spark 4.1.2 in docs, examples, and tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -95,7 +95,7 @@ jobs:
       SPARK_REMOTE: "sc://localhost:15003"
     services:
       spark:
-        image: apache/spark:4.1.1-scala
+        image: apache/spark:4.1.2-scala
         env:
           SPARK_NO_DAEMONIZE: 1
         ports:
@@ -200,9 +200,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.1/spark-4.1.1-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.1.1-bin-hadoop3.tgz && rm spark-4.1.1-bin-hadoop3.tgz
-        mv spark-4.1.1-bin-hadoop3 /tmp/spark
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.1.2/spark-4.1.2-bin-hadoop3.tgz?action=download
+        tar xvfz spark-4.1.2-bin-hadoop3.tgz && rm spark-4.1.2-bin-hadoop3.tgz
+        mv spark-4.1.2-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -

--- a/Examples/app/README.md
+++ b/Examples/app/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to use Apache Spark Connect Swi
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -23,7 +23,7 @@ Run `app` docker image.
 
 ```bash
 $ docker run --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 apache/spark-connect-swift:app
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT) USING ORC
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)
@@ -52,7 +52,7 @@ Run from source code.
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT) USING ORC
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)

--- a/Examples/pi/README.md
+++ b/Examples/pi/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to use Apache Spark Connect Swi
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.

--- a/Examples/pyspark-connect/README.md
+++ b/Examples/pyspark-connect/README.md
@@ -7,7 +7,7 @@ This is a reference example Python application to show how to use Apache Spark C
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.

--- a/Examples/spark-sql/README.md
+++ b/Examples/spark-sql/README.md
@@ -7,7 +7,7 @@ This is an example Swift application to show how to develop a Spark SQL REPL (Re
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run -it --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run -it --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -23,7 +23,7 @@ Run `spark-sql` docker image.
 
 ```bash
 $ docker run -it --rm -e SPARK_REMOTE=sc://host.docker.internal:15002 apache/spark-connect-swift:spark-sql
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 spark-sql (default)> SHOW DATABASES;
 +---------+
 |namespace|
@@ -87,14 +87,14 @@ Time taken: 46 ms
 spark-sql (default)> exit;
 ```
 
-Apache Spark 4 supports [SQL Pipe Syntax](https://spark.apache.org/docs/4.1.1/sql-pipe-syntax.html).
+Apache Spark 4 supports [SQL Pipe Syntax](https://spark.apache.org/docs/4.1.2/sql-pipe-syntax.html).
 Run from source code at this time.
 
 ```bash
 $ swift run
 ...
 Build of product 'SparkSQLRepl' complete! (2.33s)
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 spark-sql (default)>
 FROM ORC.`/opt/spark/examples/src/main/resources/users.orc`
 |> AGGREGATE COUNT(*) cnt

--- a/Examples/stream/README.md
+++ b/Examples/stream/README.md
@@ -5,7 +5,7 @@ This is an example Swift stream processing application to show how to count word
 ## Run `Spark Connect Server`
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
+docker run --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
 ```
 
 ## Run `Netcat` as a streaming input server
@@ -81,5 +81,5 @@ Batch: 2
 ```bash
 $ TARGET_HOST=host.docker.internal swift run
 ...
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 ```

--- a/Examples/web/README.md
+++ b/Examples/web/README.md
@@ -90,7 +90,7 @@ index 2edcc8f..dd918a9 100644
 Prepare `Spark Connect Server` via running Docker image.
 
 ```bash
-docker run --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
+docker run --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait"
 ```
 
 Build an application Docker image.
@@ -116,7 +116,7 @@ $ curl http://127.0.0.1:8080/
 Welcome to the Swift world. Say hello!%
 
 $ curl http://127.0.0.1:8080/hello
-Hi, this is powered by the Apache Spark 4.1.1.%
+Hi, this is powered by the Apache Spark 4.1.2.%
 ```
 
 Run from source code.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 **Docker Image Size**
 |     Name      | Image Size |
 | ------------- | ---------- |
-| `apache/spark:4.1.1-python3`-based SparkPi | [![Docker Image Size](https://img.shields.io/docker/image-size/apache/spark/4.1.1-python3?style=flat-square&logo=docker)](https://hub.docker.com/r/apache/spark/tags?page=1&name=4.1.1-python3) |
+| `apache/spark:4.1.2-python3`-based SparkPi | [![Docker Image Size](https://img.shields.io/docker/image-size/apache/spark/4.1.2-python3?style=flat-square&logo=docker)](https://hub.docker.com/r/apache/spark/tags?page=1&name=4.1.2-python3) |
 | `pyspark-connect`-based SparkPi | [![Docker Image Size](https://img.shields.io/docker/image-size/apache/spark-connect-swift/pyspark-connect?style=flat-square&logo=docker)](https://hub.docker.com/r/apache/spark-connect-swift/tags?page=1&name=pyspark-connect) |
 | `Swift`-based SparkPi | [![Docker Image Size](https://img.shields.io/docker/image-size/apache/spark-connect-swift/pi?style=flat-square&logo=docker)](https://hub.docker.com/r/apache/spark-connect-swift/tags?page=1&name=pi) |
 
@@ -23,7 +23,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 
 ## Requirements
 
-- [Apache Spark 4.1.1 (January 2026)](https://github.com/apache/spark/releases/tag/v4.1.1)
+- [Apache Spark 4.1.2 (May 2026)](https://github.com/apache/spark/releases/tag/v4.1.2)
 - [Swift 6.3.1 (April 2026)](https://swift.org)
 - [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
 - [gRPC Swift Protobuf 2.4.0 (May 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.0)
@@ -100,7 +100,7 @@ Run your Swift application.
 ```bash
 $ swift run
 ...
-Connected to Apache Spark 4.1.1 Server
+Connected to Apache Spark 4.1.2 Server
 EXECUTE: DROP TABLE IF EXISTS t
 EXECUTE: CREATE TABLE IF NOT EXISTS t(a INT) USING ORC
 EXECUTE: INSERT INTO t VALUES (1), (2), (3)

--- a/Sources/SparkConnect/Documentation.docc/Examples.md
+++ b/Sources/SparkConnect/Documentation.docc/Examples.md
@@ -7,7 +7,7 @@ This document provides an overview of the example applications inside [Examples]
 Start a Spark Connect Server:
 
 ```bash
-docker run -it --rm -p 15002:15002 apache/spark:4.1.1 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
+docker run -it --rm -p 15002:15002 apache/spark:4.1.2 bash -c "/opt/spark/sbin/start-connect-server.sh --wait -c spark.log.level=ERROR"
 ```
 
 ## Basic Application Example
@@ -154,7 +154,7 @@ Welcome to the Swift world. Say hello!%
 
 # Spark-powered endpoint
 curl http://127.0.0.1:8080/hello
-Hi, this is powered by the Apache Spark 4.1.1.%
+Hi, this is powered by the Apache Spark 4.1.2.%
 ```
 
 ## Development Environment


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Apache Spark 4.1.2`  in `README.md`, `Examples`, and GitHub Action CIs (`integration-test-ubuntu-spark41` and `integration-test-token`).

### Why are the changes needed?

`Apache Spark 4.1.2` has been officially released.
- https://spark.apache.org/news/spark-4-1-2-released.html
- https://github.com/apache/spark/releases/tag/v4.1.2

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manually check like the following.

**BEFORE**
```
$ git grep '4\.1\.1' | wc -l
      22
```

**AFTER**
```
$ git grep '4\.1\.1' | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7