### PR TITLE
[SPARK-57008] Regenerate `Spark Connect`-generated Swift source code with `protoc-gen-grpc-swift-2` 2.4.0

### DIFF
--- a/Sources/SparkConnect/base.pb.swift
+++ b/Sources/SparkConnect/base.pb.swift
@@ -36,13 +36,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Compression codec for plan compression.
-enum Spark_Connect_CompressionCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Spark_Connect_CompressionCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case unspecified // = 0
   case zstd // = 1
@@ -81,7 +81,7 @@ enum Spark_Connect_CompressionCodec: SwiftProtobuf.Enum, Swift.CaseIterable {
 /// - [[Relation]]: a reference to the underlying logical plan.
 /// - [[Command]]: used to execute commands on the server.
 /// - [[CompressedOperation]]: a compressed representation of either a Relation or a Command.
-struct Spark_Connect_Plan: Sendable {
+nonisolated struct Spark_Connect_Plan: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,14 +114,14 @@ struct Spark_Connect_Plan: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_OpType: Equatable, Sendable {
+  nonisolated enum OneOf_OpType: Equatable, Sendable {
     case root(Spark_Connect_Relation)
     case command(Spark_Connect_Command)
     case compressedOperation(Spark_Connect_Plan.CompressedOperation)
 
   }
 
-  struct CompressedOperation: Sendable {
+  nonisolated struct CompressedOperation: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -134,7 +134,7 @@ struct Spark_Connect_Plan: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OpType: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum OpType: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
       case relation // = 1
@@ -180,7 +180,7 @@ struct Spark_Connect_Plan: Sendable {
 
 /// User Context is used to refer to one particular user session that is executing
 /// queries in the backend.
-struct Spark_Connect_UserContext: Sendable {
+nonisolated struct Spark_Connect_UserContext: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -201,7 +201,7 @@ struct Spark_Connect_UserContext: Sendable {
 }
 
 /// Request to perform plan analyze, optionally to explain the plan.
-struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
+nonisolated struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -371,7 +371,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Analyze: Equatable, Sendable {
+  nonisolated enum OneOf_Analyze: Equatable, Sendable {
     case schema(Spark_Connect_AnalyzePlanRequest.Schema)
     case explain(Spark_Connect_AnalyzePlanRequest.Explain)
     case treeString(Spark_Connect_AnalyzePlanRequest.TreeString)
@@ -389,7 +389,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
 
   }
 
-  struct Schema: Sendable {
+  nonisolated struct Schema: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -412,7 +412,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
   }
 
   /// Explains the input plan based on a configurable mode.
-  struct Explain: Sendable {
+  nonisolated struct Explain: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -433,7 +433,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// Plan explanation mode.
-    enum ExplainMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum ExplainMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
 
@@ -502,7 +502,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _plan: Spark_Connect_Plan? = nil
   }
 
-  struct TreeString: Sendable {
+  nonisolated struct TreeString: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -535,7 +535,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _level: Int32? = nil
   }
 
-  struct IsLocal: Sendable {
+  nonisolated struct IsLocal: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -557,7 +557,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _plan: Spark_Connect_Plan? = nil
   }
 
-  struct IsStreaming: Sendable {
+  nonisolated struct IsStreaming: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -579,7 +579,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _plan: Spark_Connect_Plan? = nil
   }
 
-  struct InputFiles: Sendable {
+  nonisolated struct InputFiles: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -601,7 +601,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _plan: Spark_Connect_Plan? = nil
   }
 
-  struct SparkVersion: Sendable {
+  nonisolated struct SparkVersion: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -611,7 +611,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     init() {}
   }
 
-  struct DDLParse: Sendable {
+  nonisolated struct DDLParse: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -625,7 +625,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
   }
 
   /// Returns `true` when the logical query plans  are equal and therefore return same results.
-  struct SameSemantics: @unchecked Sendable {
+  nonisolated struct SameSemantics: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -657,7 +657,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct SemanticHash: Sendable {
+  nonisolated struct SemanticHash: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -679,7 +679,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _plan: Spark_Connect_Plan? = nil
   }
 
-  struct Persist: Sendable {
+  nonisolated struct Persist: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -712,7 +712,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _storageLevel: Spark_Connect_StorageLevel? = nil
   }
 
-  struct Unpersist: Sendable {
+  nonisolated struct Unpersist: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -745,7 +745,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _blocking: Bool? = nil
   }
 
-  struct GetStorageLevel: Sendable {
+  nonisolated struct GetStorageLevel: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -767,7 +767,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
     fileprivate var _relation: Spark_Connect_Relation? = nil
   }
 
-  struct JsonToDDL: Sendable {
+  nonisolated struct JsonToDDL: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -788,7 +788,7 @@ struct Spark_Connect_AnalyzePlanRequest: @unchecked Sendable {
 /// Response to performing analysis of the query. Contains relevant metadata to be able to
 /// reason about the performance.
 /// Next ID: 16
-struct Spark_Connect_AnalyzePlanResponse: Sendable {
+nonisolated struct Spark_Connect_AnalyzePlanResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -915,7 +915,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Result: Equatable, Sendable {
+  nonisolated enum OneOf_Result: Equatable, Sendable {
     case schema(Spark_Connect_AnalyzePlanResponse.Schema)
     case explain(Spark_Connect_AnalyzePlanResponse.Explain)
     case treeString(Spark_Connect_AnalyzePlanResponse.TreeString)
@@ -933,7 +933,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
 
   }
 
-  struct Schema: Sendable {
+  nonisolated struct Schema: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -954,7 +954,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     fileprivate var _schema: Spark_Connect_DataType? = nil
   }
 
-  struct Explain: Sendable {
+  nonisolated struct Explain: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -966,7 +966,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct TreeString: Sendable {
+  nonisolated struct TreeString: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -978,7 +978,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct IsLocal: Sendable {
+  nonisolated struct IsLocal: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -990,7 +990,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct IsStreaming: Sendable {
+  nonisolated struct IsStreaming: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1002,7 +1002,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct InputFiles: Sendable {
+  nonisolated struct InputFiles: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1015,7 +1015,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct SparkVersion: Sendable {
+  nonisolated struct SparkVersion: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1027,7 +1027,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct DDLParse: Sendable {
+  nonisolated struct DDLParse: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1048,7 +1048,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     fileprivate var _parsed: Spark_Connect_DataType? = nil
   }
 
-  struct SameSemantics: Sendable {
+  nonisolated struct SameSemantics: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1060,7 +1060,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct SemanticHash: Sendable {
+  nonisolated struct SemanticHash: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1072,7 +1072,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct Persist: Sendable {
+  nonisolated struct Persist: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1082,7 +1082,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct Unpersist: Sendable {
+  nonisolated struct Unpersist: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1092,7 +1092,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     init() {}
   }
 
-  struct GetStorageLevel: Sendable {
+  nonisolated struct GetStorageLevel: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1114,7 +1114,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
     fileprivate var _storageLevel: Spark_Connect_StorageLevel? = nil
   }
 
-  struct JsonToDDL: Sendable {
+  nonisolated struct JsonToDDL: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1130,7 +1130,7 @@ struct Spark_Connect_AnalyzePlanResponse: Sendable {
 }
 
 /// A request to be executed by the service.
-struct Spark_Connect_ExecutePlanRequest: @unchecked Sendable {
+nonisolated struct Spark_Connect_ExecutePlanRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1224,7 +1224,7 @@ struct Spark_Connect_ExecutePlanRequest: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct RequestOption: Sendable {
+  nonisolated struct RequestOption: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1258,7 +1258,7 @@ struct Spark_Connect_ExecutePlanRequest: @unchecked Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_RequestOption: Equatable, Sendable {
+    nonisolated enum OneOf_RequestOption: Equatable, Sendable {
       case reattachOptions(Spark_Connect_ReattachOptions)
       case resultChunkingOptions(Spark_Connect_ResultChunkingOptions)
       /// Extension type for request options
@@ -1277,7 +1277,7 @@ struct Spark_Connect_ExecutePlanRequest: @unchecked Sendable {
 /// The response of a query, can be one or more for each request. Responses belonging to the
 /// same input query, carry the same `session_id`.
 /// Next ID: 17
-struct Spark_Connect_ExecutePlanResponse: Sendable {
+nonisolated struct Spark_Connect_ExecutePlanResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1472,7 +1472,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Union type for the different response messages.
-  enum OneOf_ResponseType: Equatable, Sendable {
+  nonisolated enum OneOf_ResponseType: Equatable, Sendable {
     case arrowBatch(Spark_Connect_ExecutePlanResponse.ArrowBatch)
     /// Special case for executing SQL commands.
     case sqlCommandResult(Spark_Connect_ExecutePlanResponse.SqlCommandResult)
@@ -1510,7 +1510,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
 
   /// A SQL command returns an opaque Relation that can be directly used as input for the next
   /// call.
-  struct SqlCommandResult: Sendable {
+  nonisolated struct SqlCommandResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1532,7 +1532,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
   }
 
   /// Batch results of metrics.
-  struct ArrowBatch: Sendable {
+  nonisolated struct ArrowBatch: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1584,7 +1584,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
     fileprivate var _numChunksInBatch: Int64? = nil
   }
 
-  struct Metrics: Sendable {
+  nonisolated struct Metrics: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1593,7 +1593,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct MetricObject: Sendable {
+    nonisolated struct MetricObject: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1611,7 +1611,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
       init() {}
     }
 
-    struct MetricValue: Sendable {
+    nonisolated struct MetricValue: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1630,7 +1630,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
     init() {}
   }
 
-  struct ObservedMetrics: Sendable {
+  nonisolated struct ObservedMetrics: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1668,7 +1668,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
   /// If present, in a reattachable execution this means that after server sends onComplete,
   /// the execution is complete. If the server sends onComplete without sending a ResultComplete,
   /// it means that there is more, and the client should use ReattachExecute RPC to continue.
-  struct ResultComplete: Sendable {
+  nonisolated struct ResultComplete: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1679,7 +1679,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
   }
 
   /// This message is used to communicate progress about the query progress during the execution.
-  struct ExecutionProgress: Sendable {
+  nonisolated struct ExecutionProgress: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1692,7 +1692,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct StageInfo: Sendable {
+    nonisolated struct StageInfo: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1722,7 +1722,7 @@ struct Spark_Connect_ExecutePlanResponse: Sendable {
 }
 
 /// The key-value pair for the config request and response.
-struct Spark_Connect_KeyValue: Sendable {
+nonisolated struct Spark_Connect_KeyValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1748,7 +1748,7 @@ struct Spark_Connect_KeyValue: Sendable {
 }
 
 /// Request to update or fetch the configurations.
-struct Spark_Connect_ConfigRequest: Sendable {
+nonisolated struct Spark_Connect_ConfigRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1808,7 +1808,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Operation: Sendable {
+  nonisolated struct Operation: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1873,7 +1873,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_OpType: Equatable, Sendable {
+    nonisolated enum OneOf_OpType: Equatable, Sendable {
       case set(Spark_Connect_ConfigRequest.Set)
       case get(Spark_Connect_ConfigRequest.Get)
       case getWithDefault(Spark_Connect_ConfigRequest.GetWithDefault)
@@ -1887,7 +1887,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     init() {}
   }
 
-  struct Set: Sendable {
+  nonisolated struct Set: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1912,7 +1912,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     fileprivate var _silent: Bool? = nil
   }
 
-  struct Get: Sendable {
+  nonisolated struct Get: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1925,7 +1925,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     init() {}
   }
 
-  struct GetWithDefault: Sendable {
+  nonisolated struct GetWithDefault: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1938,7 +1938,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     init() {}
   }
 
-  struct GetOption: Sendable {
+  nonisolated struct GetOption: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1951,7 +1951,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     init() {}
   }
 
-  struct GetAll: Sendable {
+  nonisolated struct GetAll: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1973,7 +1973,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     fileprivate var _prefix: String? = nil
   }
 
-  struct Unset: Sendable {
+  nonisolated struct Unset: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1986,7 +1986,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
     init() {}
   }
 
-  struct IsModifiable: Sendable {
+  nonisolated struct IsModifiable: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2009,7 +2009,7 @@ struct Spark_Connect_ConfigRequest: Sendable {
 
 /// Response to the config request.
 /// Next ID: 5
-struct Spark_Connect_ConfigResponse: Sendable {
+nonisolated struct Spark_Connect_ConfigResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2037,7 +2037,7 @@ struct Spark_Connect_ConfigResponse: Sendable {
 }
 
 /// Request to transfer client-local artifacts.
-struct Spark_Connect_AddArtifactsRequest: Sendable {
+nonisolated struct Spark_Connect_AddArtifactsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2120,7 +2120,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The payload is either a batch of artifacts or a partial chunk of a large artifact.
-  enum OneOf_Payload: Equatable, Sendable {
+  nonisolated enum OneOf_Payload: Equatable, Sendable {
     case batch(Spark_Connect_AddArtifactsRequest.Batch)
     /// The metadata and the initial chunk of a large artifact chunked into multiple requests.
     /// The server side is notified about the total size of the large artifact as well as the
@@ -2133,7 +2133,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
   }
 
   /// A chunk of an Artifact.
-  struct ArtifactChunk: Sendable {
+  nonisolated struct ArtifactChunk: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2151,7 +2151,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
 
   /// An artifact that is contained in a single `ArtifactChunk`.
   /// Generally, this message represents tiny artifacts such as REPL-generated class files.
-  struct SingleChunkArtifact: Sendable {
+  nonisolated struct SingleChunkArtifact: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2182,7 +2182,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
   }
 
   /// A number of `SingleChunkArtifact` batched into a single RPC.
-  struct Batch: Sendable {
+  nonisolated struct Batch: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2197,7 +2197,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
   /// Signals the beginning/start of a chunked artifact.
   /// A large artifact is transferred through a payload of `BeginChunkedArtifact` followed by a
   /// sequence of `ArtifactChunk`s.
-  struct BeginChunkedArtifact: Sendable {
+  nonisolated struct BeginChunkedArtifact: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2240,7 +2240,7 @@ struct Spark_Connect_AddArtifactsRequest: Sendable {
 /// Response to adding an artifact. Contains relevant metadata to verify successful transfer of
 /// artifact(s).
 /// Next ID: 4
-struct Spark_Connect_AddArtifactsResponse: Sendable {
+nonisolated struct Spark_Connect_AddArtifactsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2258,7 +2258,7 @@ struct Spark_Connect_AddArtifactsResponse: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Metadata of an artifact.
-  struct ArtifactSummary: Sendable {
+  nonisolated struct ArtifactSummary: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2279,7 +2279,7 @@ struct Spark_Connect_AddArtifactsResponse: Sendable {
 }
 
 /// Request to get current statuses of artifacts at the server side.
-struct Spark_Connect_ArtifactStatusesRequest: Sendable {
+nonisolated struct Spark_Connect_ArtifactStatusesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2346,7 +2346,7 @@ struct Spark_Connect_ArtifactStatusesRequest: Sendable {
 
 /// Response to checking artifact statuses.
 /// Next ID: 4
-struct Spark_Connect_ArtifactStatusesResponse: Sendable {
+nonisolated struct Spark_Connect_ArtifactStatusesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2363,7 +2363,7 @@ struct Spark_Connect_ArtifactStatusesResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ArtifactStatus: Sendable {
+  nonisolated struct ArtifactStatus: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2379,7 +2379,7 @@ struct Spark_Connect_ArtifactStatusesResponse: Sendable {
   init() {}
 }
 
-struct Spark_Connect_InterruptRequest: Sendable {
+nonisolated struct Spark_Connect_InterruptRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2452,7 +2452,7 @@ struct Spark_Connect_InterruptRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Interrupt: Equatable, Sendable {
+  nonisolated enum OneOf_Interrupt: Equatable, Sendable {
     /// if interrupt_tag == INTERRUPT_TYPE_TAG, interrupt operation with this tag.
     case operationTag(String)
     /// if interrupt_tag == INTERRUPT_TYPE_OPERATION_ID, interrupt operation with this operation_id.
@@ -2460,7 +2460,7 @@ struct Spark_Connect_InterruptRequest: Sendable {
 
   }
 
-  enum InterruptType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum InterruptType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
 
@@ -2516,7 +2516,7 @@ struct Spark_Connect_InterruptRequest: Sendable {
 }
 
 /// Next ID: 4
-struct Spark_Connect_InterruptResponse: Sendable {
+nonisolated struct Spark_Connect_InterruptResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2536,7 +2536,7 @@ struct Spark_Connect_InterruptResponse: Sendable {
   init() {}
 }
 
-struct Spark_Connect_ReattachOptions: Sendable {
+nonisolated struct Spark_Connect_ReattachOptions: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2556,7 +2556,7 @@ struct Spark_Connect_ReattachOptions: Sendable {
   init() {}
 }
 
-struct Spark_Connect_ResultChunkingOptions: Sendable {
+nonisolated struct Spark_Connect_ResultChunkingOptions: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2591,7 +2591,7 @@ struct Spark_Connect_ResultChunkingOptions: Sendable {
   fileprivate var _preferredArrowChunkSize: Int64? = nil
 }
 
-struct Spark_Connect_ReattachExecuteRequest: Sendable {
+nonisolated struct Spark_Connect_ReattachExecuteRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2672,7 +2672,7 @@ struct Spark_Connect_ReattachExecuteRequest: Sendable {
   fileprivate var _lastResponseID: String? = nil
 }
 
-struct Spark_Connect_ReleaseExecuteRequest: Sendable {
+nonisolated struct Spark_Connect_ReleaseExecuteRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2746,7 +2746,7 @@ struct Spark_Connect_ReleaseExecuteRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Release: Equatable, Sendable {
+  nonisolated enum OneOf_Release: Equatable, Sendable {
     case releaseAll(Spark_Connect_ReleaseExecuteRequest.ReleaseAll)
     case releaseUntil(Spark_Connect_ReleaseExecuteRequest.ReleaseUntil)
 
@@ -2754,7 +2754,7 @@ struct Spark_Connect_ReleaseExecuteRequest: Sendable {
 
   /// Release and close operation completely.
   /// This will also interrupt the query if it is running execution, and wait for it to be torn down.
-  struct ReleaseAll: Sendable {
+  nonisolated struct ReleaseAll: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2769,7 +2769,7 @@ struct Spark_Connect_ReleaseExecuteRequest: Sendable {
   /// While server determines by itself how much of a buffer of responses to keep, client providing
   /// explicit release calls will help reduce resource consumption.
   /// Noop if response_id not found in cached responses.
-  struct ReleaseUntil: Sendable {
+  nonisolated struct ReleaseUntil: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2789,7 +2789,7 @@ struct Spark_Connect_ReleaseExecuteRequest: Sendable {
 }
 
 /// Next ID: 4
-struct Spark_Connect_ReleaseExecuteResponse: Sendable {
+nonisolated struct Spark_Connect_ReleaseExecuteResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2820,7 +2820,7 @@ struct Spark_Connect_ReleaseExecuteResponse: Sendable {
   fileprivate var _operationID: String? = nil
 }
 
-struct Spark_Connect_ReleaseSessionRequest: Sendable {
+nonisolated struct Spark_Connect_ReleaseSessionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2879,7 +2879,7 @@ struct Spark_Connect_ReleaseSessionRequest: Sendable {
 }
 
 /// Next ID: 3
-struct Spark_Connect_ReleaseSessionResponse: Sendable {
+nonisolated struct Spark_Connect_ReleaseSessionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2896,7 +2896,7 @@ struct Spark_Connect_ReleaseSessionResponse: Sendable {
   init() {}
 }
 
-struct Spark_Connect_FetchErrorDetailsRequest: Sendable {
+nonisolated struct Spark_Connect_FetchErrorDetailsRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2955,7 +2955,7 @@ struct Spark_Connect_FetchErrorDetailsRequest: Sendable {
 }
 
 /// Next ID: 5
-struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
+nonisolated struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2981,7 +2981,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct StackTraceElement: Sendable {
+  nonisolated struct StackTraceElement: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3014,7 +3014,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
 
   /// QueryContext defines the schema for the query context of a SparkThrowable.
   /// It helps users understand where the error occurs while executing queries.
-  struct QueryContext: Sendable {
+  nonisolated struct QueryContext: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3049,7 +3049,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The type of this query context.
-    enum ContextType: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum ContextType: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case sql // = 0
       case dataframe // = 1
@@ -3087,7 +3087,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   }
 
   /// SparkThrowable defines the schema for SparkThrowable exceptions.
-  struct SparkThrowable: Sendable {
+  nonisolated struct SparkThrowable: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3139,7 +3139,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   }
 
   /// BreakingChangeInfo defines the schema for breaking change information.
-  struct BreakingChangeInfo: Sendable {
+  nonisolated struct BreakingChangeInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3178,7 +3178,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   }
 
   /// MitigationConfig defines a spark config flag that can be used to mitigate a breaking change.
-  struct MitigationConfig: Sendable {
+  nonisolated struct MitigationConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3195,7 +3195,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   }
 
   /// Error defines the schema for the representing exception.
-  struct Error: Sendable {
+  nonisolated struct Error: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3243,7 +3243,7 @@ struct Spark_Connect_FetchErrorDetailsResponse: Sendable {
   fileprivate var _rootErrorIdx: Int32? = nil
 }
 
-struct Spark_Connect_CheckpointCommandResult: Sendable {
+nonisolated struct Spark_Connect_CheckpointCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3265,7 +3265,7 @@ struct Spark_Connect_CheckpointCommandResult: Sendable {
   fileprivate var _relation: Spark_Connect_CachedRemoteRelation? = nil
 }
 
-struct Spark_Connect_CloneSessionRequest: Sendable {
+nonisolated struct Spark_Connect_CloneSessionRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3339,7 +3339,7 @@ struct Spark_Connect_CloneSessionRequest: Sendable {
 }
 
 /// Next ID: 5
-struct Spark_Connect_CloneSessionResponse: Sendable {
+nonisolated struct Spark_Connect_CloneSessionResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3363,7 +3363,7 @@ struct Spark_Connect_CloneSessionResponse: Sendable {
 }
 
 /// Next ID: 6
-struct Spark_Connect_GetStatusRequest: Sendable {
+nonisolated struct Spark_Connect_GetStatusRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3431,7 +3431,7 @@ struct Spark_Connect_GetStatusRequest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct OperationStatusRequest: Sendable {
+  nonisolated struct OperationStatusRequest: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3457,7 +3457,7 @@ struct Spark_Connect_GetStatusRequest: Sendable {
 }
 
 /// Next ID: 4
-struct Spark_Connect_GetStatusResponse: Sendable {
+nonisolated struct Spark_Connect_GetStatusResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3478,7 +3478,7 @@ struct Spark_Connect_GetStatusResponse: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Status information for a single operation.
-  struct OperationStatus: Sendable {
+  nonisolated struct OperationStatus: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -3494,7 +3494,7 @@ struct Spark_Connect_GetStatusResponse: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum OperationState: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
       case unknown // = 1
@@ -3556,13 +3556,13 @@ struct Spark_Connect_GetStatusResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_CompressionCodec: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CompressionCodec: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0COMPRESSION_CODEC_UNSPECIFIED\0\u{1}COMPRESSION_CODEC_ZSTD\0")
 }
 
-extension Spark_Connect_Plan: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Plan: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Plan"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}root\0\u{1}command\0\u{3}compressed_operation\0")
 
@@ -3646,7 +3646,7 @@ extension Spark_Connect_Plan: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Plan.CompressedOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Plan.CompressedOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Plan.protoMessageName + ".CompressedOperation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{3}op_type\0\u{3}compression_codec\0")
 
@@ -3686,11 +3686,11 @@ extension Spark_Connect_Plan.CompressedOperation: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_Plan.CompressedOperation.OpType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Plan.CompressedOperation.OpType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OP_TYPE_UNSPECIFIED\0\u{1}OP_TYPE_RELATION\0\u{1}OP_TYPE_COMMAND\0")
 }
 
-extension Spark_Connect_UserContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_UserContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UserContext"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}user_id\0\u{3}user_name\0\u{2}e\u{f}extensions\0")
 
@@ -3730,7 +3730,7 @@ extension Spark_Connect_UserContext: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AnalyzePlanRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{1}schema\0\u{1}explain\0\u{3}tree_string\0\u{3}is_local\0\u{3}is_streaming\0\u{3}input_files\0\u{3}spark_version\0\u{3}ddl_parse\0\u{3}same_semantics\0\u{3}semantic_hash\0\u{1}persist\0\u{1}unpersist\0\u{3}get_storage_level\0\u{3}client_observed_server_side_session_id\0\u{3}json_to_ddl\0")
 
@@ -4064,7 +4064,7 @@ extension Spark_Connect_AnalyzePlanRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.Schema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.Schema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".Schema"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0")
 
@@ -4098,7 +4098,7 @@ extension Spark_Connect_AnalyzePlanRequest.Schema: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.Explain: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.Explain: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".Explain"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0\u{3}explain_mode\0")
 
@@ -4137,11 +4137,11 @@ extension Spark_Connect_AnalyzePlanRequest.Explain: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.Explain.ExplainMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.Explain.ExplainMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0EXPLAIN_MODE_UNSPECIFIED\0\u{1}EXPLAIN_MODE_SIMPLE\0\u{1}EXPLAIN_MODE_EXTENDED\0\u{1}EXPLAIN_MODE_CODEGEN\0\u{1}EXPLAIN_MODE_COST\0\u{1}EXPLAIN_MODE_FORMATTED\0")
 }
 
-extension Spark_Connect_AnalyzePlanRequest.TreeString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.TreeString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".TreeString"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0\u{1}level\0")
 
@@ -4180,7 +4180,7 @@ extension Spark_Connect_AnalyzePlanRequest.TreeString: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.IsLocal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.IsLocal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".IsLocal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0")
 
@@ -4214,7 +4214,7 @@ extension Spark_Connect_AnalyzePlanRequest.IsLocal: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.IsStreaming: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.IsStreaming: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".IsStreaming"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0")
 
@@ -4248,7 +4248,7 @@ extension Spark_Connect_AnalyzePlanRequest.IsStreaming: SwiftProtobuf.Message, S
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.InputFiles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.InputFiles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".InputFiles"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0")
 
@@ -4282,7 +4282,7 @@ extension Spark_Connect_AnalyzePlanRequest.InputFiles: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.SparkVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.SparkVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".SparkVersion"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -4301,7 +4301,7 @@ extension Spark_Connect_AnalyzePlanRequest.SparkVersion: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.DDLParse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.DDLParse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".DDLParse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ddl_string\0")
 
@@ -4331,7 +4331,7 @@ extension Spark_Connect_AnalyzePlanRequest.DDLParse: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.SameSemantics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.SameSemantics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".SameSemantics"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}target_plan\0\u{3}other_plan\0")
 
@@ -4408,7 +4408,7 @@ extension Spark_Connect_AnalyzePlanRequest.SameSemantics: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.SemanticHash: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.SemanticHash: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".SemanticHash"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}plan\0")
 
@@ -4442,7 +4442,7 @@ extension Spark_Connect_AnalyzePlanRequest.SemanticHash: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.Persist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.Persist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".Persist"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0\u{3}storage_level\0")
 
@@ -4481,7 +4481,7 @@ extension Spark_Connect_AnalyzePlanRequest.Persist: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.Unpersist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.Unpersist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".Unpersist"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0\u{1}blocking\0")
 
@@ -4520,7 +4520,7 @@ extension Spark_Connect_AnalyzePlanRequest.Unpersist: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.GetStorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.GetStorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".GetStorageLevel"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0")
 
@@ -4554,7 +4554,7 @@ extension Spark_Connect_AnalyzePlanRequest.GetStorageLevel: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_AnalyzePlanRequest.JsonToDDL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanRequest.JsonToDDL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanRequest.protoMessageName + ".JsonToDDL"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}json_string\0")
 
@@ -4584,7 +4584,7 @@ extension Spark_Connect_AnalyzePlanRequest.JsonToDDL: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AnalyzePlanResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{1}schema\0\u{1}explain\0\u{3}tree_string\0\u{3}is_local\0\u{3}is_streaming\0\u{3}input_files\0\u{3}spark_version\0\u{3}ddl_parse\0\u{3}same_semantics\0\u{3}semantic_hash\0\u{1}persist\0\u{1}unpersist\0\u{3}get_storage_level\0\u{3}server_side_session_id\0\u{3}json_to_ddl\0")
 
@@ -4864,7 +4864,7 @@ extension Spark_Connect_AnalyzePlanResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.Schema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.Schema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".Schema"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}schema\0")
 
@@ -4898,7 +4898,7 @@ extension Spark_Connect_AnalyzePlanResponse.Schema: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.Explain: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.Explain: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".Explain"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}explain_string\0")
 
@@ -4928,7 +4928,7 @@ extension Spark_Connect_AnalyzePlanResponse.Explain: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.TreeString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.TreeString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".TreeString"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}tree_string\0")
 
@@ -4958,7 +4958,7 @@ extension Spark_Connect_AnalyzePlanResponse.TreeString: SwiftProtobuf.Message, S
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.IsLocal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.IsLocal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".IsLocal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}is_local\0")
 
@@ -4988,7 +4988,7 @@ extension Spark_Connect_AnalyzePlanResponse.IsLocal: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.IsStreaming: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.IsStreaming: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".IsStreaming"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}is_streaming\0")
 
@@ -5018,7 +5018,7 @@ extension Spark_Connect_AnalyzePlanResponse.IsStreaming: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.InputFiles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.InputFiles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".InputFiles"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}files\0")
 
@@ -5048,7 +5048,7 @@ extension Spark_Connect_AnalyzePlanResponse.InputFiles: SwiftProtobuf.Message, S
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.SparkVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.SparkVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".SparkVersion"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}version\0")
 
@@ -5078,7 +5078,7 @@ extension Spark_Connect_AnalyzePlanResponse.SparkVersion: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.DDLParse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.DDLParse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".DDLParse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}parsed\0")
 
@@ -5112,7 +5112,7 @@ extension Spark_Connect_AnalyzePlanResponse.DDLParse: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.SameSemantics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.SameSemantics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".SameSemantics"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0")
 
@@ -5142,7 +5142,7 @@ extension Spark_Connect_AnalyzePlanResponse.SameSemantics: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.SemanticHash: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.SemanticHash: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".SemanticHash"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0")
 
@@ -5172,7 +5172,7 @@ extension Spark_Connect_AnalyzePlanResponse.SemanticHash: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.Persist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.Persist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".Persist"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -5191,7 +5191,7 @@ extension Spark_Connect_AnalyzePlanResponse.Persist: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.Unpersist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.Unpersist: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".Unpersist"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -5210,7 +5210,7 @@ extension Spark_Connect_AnalyzePlanResponse.Unpersist: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.GetStorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.GetStorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".GetStorageLevel"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}storage_level\0")
 
@@ -5244,7 +5244,7 @@ extension Spark_Connect_AnalyzePlanResponse.GetStorageLevel: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_AnalyzePlanResponse.JsonToDDL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AnalyzePlanResponse.JsonToDDL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AnalyzePlanResponse.protoMessageName + ".JsonToDDL"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}ddl_string\0")
 
@@ -5274,7 +5274,7 @@ extension Spark_Connect_AnalyzePlanResponse.JsonToDDL: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_ExecutePlanRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExecutePlanRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{1}plan\0\u{3}client_type\0\u{3}request_options\0\u{3}operation_id\0\u{1}tags\0\u{3}client_observed_server_side_session_id\0")
 
@@ -5393,7 +5393,7 @@ extension Spark_Connect_ExecutePlanRequest: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_ExecutePlanRequest.RequestOption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanRequest.RequestOption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanRequest.protoMessageName + ".RequestOption"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}reattach_options\0\u{3}result_chunking_options\0\u{2}e\u{f}extension\0")
 
@@ -5477,7 +5477,7 @@ extension Spark_Connect_ExecutePlanRequest.RequestOption: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExecutePlanResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}arrow_batch\0\u{2}\u{2}metrics\0\u{3}sql_command_result\0\u{3}observed_metrics\0\u{1}schema\0\u{3}write_stream_operation_start_result\0\u{3}streaming_query_command_result\0\u{3}get_resources_command_result\0\u{3}streaming_query_manager_command_result\0\u{3}operation_id\0\u{3}response_id\0\u{3}result_complete\0\u{3}server_side_session_id\0\u{3}streaming_query_listener_events_result\0\u{3}create_resource_profile_command_result\0\u{3}execution_progress\0\u{3}checkpoint_command_result\0\u{3}ml_command_result\0\u{3}pipeline_event_result\0\u{3}pipeline_command_result\0\u{3}pipeline_query_function_execution_signal\0\u{2}P\u{f}extension\0")
 
@@ -5817,7 +5817,7 @@ extension Spark_Connect_ExecutePlanResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.SqlCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.SqlCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".SqlCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0")
 
@@ -5851,7 +5851,7 @@ extension Spark_Connect_ExecutePlanResponse.SqlCommandResult: SwiftProtobuf.Mess
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.ArrowBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.ArrowBatch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".ArrowBatch"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}row_count\0\u{1}data\0\u{3}start_offset\0\u{3}chunk_index\0\u{3}num_chunks_in_batch\0")
 
@@ -5905,7 +5905,7 @@ extension Spark_Connect_ExecutePlanResponse.ArrowBatch: SwiftProtobuf.Message, S
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.Metrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.Metrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".Metrics"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}metrics\0")
 
@@ -5935,7 +5935,7 @@ extension Spark_Connect_ExecutePlanResponse.Metrics: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.Metrics.MetricObject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.Metrics.MetricObject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.Metrics.protoMessageName + ".MetricObject"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}plan_id\0\u{1}parent\0\u{3}execution_metrics\0")
 
@@ -5980,7 +5980,7 @@ extension Spark_Connect_ExecutePlanResponse.Metrics.MetricObject: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.Metrics.MetricValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.Metrics.MetricValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.Metrics.protoMessageName + ".MetricValue"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}value\0\u{3}metric_type\0")
 
@@ -6020,7 +6020,7 @@ extension Spark_Connect_ExecutePlanResponse.Metrics.MetricValue: SwiftProtobuf.M
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.ObservedMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.ObservedMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".ObservedMetrics"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}values\0\u{1}keys\0\u{3}plan_id\0\u{3}root_error_idx\0\u{1}errors\0")
 
@@ -6079,7 +6079,7 @@ extension Spark_Connect_ExecutePlanResponse.ObservedMetrics: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.ResultComplete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.ResultComplete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".ResultComplete"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -6098,7 +6098,7 @@ extension Spark_Connect_ExecutePlanResponse.ResultComplete: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.ExecutionProgress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.ExecutionProgress: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.protoMessageName + ".ExecutionProgress"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}stages\0\u{3}num_inflight_tasks\0")
 
@@ -6133,7 +6133,7 @@ extension Spark_Connect_ExecutePlanResponse.ExecutionProgress: SwiftProtobuf.Mes
   }
 }
 
-extension Spark_Connect_ExecutePlanResponse.ExecutionProgress.StageInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutePlanResponse.ExecutionProgress.StageInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ExecutePlanResponse.ExecutionProgress.protoMessageName + ".StageInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stage_id\0\u{3}num_tasks\0\u{3}num_completed_tasks\0\u{3}input_bytes_read\0\u{1}done\0")
 
@@ -6183,7 +6183,7 @@ extension Spark_Connect_ExecutePlanResponse.ExecutionProgress.StageInfo: SwiftPr
   }
 }
 
-extension Spark_Connect_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".KeyValue"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
@@ -6222,7 +6222,7 @@ extension Spark_Connect_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_ConfigRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{1}operation\0\u{3}client_type\0\u{4}\u{4}client_observed_server_side_session_id\0")
 
@@ -6276,7 +6276,7 @@ extension Spark_Connect_ConfigRequest: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_ConfigRequest.Operation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.Operation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".Operation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}set\0\u{1}get\0\u{3}get_with_default\0\u{3}get_option\0\u{3}get_all\0\u{1}unset\0\u{3}is_modifiable\0")
 
@@ -6428,7 +6428,7 @@ extension Spark_Connect_ConfigRequest.Operation: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_ConfigRequest.Set: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.Set: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".Set"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}pairs\0\u{1}silent\0")
 
@@ -6467,7 +6467,7 @@ extension Spark_Connect_ConfigRequest.Set: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ConfigRequest.Get: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.Get: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".Get"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}keys\0")
 
@@ -6497,7 +6497,7 @@ extension Spark_Connect_ConfigRequest.Get: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ConfigRequest.GetWithDefault: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.GetWithDefault: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".GetWithDefault"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}pairs\0")
 
@@ -6527,7 +6527,7 @@ extension Spark_Connect_ConfigRequest.GetWithDefault: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_ConfigRequest.GetOption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.GetOption: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".GetOption"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}keys\0")
 
@@ -6557,7 +6557,7 @@ extension Spark_Connect_ConfigRequest.GetOption: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_ConfigRequest.GetAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.GetAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".GetAll"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}prefix\0")
 
@@ -6591,7 +6591,7 @@ extension Spark_Connect_ConfigRequest.GetAll: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_ConfigRequest.Unset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.Unset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".Unset"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}keys\0")
 
@@ -6621,7 +6621,7 @@ extension Spark_Connect_ConfigRequest.Unset: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_ConfigRequest.IsModifiable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigRequest.IsModifiable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ConfigRequest.protoMessageName + ".IsModifiable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}keys\0")
 
@@ -6651,7 +6651,7 @@ extension Spark_Connect_ConfigRequest.IsModifiable: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_ConfigResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ConfigResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ConfigResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{1}pairs\0\u{1}warnings\0\u{3}server_side_session_id\0")
 
@@ -6696,7 +6696,7 @@ extension Spark_Connect_ConfigResponse: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_AddArtifactsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AddArtifactsRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{1}batch\0\u{3}begin_chunk\0\u{1}chunk\0\u{3}client_type\0\u{3}client_observed_server_side_session_id\0")
 
@@ -6800,7 +6800,7 @@ extension Spark_Connect_AddArtifactsRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_AddArtifactsRequest.ArtifactChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsRequest.ArtifactChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AddArtifactsRequest.protoMessageName + ".ArtifactChunk"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{1}crc\0")
 
@@ -6835,7 +6835,7 @@ extension Spark_Connect_AddArtifactsRequest.ArtifactChunk: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_AddArtifactsRequest.SingleChunkArtifact: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsRequest.SingleChunkArtifact: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AddArtifactsRequest.protoMessageName + ".SingleChunkArtifact"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}data\0")
 
@@ -6874,7 +6874,7 @@ extension Spark_Connect_AddArtifactsRequest.SingleChunkArtifact: SwiftProtobuf.M
   }
 }
 
-extension Spark_Connect_AddArtifactsRequest.Batch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsRequest.Batch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AddArtifactsRequest.protoMessageName + ".Batch"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}artifacts\0")
 
@@ -6904,7 +6904,7 @@ extension Spark_Connect_AddArtifactsRequest.Batch: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_AddArtifactsRequest.BeginChunkedArtifact: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsRequest.BeginChunkedArtifact: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AddArtifactsRequest.protoMessageName + ".BeginChunkedArtifact"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}total_bytes\0\u{3}num_chunks\0\u{3}initial_chunk\0")
 
@@ -6953,7 +6953,7 @@ extension Spark_Connect_AddArtifactsRequest.BeginChunkedArtifact: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_AddArtifactsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AddArtifactsResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}artifacts\0\u{3}session_id\0\u{3}server_side_session_id\0")
 
@@ -6993,7 +6993,7 @@ extension Spark_Connect_AddArtifactsResponse: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_AddArtifactsResponse.ArtifactSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AddArtifactsResponse.ArtifactSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_AddArtifactsResponse.protoMessageName + ".ArtifactSummary"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}is_crc_successful\0")
 
@@ -7028,7 +7028,7 @@ extension Spark_Connect_AddArtifactsResponse.ArtifactSummary: SwiftProtobuf.Mess
   }
 }
 
-extension Spark_Connect_ArtifactStatusesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ArtifactStatusesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ArtifactStatusesRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{1}names\0\u{3}client_observed_server_side_session_id\0")
 
@@ -7082,7 +7082,7 @@ extension Spark_Connect_ArtifactStatusesRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_ArtifactStatusesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ArtifactStatusesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ArtifactStatusesResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}statuses\0\u{3}session_id\0\u{3}server_side_session_id\0")
 
@@ -7122,7 +7122,7 @@ extension Spark_Connect_ArtifactStatusesResponse: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_ArtifactStatusesResponse.ArtifactStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ArtifactStatusesResponse.ArtifactStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ArtifactStatusesResponse.protoMessageName + ".ArtifactStatus"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}exists\0")
 
@@ -7152,7 +7152,7 @@ extension Spark_Connect_ArtifactStatusesResponse.ArtifactStatus: SwiftProtobuf.M
   }
 }
 
-extension Spark_Connect_InterruptRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_InterruptRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".InterruptRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{3}interrupt_type\0\u{3}operation_tag\0\u{3}operation_id\0\u{3}client_observed_server_side_session_id\0")
 
@@ -7234,11 +7234,11 @@ extension Spark_Connect_InterruptRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_InterruptRequest.InterruptType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_InterruptRequest.InterruptType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0INTERRUPT_TYPE_UNSPECIFIED\0\u{1}INTERRUPT_TYPE_ALL\0\u{1}INTERRUPT_TYPE_TAG\0\u{1}INTERRUPT_TYPE_OPERATION_ID\0")
 }
 
-extension Spark_Connect_InterruptResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_InterruptResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".InterruptResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}interrupted_ids\0\u{3}server_side_session_id\0")
 
@@ -7278,7 +7278,7 @@ extension Spark_Connect_InterruptResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ReattachOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReattachOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReattachOptions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}reattachable\0")
 
@@ -7308,7 +7308,7 @@ extension Spark_Connect_ReattachOptions: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_ResultChunkingOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ResultChunkingOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ResultChunkingOptions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}allow_arrow_batch_chunking\0\u{3}preferred_arrow_chunk_size\0")
 
@@ -7347,7 +7347,7 @@ extension Spark_Connect_ResultChunkingOptions: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ReattachExecuteRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReattachExecuteRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReattachExecuteRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}operation_id\0\u{3}client_type\0\u{3}last_response_id\0\u{3}client_observed_server_side_session_id\0")
 
@@ -7406,7 +7406,7 @@ extension Spark_Connect_ReattachExecuteRequest: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_ReleaseExecuteRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseExecuteRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReleaseExecuteRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}operation_id\0\u{3}client_type\0\u{3}release_all\0\u{3}release_until\0\u{3}client_observed_server_side_session_id\0")
 
@@ -7498,7 +7498,7 @@ extension Spark_Connect_ReleaseExecuteRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ReleaseExecuteRequest.ReleaseAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseExecuteRequest.ReleaseAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ReleaseExecuteRequest.protoMessageName + ".ReleaseAll"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -7517,7 +7517,7 @@ extension Spark_Connect_ReleaseExecuteRequest.ReleaseAll: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_ReleaseExecuteRequest.ReleaseUntil: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseExecuteRequest.ReleaseUntil: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_ReleaseExecuteRequest.protoMessageName + ".ReleaseUntil"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}response_id\0")
 
@@ -7547,7 +7547,7 @@ extension Spark_Connect_ReleaseExecuteRequest.ReleaseUntil: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_ReleaseExecuteResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseExecuteResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReleaseExecuteResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}operation_id\0\u{3}server_side_session_id\0")
 
@@ -7591,7 +7591,7 @@ extension Spark_Connect_ReleaseExecuteResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_ReleaseSessionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseSessionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReleaseSessionRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{3}allow_reconnect\0")
 
@@ -7640,7 +7640,7 @@ extension Spark_Connect_ReleaseSessionRequest: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ReleaseSessionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ReleaseSessionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ReleaseSessionResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}server_side_session_id\0")
 
@@ -7675,7 +7675,7 @@ extension Spark_Connect_ReleaseSessionResponse: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FetchErrorDetailsRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}error_id\0\u{3}client_type\0\u{3}client_observed_server_side_session_id\0")
 
@@ -7729,7 +7729,7 @@ extension Spark_Connect_FetchErrorDetailsRequest: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FetchErrorDetailsResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}root_error_idx\0\u{1}errors\0\u{3}server_side_session_id\0\u{3}session_id\0")
 
@@ -7778,7 +7778,7 @@ extension Spark_Connect_FetchErrorDetailsResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.StackTraceElement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.StackTraceElement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".StackTraceElement"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}declaring_class\0\u{3}method_name\0\u{3}file_name\0\u{3}line_number\0")
 
@@ -7827,7 +7827,7 @@ extension Spark_Connect_FetchErrorDetailsResponse.StackTraceElement: SwiftProtob
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.QueryContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.QueryContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".QueryContext"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}object_type\0\u{3}object_name\0\u{3}start_index\0\u{3}stop_index\0\u{1}fragment\0\u{3}call_site\0\u{1}summary\0\u{4}\u{3}context_type\0")
 
@@ -7892,11 +7892,11 @@ extension Spark_Connect_FetchErrorDetailsResponse.QueryContext: SwiftProtobuf.Me
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.QueryContext.ContextType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.QueryContext.ContextType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SQL\0\u{1}DATAFRAME\0")
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.SparkThrowable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.SparkThrowable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".SparkThrowable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}error_class\0\u{3}message_parameters\0\u{3}query_contexts\0\u{3}sql_state\0\u{3}breaking_change_info\0")
 
@@ -7950,7 +7950,7 @@ extension Spark_Connect_FetchErrorDetailsResponse.SparkThrowable: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.BreakingChangeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.BreakingChangeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".BreakingChangeInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}migration_message\0\u{3}mitigation_config\0\u{3}needs_audit\0")
 
@@ -7994,7 +7994,7 @@ extension Spark_Connect_FetchErrorDetailsResponse.BreakingChangeInfo: SwiftProto
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.MitigationConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.MitigationConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".MitigationConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
@@ -8029,7 +8029,7 @@ extension Spark_Connect_FetchErrorDetailsResponse.MitigationConfig: SwiftProtobu
   }
 }
 
-extension Spark_Connect_FetchErrorDetailsResponse.Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FetchErrorDetailsResponse.Error: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_FetchErrorDetailsResponse.protoMessageName + ".Error"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}error_type_hierarchy\0\u{1}message\0\u{3}stack_trace\0\u{3}cause_idx\0\u{3}spark_throwable\0")
 
@@ -8083,7 +8083,7 @@ extension Spark_Connect_FetchErrorDetailsResponse.Error: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_CheckpointCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CheckpointCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CheckpointCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0")
 
@@ -8117,7 +8117,7 @@ extension Spark_Connect_CheckpointCommandResult: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_CloneSessionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CloneSessionRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CloneSessionRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{3}new_session_id\0\u{3}client_observed_server_side_session_id\0")
 
@@ -8171,7 +8171,7 @@ extension Spark_Connect_CloneSessionRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_CloneSessionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CloneSessionResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CloneSessionResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}server_side_session_id\0\u{3}new_session_id\0\u{3}new_server_side_session_id\0")
 
@@ -8216,7 +8216,7 @@ extension Spark_Connect_CloneSessionResponse: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_GetStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetStatusRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}user_context\0\u{3}client_type\0\u{3}client_observed_server_side_session_id\0\u{3}operation_status\0\u{2}b\u{f}extensions\0")
 
@@ -8275,7 +8275,7 @@ extension Spark_Connect_GetStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_GetStatusRequest.OperationStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetStatusRequest.OperationStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_GetStatusRequest.protoMessageName + ".OperationStatusRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}operation_ids\0\u{2}f\u{f}extensions\0")
 
@@ -8310,7 +8310,7 @@ extension Spark_Connect_GetStatusRequest.OperationStatusRequest: SwiftProtobuf.M
   }
 }
 
-extension Spark_Connect_GetStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetStatusResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}session_id\0\u{3}server_side_session_id\0\u{3}operation_statuses\0\u{2}d\u{f}extensions\0")
 
@@ -8355,7 +8355,7 @@ extension Spark_Connect_GetStatusResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_GetStatusResponse.OperationStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetStatusResponse.OperationStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_GetStatusResponse.protoMessageName + ".OperationStatus"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}operation_id\0\u{1}state\0\u{2}e\u{f}extensions\0")
 
@@ -8395,6 +8395,6 @@ extension Spark_Connect_GetStatusResponse.OperationStatus: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_GetStatusResponse.OperationStatus.OperationState: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetStatusResponse.OperationStatus.OperationState: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OPERATION_STATE_UNSPECIFIED\0\u{1}OPERATION_STATE_UNKNOWN\0\u{1}OPERATION_STATE_RUNNING\0\u{1}OPERATION_STATE_TERMINATING\0\u{1}OPERATION_STATE_SUCCEEDED\0\u{1}OPERATION_STATE_FAILED\0\u{1}OPERATION_STATE_CANCELLED\0")
 }

--- a/Sources/SparkConnect/catalog.pb.swift
+++ b/Sources/SparkConnect/catalog.pb.swift
@@ -31,13 +31,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Catalog messages are marked as unstable.
-struct Spark_Connect_Catalog: Sendable {
+nonisolated struct Spark_Connect_Catalog: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -254,7 +254,7 @@ struct Spark_Connect_Catalog: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_CatType: Equatable, Sendable {
+  nonisolated enum OneOf_CatType: Equatable, Sendable {
     case currentDatabase(Spark_Connect_CurrentDatabase)
     case setCurrentDatabase(Spark_Connect_SetCurrentDatabase)
     case listDatabases(Spark_Connect_ListDatabases)
@@ -288,7 +288,7 @@ struct Spark_Connect_Catalog: Sendable {
 }
 
 /// See `spark.catalog.currentDatabase`
-struct Spark_Connect_CurrentDatabase: Sendable {
+nonisolated struct Spark_Connect_CurrentDatabase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -299,7 +299,7 @@ struct Spark_Connect_CurrentDatabase: Sendable {
 }
 
 /// See `spark.catalog.setCurrentDatabase`
-struct Spark_Connect_SetCurrentDatabase: Sendable {
+nonisolated struct Spark_Connect_SetCurrentDatabase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -313,7 +313,7 @@ struct Spark_Connect_SetCurrentDatabase: Sendable {
 }
 
 /// See `spark.catalog.listDatabases`
-struct Spark_Connect_ListDatabases: Sendable {
+nonisolated struct Spark_Connect_ListDatabases: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -336,7 +336,7 @@ struct Spark_Connect_ListDatabases: Sendable {
 }
 
 /// See `spark.catalog.listTables`
-struct Spark_Connect_ListTables: Sendable {
+nonisolated struct Spark_Connect_ListTables: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -370,7 +370,7 @@ struct Spark_Connect_ListTables: Sendable {
 }
 
 /// See `spark.catalog.listFunctions`
-struct Spark_Connect_ListFunctions: Sendable {
+nonisolated struct Spark_Connect_ListFunctions: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -404,7 +404,7 @@ struct Spark_Connect_ListFunctions: Sendable {
 }
 
 /// See `spark.catalog.listColumns`
-struct Spark_Connect_ListColumns: Sendable {
+nonisolated struct Spark_Connect_ListColumns: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -430,7 +430,7 @@ struct Spark_Connect_ListColumns: Sendable {
 }
 
 /// See `spark.catalog.getDatabase`
-struct Spark_Connect_GetDatabase: Sendable {
+nonisolated struct Spark_Connect_GetDatabase: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -444,7 +444,7 @@ struct Spark_Connect_GetDatabase: Sendable {
 }
 
 /// See `spark.catalog.getTable`
-struct Spark_Connect_GetTable: Sendable {
+nonisolated struct Spark_Connect_GetTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -470,7 +470,7 @@ struct Spark_Connect_GetTable: Sendable {
 }
 
 /// See `spark.catalog.getFunction`
-struct Spark_Connect_GetFunction: Sendable {
+nonisolated struct Spark_Connect_GetFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -496,7 +496,7 @@ struct Spark_Connect_GetFunction: Sendable {
 }
 
 /// See `spark.catalog.databaseExists`
-struct Spark_Connect_DatabaseExists: Sendable {
+nonisolated struct Spark_Connect_DatabaseExists: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -510,7 +510,7 @@ struct Spark_Connect_DatabaseExists: Sendable {
 }
 
 /// See `spark.catalog.tableExists`
-struct Spark_Connect_TableExists: Sendable {
+nonisolated struct Spark_Connect_TableExists: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -536,7 +536,7 @@ struct Spark_Connect_TableExists: Sendable {
 }
 
 /// See `spark.catalog.functionExists`
-struct Spark_Connect_FunctionExists: Sendable {
+nonisolated struct Spark_Connect_FunctionExists: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -562,7 +562,7 @@ struct Spark_Connect_FunctionExists: Sendable {
 }
 
 /// See `spark.catalog.createExternalTable`
-struct Spark_Connect_CreateExternalTable: Sendable {
+nonisolated struct Spark_Connect_CreateExternalTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -614,7 +614,7 @@ struct Spark_Connect_CreateExternalTable: Sendable {
 }
 
 /// See `spark.catalog.createTable`
-struct Spark_Connect_CreateTable: Sendable {
+nonisolated struct Spark_Connect_CreateTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -677,7 +677,7 @@ struct Spark_Connect_CreateTable: Sendable {
 }
 
 /// See `spark.catalog.dropTempView`
-struct Spark_Connect_DropTempView: Sendable {
+nonisolated struct Spark_Connect_DropTempView: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -691,7 +691,7 @@ struct Spark_Connect_DropTempView: Sendable {
 }
 
 /// See `spark.catalog.dropGlobalTempView`
-struct Spark_Connect_DropGlobalTempView: Sendable {
+nonisolated struct Spark_Connect_DropGlobalTempView: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -705,7 +705,7 @@ struct Spark_Connect_DropGlobalTempView: Sendable {
 }
 
 /// See `spark.catalog.recoverPartitions`
-struct Spark_Connect_RecoverPartitions: Sendable {
+nonisolated struct Spark_Connect_RecoverPartitions: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -719,7 +719,7 @@ struct Spark_Connect_RecoverPartitions: Sendable {
 }
 
 /// See `spark.catalog.isCached`
-struct Spark_Connect_IsCached: Sendable {
+nonisolated struct Spark_Connect_IsCached: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -733,7 +733,7 @@ struct Spark_Connect_IsCached: Sendable {
 }
 
 /// See `spark.catalog.cacheTable`
-struct Spark_Connect_CacheTable: Sendable {
+nonisolated struct Spark_Connect_CacheTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -759,7 +759,7 @@ struct Spark_Connect_CacheTable: Sendable {
 }
 
 /// See `spark.catalog.uncacheTable`
-struct Spark_Connect_UncacheTable: Sendable {
+nonisolated struct Spark_Connect_UncacheTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -773,7 +773,7 @@ struct Spark_Connect_UncacheTable: Sendable {
 }
 
 /// See `spark.catalog.clearCache`
-struct Spark_Connect_ClearCache: Sendable {
+nonisolated struct Spark_Connect_ClearCache: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -784,7 +784,7 @@ struct Spark_Connect_ClearCache: Sendable {
 }
 
 /// See `spark.catalog.refreshTable`
-struct Spark_Connect_RefreshTable: Sendable {
+nonisolated struct Spark_Connect_RefreshTable: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -798,7 +798,7 @@ struct Spark_Connect_RefreshTable: Sendable {
 }
 
 /// See `spark.catalog.refreshByPath`
-struct Spark_Connect_RefreshByPath: Sendable {
+nonisolated struct Spark_Connect_RefreshByPath: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -812,7 +812,7 @@ struct Spark_Connect_RefreshByPath: Sendable {
 }
 
 /// See `spark.catalog.currentCatalog`
-struct Spark_Connect_CurrentCatalog: Sendable {
+nonisolated struct Spark_Connect_CurrentCatalog: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -823,7 +823,7 @@ struct Spark_Connect_CurrentCatalog: Sendable {
 }
 
 /// See `spark.catalog.setCurrentCatalog`
-struct Spark_Connect_SetCurrentCatalog: Sendable {
+nonisolated struct Spark_Connect_SetCurrentCatalog: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -837,7 +837,7 @@ struct Spark_Connect_SetCurrentCatalog: Sendable {
 }
 
 /// See `spark.catalog.listCatalogs`
-struct Spark_Connect_ListCatalogs: Sendable {
+nonisolated struct Spark_Connect_ListCatalogs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -861,9 +861,9 @@ struct Spark_Connect_ListCatalogs: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Catalog"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_database\0\u{3}set_current_database\0\u{3}list_databases\0\u{3}list_tables\0\u{3}list_functions\0\u{3}list_columns\0\u{3}get_database\0\u{3}get_table\0\u{3}get_function\0\u{3}database_exists\0\u{3}table_exists\0\u{3}function_exists\0\u{3}create_external_table\0\u{3}create_table\0\u{3}drop_temp_view\0\u{3}drop_global_temp_view\0\u{3}recover_partitions\0\u{3}is_cached\0\u{3}cache_table\0\u{3}uncache_table\0\u{3}clear_cache\0\u{3}refresh_table\0\u{3}refresh_by_path\0\u{3}current_catalog\0\u{3}set_current_catalog\0\u{3}list_catalogs\0")
 
@@ -1338,7 +1338,7 @@ extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_CurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CurrentDatabase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -1357,7 +1357,7 @@ extension Spark_Connect_CurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_SetCurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SetCurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SetCurrentDatabase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0")
 
@@ -1387,7 +1387,7 @@ extension Spark_Connect_SetCurrentDatabase: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_ListDatabases: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ListDatabases: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListDatabases"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}pattern\0")
 
@@ -1421,7 +1421,7 @@ extension Spark_Connect_ListDatabases: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_ListTables: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ListTables: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListTables"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0\u{1}pattern\0")
 
@@ -1460,7 +1460,7 @@ extension Spark_Connect_ListTables: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_ListFunctions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ListFunctions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListFunctions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0\u{1}pattern\0")
 
@@ -1499,7 +1499,7 @@ extension Spark_Connect_ListFunctions: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_ListColumns: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ListColumns: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListColumns"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}db_name\0")
 
@@ -1538,7 +1538,7 @@ extension Spark_Connect_ListColumns: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_GetDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetDatabase"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0")
 
@@ -1568,7 +1568,7 @@ extension Spark_Connect_GetDatabase: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_GetTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}db_name\0")
 
@@ -1607,7 +1607,7 @@ extension Spark_Connect_GetTable: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_GetFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{3}db_name\0")
 
@@ -1646,7 +1646,7 @@ extension Spark_Connect_GetFunction: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_DatabaseExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DatabaseExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DatabaseExists"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0")
 
@@ -1676,7 +1676,7 @@ extension Spark_Connect_DatabaseExists: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_TableExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_TableExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TableExists"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}db_name\0")
 
@@ -1715,7 +1715,7 @@ extension Spark_Connect_TableExists: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_FunctionExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_FunctionExists: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FunctionExists"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{3}db_name\0")
 
@@ -1754,7 +1754,7 @@ extension Spark_Connect_FunctionExists: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_CreateExternalTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CreateExternalTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CreateExternalTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{1}path\0\u{1}source\0\u{1}schema\0\u{1}options\0")
 
@@ -1808,7 +1808,7 @@ extension Spark_Connect_CreateExternalTable: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_CreateTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CreateTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CreateTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{1}path\0\u{1}source\0\u{1}description\0\u{1}schema\0\u{1}options\0")
 
@@ -1867,7 +1867,7 @@ extension Spark_Connect_CreateTable: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_DropTempView: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DropTempView: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DropTempView"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}view_name\0")
 
@@ -1897,7 +1897,7 @@ extension Spark_Connect_DropTempView: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_DropGlobalTempView: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DropGlobalTempView: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DropGlobalTempView"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}view_name\0")
 
@@ -1927,7 +1927,7 @@ extension Spark_Connect_DropGlobalTempView: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_RecoverPartitions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RecoverPartitions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RecoverPartitions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
 
@@ -1957,7 +1957,7 @@ extension Spark_Connect_RecoverPartitions: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_IsCached: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_IsCached: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".IsCached"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
 
@@ -1987,7 +1987,7 @@ extension Spark_Connect_IsCached: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_CacheTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CacheTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CacheTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}storage_level\0")
 
@@ -2026,7 +2026,7 @@ extension Spark_Connect_CacheTable: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_UncacheTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_UncacheTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UncacheTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
 
@@ -2056,7 +2056,7 @@ extension Spark_Connect_UncacheTable: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_ClearCache: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ClearCache: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ClearCache"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2075,7 +2075,7 @@ extension Spark_Connect_ClearCache: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_RefreshTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RefreshTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RefreshTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
 
@@ -2105,7 +2105,7 @@ extension Spark_Connect_RefreshTable: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_RefreshByPath: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RefreshByPath: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RefreshByPath"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0")
 
@@ -2135,7 +2135,7 @@ extension Spark_Connect_RefreshByPath: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_CurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CurrentCatalog"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2154,7 +2154,7 @@ extension Spark_Connect_CurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_SetCurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SetCurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SetCurrentCatalog"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}catalog_name\0")
 
@@ -2184,7 +2184,7 @@ extension Spark_Connect_SetCurrentCatalog: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ListCatalogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ListCatalogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListCatalogs"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}pattern\0")
 

--- a/Sources/SparkConnect/commands.pb.swift
+++ b/Sources/SparkConnect/commands.pb.swift
@@ -36,7 +36,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -44,7 +44,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// The enum used for client side streaming query listener event
 /// There is no QueryStartedEvent defined here,
 /// it is added as a field in WriteStreamOperationStartResult
-enum Spark_Connect_StreamingQueryEventType: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Spark_Connect_StreamingQueryEventType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
   case queryProgressUnspecified // = 0
   case queryProgressEvent // = 1
@@ -88,7 +88,7 @@ enum Spark_Connect_StreamingQueryEventType: SwiftProtobuf.Enum, Swift.CaseIterab
 
 /// A [[Command]] is an operation that is executed by the server that does not directly consume or
 /// produce a relational result.
-struct Spark_Connect_Command: Sendable {
+nonisolated struct Spark_Connect_Command: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -259,7 +259,7 @@ struct Spark_Connect_Command: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_CommandType: Equatable, Sendable {
+  nonisolated enum OneOf_CommandType: Equatable, Sendable {
     case registerFunction(Spark_Connect_CommonInlineUserDefinedFunction)
     case writeOperation(Spark_Connect_WriteOperation)
     case createDataframeView(Spark_Connect_CreateDataFrameViewCommand)
@@ -294,7 +294,7 @@ struct Spark_Connect_Command: Sendable {
 /// and the result will be collected and returned as part of a LocalRelation. If the result is
 /// not a command, the operation will simply return a SQL Relation. This allows the client to be
 /// almost oblivious to the server-side behavior.
-struct Spark_Connect_SqlCommand: Sendable {
+nonisolated struct Spark_Connect_SqlCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -344,7 +344,7 @@ struct Spark_Connect_SqlCommand: Sendable {
 }
 
 /// A command that can create DataFrame global temp view or local temp view.
-struct Spark_Connect_CreateDataFrameViewCommand: Sendable {
+nonisolated struct Spark_Connect_CreateDataFrameViewCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -379,7 +379,7 @@ struct Spark_Connect_CreateDataFrameViewCommand: Sendable {
 }
 
 /// As writes are not directly handled during analysis and planning, they are modeled as commands.
-struct Spark_Connect_WriteOperation: Sendable {
+nonisolated struct Spark_Connect_WriteOperation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -460,13 +460,13 @@ struct Spark_Connect_WriteOperation: Sendable {
   /// The destination of the write operation can be either a path or a table.
   /// If the destination is neither a path nor a table, such as jdbc and noop,
   /// the `save_type` should not be set.
-  enum OneOf_SaveType: Equatable, Sendable {
+  nonisolated enum OneOf_SaveType: Equatable, Sendable {
     case path(String)
     case table(Spark_Connect_WriteOperation.SaveTable)
 
   }
 
-  enum SaveMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum SaveMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case append // = 1
@@ -512,7 +512,7 @@ struct Spark_Connect_WriteOperation: Sendable {
 
   }
 
-  struct SaveTable: Sendable {
+  nonisolated struct SaveTable: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -525,7 +525,7 @@ struct Spark_Connect_WriteOperation: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TableSaveMethod: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum TableSaveMethod: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
       case saveAsTable // = 1
@@ -566,7 +566,7 @@ struct Spark_Connect_WriteOperation: Sendable {
     init() {}
   }
 
-  struct BucketBy: Sendable {
+  nonisolated struct BucketBy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -588,7 +588,7 @@ struct Spark_Connect_WriteOperation: Sendable {
 }
 
 /// As writes are not directly handled during analysis and planning, they are modeled as commands.
-struct Spark_Connect_WriteOperationV2: Sendable {
+nonisolated struct Spark_Connect_WriteOperationV2: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -645,7 +645,7 @@ struct Spark_Connect_WriteOperationV2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Mode: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Mode: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case create // = 1
@@ -708,7 +708,7 @@ struct Spark_Connect_WriteOperationV2: Sendable {
 
 /// Starts write stream operation as streaming query. Query ID and Run ID of the streaming
 /// query are returned.
-struct Spark_Connect_WriteStreamOperationStart: @unchecked Sendable {
+nonisolated struct Spark_Connect_WriteStreamOperationStart: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -841,7 +841,7 @@ struct Spark_Connect_WriteStreamOperationStart: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Trigger: Equatable, Sendable {
+  nonisolated enum OneOf_Trigger: Equatable, Sendable {
     case processingTimeInterval(String)
     case availableNow(Bool)
     case once(Bool)
@@ -851,7 +851,7 @@ struct Spark_Connect_WriteStreamOperationStart: @unchecked Sendable {
   }
 
   /// The destination is optional. When set, it can be a path or a table name.
-  enum OneOf_SinkDestination: Equatable, Sendable {
+  nonisolated enum OneOf_SinkDestination: Equatable, Sendable {
     case path(String)
     case tableName(String)
 
@@ -862,7 +862,7 @@ struct Spark_Connect_WriteStreamOperationStart: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_StreamingForeachFunction: Sendable {
+nonisolated struct Spark_Connect_StreamingForeachFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -887,7 +887,7 @@ struct Spark_Connect_StreamingForeachFunction: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Function: Equatable, Sendable {
+  nonisolated enum OneOf_Function: Equatable, Sendable {
     case pythonFunction(Spark_Connect_PythonUDF)
     case scalaFunction(Spark_Connect_ScalarScalaUDF)
 
@@ -896,7 +896,7 @@ struct Spark_Connect_StreamingForeachFunction: Sendable {
   init() {}
 }
 
-struct Spark_Connect_WriteStreamOperationStartResult: Sendable {
+nonisolated struct Spark_Connect_WriteStreamOperationStartResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -935,7 +935,7 @@ struct Spark_Connect_WriteStreamOperationStartResult: Sendable {
 /// A tuple that uniquely identifies an instance of streaming query run. It consists of `id` that
 /// persists across the streaming runs and `run_id` that changes between each run of the
 /// streaming query that resumes from the checkpoint.
-struct Spark_Connect_StreamingQueryInstanceId: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryInstanceId: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -956,7 +956,7 @@ struct Spark_Connect_StreamingQueryInstanceId: Sendable {
 }
 
 /// Commands for a streaming query.
-struct Spark_Connect_StreamingQueryCommand: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1049,7 +1049,7 @@ struct Spark_Connect_StreamingQueryCommand: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// See documentation for the corresponding API method in StreamingQuery.
-  enum OneOf_Command: Equatable, Sendable {
+  nonisolated enum OneOf_Command: Equatable, Sendable {
     /// status() API.
     case status(Bool)
     /// lastProgress() API.
@@ -1069,7 +1069,7 @@ struct Spark_Connect_StreamingQueryCommand: Sendable {
 
   }
 
-  struct ExplainCommand: Sendable {
+  nonisolated struct ExplainCommand: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1083,7 +1083,7 @@ struct Spark_Connect_StreamingQueryCommand: Sendable {
     init() {}
   }
 
-  struct AwaitTerminationCommand: Sendable {
+  nonisolated struct AwaitTerminationCommand: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1110,7 +1110,7 @@ struct Spark_Connect_StreamingQueryCommand: Sendable {
 }
 
 /// Response for commands on a streaming query.
-struct Spark_Connect_StreamingQueryCommandResult: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1169,7 +1169,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ResultType: Equatable, Sendable {
+  nonisolated enum OneOf_ResultType: Equatable, Sendable {
     case status(Spark_Connect_StreamingQueryCommandResult.StatusResult)
     case recentProgress(Spark_Connect_StreamingQueryCommandResult.RecentProgressResult)
     case explain(Spark_Connect_StreamingQueryCommandResult.ExplainResult)
@@ -1178,7 +1178,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
 
   }
 
-  struct StatusResult: Sendable {
+  nonisolated struct StatusResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1197,7 +1197,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
     init() {}
   }
 
-  struct RecentProgressResult: Sendable {
+  nonisolated struct RecentProgressResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1210,7 +1210,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
     init() {}
   }
 
-  struct ExplainResult: Sendable {
+  nonisolated struct ExplainResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1223,7 +1223,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
     init() {}
   }
 
-  struct ExceptionResult: Sendable {
+  nonisolated struct ExceptionResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1268,7 +1268,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
     fileprivate var _stackTrace: String? = nil
   }
 
-  struct AwaitTerminationResult: Sendable {
+  nonisolated struct AwaitTerminationResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1286,7 +1286,7 @@ struct Spark_Connect_StreamingQueryCommandResult: Sendable {
 }
 
 /// Commands for the streaming query manager.
-struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1360,7 +1360,7 @@ struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// See documentation for the corresponding API method in StreamingQueryManager.
-  enum OneOf_Command: Equatable, Sendable {
+  nonisolated enum OneOf_Command: Equatable, Sendable {
     /// active() API, returns a list of active queries.
     case active(Bool)
     /// get() API, returns the StreamingQuery identified by id.
@@ -1378,7 +1378,7 @@ struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
 
   }
 
-  struct AwaitAnyTerminationCommand: Sendable {
+  nonisolated struct AwaitAnyTerminationCommand: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1400,7 +1400,7 @@ struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
     fileprivate var _timeoutMs: Int64? = nil
   }
 
-  struct StreamingQueryListenerCommand: Sendable {
+  nonisolated struct StreamingQueryListenerCommand: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1429,7 +1429,7 @@ struct Spark_Connect_StreamingQueryManagerCommand: Sendable {
 }
 
 /// Response for commands on the streaming query manager.
-struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1494,7 +1494,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ResultType: Equatable, Sendable {
+  nonisolated enum OneOf_ResultType: Equatable, Sendable {
     case active(Spark_Connect_StreamingQueryManagerCommandResult.ActiveResult)
     case query(Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryInstance)
     case awaitAnyTermination(Spark_Connect_StreamingQueryManagerCommandResult.AwaitAnyTerminationResult)
@@ -1505,7 +1505,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
 
   }
 
-  struct ActiveResult: Sendable {
+  nonisolated struct ActiveResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1517,7 +1517,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
     init() {}
   }
 
-  struct StreamingQueryInstance: Sendable {
+  nonisolated struct StreamingQueryInstance: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1550,7 +1550,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
     fileprivate var _name: String? = nil
   }
 
-  struct AwaitAnyTerminationResult: Sendable {
+  nonisolated struct AwaitAnyTerminationResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1562,7 +1562,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
     init() {}
   }
 
-  struct StreamingQueryListenerInstance: Sendable {
+  nonisolated struct StreamingQueryListenerInstance: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1574,7 +1574,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
     init() {}
   }
 
-  struct ListStreamingQueryListenerResult: Sendable {
+  nonisolated struct ListStreamingQueryListenerResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1595,7 +1595,7 @@ struct Spark_Connect_StreamingQueryManagerCommandResult: Sendable {
 /// listener is removed from the client.
 /// The add_listener_bus_listener command will only be set true in the first case.
 /// The remove_listener_bus_listener command will only be set true in the second case.
-struct Spark_Connect_StreamingQueryListenerBusCommand: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryListenerBusCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1620,7 +1620,7 @@ struct Spark_Connect_StreamingQueryListenerBusCommand: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Command: Equatable, Sendable {
+  nonisolated enum OneOf_Command: Equatable, Sendable {
     case addListenerBusListener(Bool)
     case removeListenerBusListener(Bool)
 
@@ -1630,7 +1630,7 @@ struct Spark_Connect_StreamingQueryListenerBusCommand: Sendable {
 }
 
 /// The protocol for the returned events in the long-running response channel.
-struct Spark_Connect_StreamingQueryListenerEvent: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryListenerEvent: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1646,7 +1646,7 @@ struct Spark_Connect_StreamingQueryListenerEvent: Sendable {
   init() {}
 }
 
-struct Spark_Connect_StreamingQueryListenerEventsResult: Sendable {
+nonisolated struct Spark_Connect_StreamingQueryListenerEventsResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1670,7 +1670,7 @@ struct Spark_Connect_StreamingQueryListenerEventsResult: Sendable {
 }
 
 /// Command to get the output of 'SparkContext.resources'
-struct Spark_Connect_GetResourcesCommand: Sendable {
+nonisolated struct Spark_Connect_GetResourcesCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1681,7 +1681,7 @@ struct Spark_Connect_GetResourcesCommand: Sendable {
 }
 
 /// Response for command 'GetResourcesCommand'.
-struct Spark_Connect_GetResourcesCommandResult: Sendable {
+nonisolated struct Spark_Connect_GetResourcesCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1694,7 +1694,7 @@ struct Spark_Connect_GetResourcesCommandResult: Sendable {
 }
 
 /// Command to create ResourceProfile
-struct Spark_Connect_CreateResourceProfileCommand: Sendable {
+nonisolated struct Spark_Connect_CreateResourceProfileCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1717,7 +1717,7 @@ struct Spark_Connect_CreateResourceProfileCommand: Sendable {
 }
 
 /// Response for command 'CreateResourceProfileCommand'.
-struct Spark_Connect_CreateResourceProfileCommandResult: Sendable {
+nonisolated struct Spark_Connect_CreateResourceProfileCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1731,7 +1731,7 @@ struct Spark_Connect_CreateResourceProfileCommandResult: Sendable {
 }
 
 /// Command to remove `CashedRemoteRelation`
-struct Spark_Connect_RemoveCachedRemoteRelationCommand: Sendable {
+nonisolated struct Spark_Connect_RemoveCachedRemoteRelationCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1753,7 +1753,7 @@ struct Spark_Connect_RemoveCachedRemoteRelationCommand: Sendable {
   fileprivate var _relation: Spark_Connect_CachedRemoteRelation? = nil
 }
 
-struct Spark_Connect_CheckpointCommand: Sendable {
+nonisolated struct Spark_Connect_CheckpointCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1793,7 +1793,7 @@ struct Spark_Connect_CheckpointCommand: Sendable {
   fileprivate var _storageLevel: Spark_Connect_StorageLevel? = nil
 }
 
-struct Spark_Connect_MergeIntoTableCommand: Sendable {
+nonisolated struct Spark_Connect_MergeIntoTableCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1842,7 +1842,7 @@ struct Spark_Connect_MergeIntoTableCommand: Sendable {
 }
 
 /// Execute an arbitrary string command inside an external execution engine
-struct Spark_Connect_ExecuteExternalCommand: Sendable {
+nonisolated struct Spark_Connect_ExecuteExternalCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1863,13 +1863,13 @@ struct Spark_Connect_ExecuteExternalCommand: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_StreamingQueryEventType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryEventType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0QUERY_PROGRESS_UNSPECIFIED\0\u{1}QUERY_PROGRESS_EVENT\0\u{1}QUERY_TERMINATED_EVENT\0\u{1}QUERY_IDLE_EVENT\0")
 }
 
-extension Spark_Connect_Command: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Command: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Command"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}register_function\0\u{3}write_operation\0\u{3}create_dataframe_view\0\u{3}write_operation_v2\0\u{3}sql_command\0\u{3}write_stream_operation_start\0\u{3}streaming_query_command\0\u{3}get_resources_command\0\u{3}streaming_query_manager_command\0\u{3}register_table_function\0\u{3}streaming_query_listener_bus_command\0\u{3}register_data_source\0\u{3}create_resource_profile_command\0\u{3}checkpoint_command\0\u{3}remove_cached_remote_relation_command\0\u{3}merge_into_table_command\0\u{3}ml_command\0\u{3}execute_external_command\0\u{3}pipeline_command\0\u{2}T\u{f}extension\0")
 
@@ -2242,7 +2242,7 @@ extension Spark_Connect_Command: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_SqlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SqlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SqlCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}sql\0\u{1}args\0\u{3}pos_args\0\u{3}named_arguments\0\u{3}pos_arguments\0\u{1}input\0")
 
@@ -2301,7 +2301,7 @@ extension Spark_Connect_SqlCommand: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_CreateDataFrameViewCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CreateDataFrameViewCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CreateDataFrameViewCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}name\0\u{3}is_global\0\u{1}replace\0")
 
@@ -2350,7 +2350,7 @@ extension Spark_Connect_CreateDataFrameViewCommand: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteOperation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}source\0\u{1}path\0\u{1}table\0\u{1}mode\0\u{3}sort_column_names\0\u{3}partitioning_columns\0\u{3}bucket_by\0\u{1}options\0\u{3}clustering_columns\0")
 
@@ -2452,11 +2452,11 @@ extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_WriteOperation.SaveMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperation.SaveMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SAVE_MODE_UNSPECIFIED\0\u{1}SAVE_MODE_APPEND\0\u{1}SAVE_MODE_OVERWRITE\0\u{1}SAVE_MODE_ERROR_IF_EXISTS\0\u{1}SAVE_MODE_IGNORE\0")
 }
 
-extension Spark_Connect_WriteOperation.SaveTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperation.SaveTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_WriteOperation.protoMessageName + ".SaveTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}save_method\0")
 
@@ -2491,11 +2491,11 @@ extension Spark_Connect_WriteOperation.SaveTable: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_WriteOperation.SaveTable.TableSaveMethod: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperation.SaveTable.TableSaveMethod: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0TABLE_SAVE_METHOD_UNSPECIFIED\0\u{1}TABLE_SAVE_METHOD_SAVE_AS_TABLE\0\u{1}TABLE_SAVE_METHOD_INSERT_INTO\0")
 }
 
-extension Spark_Connect_WriteOperation.BucketBy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperation.BucketBy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_WriteOperation.protoMessageName + ".BucketBy"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}bucket_column_names\0\u{3}num_buckets\0")
 
@@ -2530,7 +2530,7 @@ extension Spark_Connect_WriteOperation.BucketBy: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteOperationV2"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}table_name\0\u{1}provider\0\u{3}partitioning_columns\0\u{1}options\0\u{3}table_properties\0\u{1}mode\0\u{3}overwrite_condition\0\u{3}clustering_columns\0")
 
@@ -2604,11 +2604,11 @@ extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_WriteOperationV2.Mode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteOperationV2.Mode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0MODE_UNSPECIFIED\0\u{1}MODE_CREATE\0\u{1}MODE_OVERWRITE\0\u{1}MODE_OVERWRITE_PARTITIONS\0\u{1}MODE_APPEND\0\u{1}MODE_REPLACE\0\u{1}MODE_CREATE_OR_REPLACE\0")
 }
 
-extension Spark_Connect_WriteStreamOperationStart: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteStreamOperationStart: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteStreamOperationStart"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}format\0\u{1}options\0\u{3}partitioning_column_names\0\u{3}processing_time_interval\0\u{3}available_now\0\u{1}once\0\u{3}continuous_checkpoint_interval\0\u{3}output_mode\0\u{3}query_name\0\u{1}path\0\u{3}table_name\0\u{3}foreach_writer\0\u{3}foreach_batch\0\u{3}clustering_column_names\0\u{4}U\u{1}real_time_batch_duration\0")
 
@@ -2829,7 +2829,7 @@ extension Spark_Connect_WriteStreamOperationStart: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_StreamingForeachFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingForeachFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingForeachFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}python_function\0\u{3}scala_function\0")
 
@@ -2896,7 +2896,7 @@ extension Spark_Connect_StreamingForeachFunction: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_WriteStreamOperationStartResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WriteStreamOperationStartResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteStreamOperationStartResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_id\0\u{1}name\0\u{3}query_started_event_json\0")
 
@@ -2940,7 +2940,7 @@ extension Spark_Connect_WriteStreamOperationStartResult: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_StreamingQueryInstanceId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryInstanceId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryInstanceId"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{3}run_id\0")
 
@@ -2975,7 +2975,7 @@ extension Spark_Connect_StreamingQueryInstanceId: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_StreamingQueryCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_id\0\u{1}status\0\u{3}last_progress\0\u{3}recent_progress\0\u{1}stop\0\u{3}process_all_available\0\u{1}explain\0\u{1}exception\0\u{3}await_termination\0")
 
@@ -3119,7 +3119,7 @@ extension Spark_Connect_StreamingQueryCommand: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_StreamingQueryCommand.ExplainCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommand.ExplainCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommand.protoMessageName + ".ExplainCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}extended\0")
 
@@ -3149,7 +3149,7 @@ extension Spark_Connect_StreamingQueryCommand.ExplainCommand: SwiftProtobuf.Mess
   }
 }
 
-extension Spark_Connect_StreamingQueryCommand.AwaitTerminationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommand.AwaitTerminationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommand.protoMessageName + ".AwaitTerminationCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}timeout_ms\0")
 
@@ -3183,7 +3183,7 @@ extension Spark_Connect_StreamingQueryCommand.AwaitTerminationCommand: SwiftProt
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}query_id\0\u{1}status\0\u{3}recent_progress\0\u{1}explain\0\u{1}exception\0\u{3}await_termination\0")
 
@@ -3306,7 +3306,7 @@ extension Spark_Connect_StreamingQueryCommandResult: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult.StatusResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult.StatusResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommandResult.protoMessageName + ".StatusResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}status_message\0\u{3}is_data_available\0\u{3}is_trigger_active\0\u{3}is_active\0")
 
@@ -3351,7 +3351,7 @@ extension Spark_Connect_StreamingQueryCommandResult.StatusResult: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult.RecentProgressResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult.RecentProgressResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommandResult.protoMessageName + ".RecentProgressResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{5}recent_progress_json\0")
 
@@ -3381,7 +3381,7 @@ extension Spark_Connect_StreamingQueryCommandResult.RecentProgressResult: SwiftP
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult.ExplainResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult.ExplainResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommandResult.protoMessageName + ".ExplainResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}result\0")
 
@@ -3411,7 +3411,7 @@ extension Spark_Connect_StreamingQueryCommandResult.ExplainResult: SwiftProtobuf
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult.ExceptionResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult.ExceptionResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommandResult.protoMessageName + ".ExceptionResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}exception_message\0\u{3}error_class\0\u{3}stack_trace\0")
 
@@ -3455,7 +3455,7 @@ extension Spark_Connect_StreamingQueryCommandResult.ExceptionResult: SwiftProtob
   }
 }
 
-extension Spark_Connect_StreamingQueryCommandResult.AwaitTerminationResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryCommandResult.AwaitTerminationResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryCommandResult.protoMessageName + ".AwaitTerminationResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}terminated\0")
 
@@ -3485,7 +3485,7 @@ extension Spark_Connect_StreamingQueryCommandResult.AwaitTerminationResult: Swif
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryManagerCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}active\0\u{3}get_query\0\u{3}await_any_termination\0\u{3}reset_terminated\0\u{3}add_listener\0\u{3}remove_listener\0\u{3}list_listeners\0")
 
@@ -3617,7 +3617,7 @@ extension Spark_Connect_StreamingQueryManagerCommand: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommand.AwaitAnyTerminationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommand.AwaitAnyTerminationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommand.protoMessageName + ".AwaitAnyTerminationCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}timeout_ms\0")
 
@@ -3651,7 +3651,7 @@ extension Spark_Connect_StreamingQueryManagerCommand.AwaitAnyTerminationCommand:
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommand.StreamingQueryListenerCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommand.StreamingQueryListenerCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommand.protoMessageName + ".StreamingQueryListenerCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}listener_payload\0\u{3}python_listener_payload\0\u{1}id\0")
 
@@ -3695,7 +3695,7 @@ extension Spark_Connect_StreamingQueryManagerCommand.StreamingQueryListenerComma
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryManagerCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}active\0\u{1}query\0\u{3}await_any_termination\0\u{3}reset_terminated\0\u{3}add_listener\0\u{3}remove_listener\0\u{3}list_listeners\0")
 
@@ -3832,7 +3832,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult.ActiveResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult.ActiveResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommandResult.protoMessageName + ".ActiveResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}active_queries\0")
 
@@ -3862,7 +3862,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult.ActiveResult: SwiftPr
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryInstance: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryInstance: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommandResult.protoMessageName + ".StreamingQueryInstance"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}name\0")
 
@@ -3901,7 +3901,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryInstanc
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult.AwaitAnyTerminationResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult.AwaitAnyTerminationResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommandResult.protoMessageName + ".AwaitAnyTerminationResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}terminated\0")
 
@@ -3931,7 +3931,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult.AwaitAnyTerminationRe
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryListenerInstance: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryListenerInstance: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommandResult.protoMessageName + ".StreamingQueryListenerInstance"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}listener_payload\0")
 
@@ -3961,7 +3961,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult.StreamingQueryListene
   }
 }
 
-extension Spark_Connect_StreamingQueryManagerCommandResult.ListStreamingQueryListenerResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryManagerCommandResult.ListStreamingQueryListenerResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StreamingQueryManagerCommandResult.protoMessageName + ".ListStreamingQueryListenerResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}listener_ids\0")
 
@@ -3991,7 +3991,7 @@ extension Spark_Connect_StreamingQueryManagerCommandResult.ListStreamingQueryLis
   }
 }
 
-extension Spark_Connect_StreamingQueryListenerBusCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryListenerBusCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryListenerBusCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}add_listener_bus_listener\0\u{3}remove_listener_bus_listener\0")
 
@@ -4048,7 +4048,7 @@ extension Spark_Connect_StreamingQueryListenerBusCommand: SwiftProtobuf.Message,
   }
 }
 
-extension Spark_Connect_StreamingQueryListenerEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryListenerEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryListenerEvent"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}event_json\0\u{3}event_type\0")
 
@@ -4083,7 +4083,7 @@ extension Spark_Connect_StreamingQueryListenerEvent: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_StreamingQueryListenerEventsResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StreamingQueryListenerEventsResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StreamingQueryListenerEventsResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}events\0\u{3}listener_bus_listener_added\0")
 
@@ -4122,7 +4122,7 @@ extension Spark_Connect_StreamingQueryListenerEventsResult: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_GetResourcesCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetResourcesCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetResourcesCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -4141,7 +4141,7 @@ extension Spark_Connect_GetResourcesCommand: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_GetResourcesCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GetResourcesCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GetResourcesCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resources\0")
 
@@ -4171,7 +4171,7 @@ extension Spark_Connect_GetResourcesCommandResult: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_CreateResourceProfileCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CreateResourceProfileCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CreateResourceProfileCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}profile\0")
 
@@ -4205,7 +4205,7 @@ extension Spark_Connect_CreateResourceProfileCommand: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_CreateResourceProfileCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CreateResourceProfileCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CreateResourceProfileCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}profile_id\0")
 
@@ -4235,7 +4235,7 @@ extension Spark_Connect_CreateResourceProfileCommandResult: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_RemoveCachedRemoteRelationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RemoveCachedRemoteRelationCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RemoveCachedRemoteRelationCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0")
 
@@ -4269,7 +4269,7 @@ extension Spark_Connect_RemoveCachedRemoteRelationCommand: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_CheckpointCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CheckpointCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CheckpointCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0\u{1}local\0\u{1}eager\0\u{3}storage_level\0")
 
@@ -4318,7 +4318,7 @@ extension Spark_Connect_CheckpointCommand: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_MergeIntoTableCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MergeIntoTableCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MergeIntoTableCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}target_table_name\0\u{3}source_table_plan\0\u{3}merge_condition\0\u{3}match_actions\0\u{3}not_matched_actions\0\u{3}not_matched_by_source_actions\0\u{3}with_schema_evolution\0")
 
@@ -4382,7 +4382,7 @@ extension Spark_Connect_MergeIntoTableCommand: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ExecuteExternalCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecuteExternalCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExecuteExternalCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}runner\0\u{1}command\0\u{1}options\0")
 

--- a/Sources/SparkConnect/common.pb.swift
+++ b/Sources/SparkConnect/common.pb.swift
@@ -31,13 +31,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// StorageLevel for persisting Datasets/Tables.
-struct Spark_Connect_StorageLevel: Sendable {
+nonisolated struct Spark_Connect_StorageLevel: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -64,7 +64,7 @@ struct Spark_Connect_StorageLevel: Sendable {
 
 /// ResourceInformation to hold information about a type of Resource.
 /// The corresponding class is 'org.apache.spark.resource.ResourceInformation'
-struct Spark_Connect_ResourceInformation: Sendable {
+nonisolated struct Spark_Connect_ResourceInformation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -81,7 +81,7 @@ struct Spark_Connect_ResourceInformation: Sendable {
 }
 
 /// An executor resource request.
-struct Spark_Connect_ExecutorResourceRequest: Sendable {
+nonisolated struct Spark_Connect_ExecutorResourceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -121,7 +121,7 @@ struct Spark_Connect_ExecutorResourceRequest: Sendable {
 }
 
 /// A task resource request.
-struct Spark_Connect_TaskResourceRequest: Sendable {
+nonisolated struct Spark_Connect_TaskResourceRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -138,7 +138,7 @@ struct Spark_Connect_TaskResourceRequest: Sendable {
   init() {}
 }
 
-struct Spark_Connect_ResourceProfile: Sendable {
+nonisolated struct Spark_Connect_ResourceProfile: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -156,7 +156,7 @@ struct Spark_Connect_ResourceProfile: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Origin: Sendable {
+nonisolated struct Spark_Connect_Origin: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -183,7 +183,7 @@ struct Spark_Connect_Origin: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// (Required) Indicate the origin type.
-  enum OneOf_Function: Equatable, Sendable {
+  nonisolated enum OneOf_Function: Equatable, Sendable {
     case pythonOrigin(Spark_Connect_PythonOrigin)
     case jvmOrigin(Spark_Connect_JvmOrigin)
 
@@ -192,7 +192,7 @@ struct Spark_Connect_Origin: Sendable {
   init() {}
 }
 
-struct Spark_Connect_PythonOrigin: Sendable {
+nonisolated struct Spark_Connect_PythonOrigin: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -208,7 +208,7 @@ struct Spark_Connect_PythonOrigin: Sendable {
   init() {}
 }
 
-struct Spark_Connect_JvmOrigin: Sendable {
+nonisolated struct Spark_Connect_JvmOrigin: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -300,7 +300,7 @@ struct Spark_Connect_JvmOrigin: Sendable {
 }
 
 /// A message to hold a [[java.lang.StackTraceElement]].
-struct Spark_Connect_StackTraceElement: Sendable {
+nonisolated struct Spark_Connect_StackTraceElement: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -364,7 +364,7 @@ struct Spark_Connect_StackTraceElement: Sendable {
   fileprivate var _fileName: String? = nil
 }
 
-struct Spark_Connect_ResolvedIdentifier: Sendable {
+nonisolated struct Spark_Connect_ResolvedIdentifier: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -380,7 +380,7 @@ struct Spark_Connect_ResolvedIdentifier: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Bools: Sendable {
+nonisolated struct Spark_Connect_Bools: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -392,7 +392,7 @@ struct Spark_Connect_Bools: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Ints: Sendable {
+nonisolated struct Spark_Connect_Ints: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -404,7 +404,7 @@ struct Spark_Connect_Ints: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Longs: Sendable {
+nonisolated struct Spark_Connect_Longs: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -416,7 +416,7 @@ struct Spark_Connect_Longs: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Floats: Sendable {
+nonisolated struct Spark_Connect_Floats: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -428,7 +428,7 @@ struct Spark_Connect_Floats: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Doubles: Sendable {
+nonisolated struct Spark_Connect_Doubles: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -440,7 +440,7 @@ struct Spark_Connect_Doubles: Sendable {
   init() {}
 }
 
-struct Spark_Connect_Strings: Sendable {
+nonisolated struct Spark_Connect_Strings: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -454,9 +454,9 @@ struct Spark_Connect_Strings: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_StorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StorageLevel: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StorageLevel"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}use_disk\0\u{3}use_memory\0\u{3}use_off_heap\0\u{1}deserialized\0\u{1}replication\0")
 
@@ -506,7 +506,7 @@ extension Spark_Connect_StorageLevel: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_ResourceInformation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ResourceInformation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ResourceInformation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}addresses\0")
 
@@ -541,7 +541,7 @@ extension Spark_Connect_ResourceInformation: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_ExecutorResourceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExecutorResourceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExecutorResourceRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_name\0\u{1}amount\0\u{3}discovery_script\0\u{1}vendor\0")
 
@@ -590,7 +590,7 @@ extension Spark_Connect_ExecutorResourceRequest: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_TaskResourceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_TaskResourceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TaskResourceRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_name\0\u{1}amount\0")
 
@@ -625,7 +625,7 @@ extension Spark_Connect_TaskResourceRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_ResourceProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ResourceProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ResourceProfile"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}executor_resources\0\u{3}task_resources\0")
 
@@ -660,7 +660,7 @@ extension Spark_Connect_ResourceProfile: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_Origin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Origin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Origin"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}python_origin\0\u{3}jvm_origin\0")
 
@@ -727,7 +727,7 @@ extension Spark_Connect_Origin: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_PythonOrigin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PythonOrigin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PythonOrigin"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fragment\0\u{3}call_site\0")
 
@@ -762,7 +762,7 @@ extension Spark_Connect_PythonOrigin: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_JvmOrigin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_JvmOrigin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JvmOrigin"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}line\0\u{3}start_position\0\u{3}start_index\0\u{3}stop_index\0\u{3}sql_text\0\u{3}object_type\0\u{3}object_name\0\u{3}stack_trace\0")
 
@@ -831,7 +831,7 @@ extension Spark_Connect_JvmOrigin: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_StackTraceElement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StackTraceElement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StackTraceElement"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}class_loader_name\0\u{3}module_name\0\u{3}module_version\0\u{3}declaring_class\0\u{3}method_name\0\u{3}file_name\0\u{3}line_number\0")
 
@@ -895,7 +895,7 @@ extension Spark_Connect_StackTraceElement: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ResolvedIdentifier: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ResolvedIdentifier: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ResolvedIdentifier"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}catalog_name\0\u{1}namespace\0\u{3}table_name\0")
 
@@ -935,7 +935,7 @@ extension Spark_Connect_ResolvedIdentifier: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_Bools: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Bools: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Bools"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -965,7 +965,7 @@ extension Spark_Connect_Bools: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_Ints: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Ints: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Ints"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -995,7 +995,7 @@ extension Spark_Connect_Ints: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Longs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Longs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Longs"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -1025,7 +1025,7 @@ extension Spark_Connect_Longs: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_Floats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Floats: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Floats"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -1055,7 +1055,7 @@ extension Spark_Connect_Floats: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_Doubles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Doubles: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Doubles"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -1085,7 +1085,7 @@ extension Spark_Connect_Doubles: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_Strings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Strings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Strings"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 

--- a/Sources/SparkConnect/example_plugins.pb.swift
+++ b/Sources/SparkConnect/example_plugins.pb.swift
@@ -31,12 +31,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-struct Spark_Connect_ExamplePluginRelation: Sendable {
+nonisolated struct Spark_Connect_ExamplePluginRelation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,7 +59,7 @@ struct Spark_Connect_ExamplePluginRelation: Sendable {
   fileprivate var _input: Spark_Connect_Relation? = nil
 }
 
-struct Spark_Connect_ExamplePluginExpression: Sendable {
+nonisolated struct Spark_Connect_ExamplePluginExpression: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -82,7 +82,7 @@ struct Spark_Connect_ExamplePluginExpression: Sendable {
   fileprivate var _child: Spark_Connect_Expression? = nil
 }
 
-struct Spark_Connect_ExamplePluginCommand: Sendable {
+nonisolated struct Spark_Connect_ExamplePluginCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,9 +96,9 @@ struct Spark_Connect_ExamplePluginCommand: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_ExamplePluginRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExamplePluginRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExamplePluginRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}custom_field\0")
 
@@ -137,7 +137,7 @@ extension Spark_Connect_ExamplePluginRelation: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ExamplePluginExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExamplePluginExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExamplePluginExpression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}child\0\u{3}custom_field\0")
 
@@ -176,7 +176,7 @@ extension Spark_Connect_ExamplePluginExpression: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_ExamplePluginCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExamplePluginCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExamplePluginCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}custom_field\0")
 

--- a/Sources/SparkConnect/expressions.pb.swift
+++ b/Sources/SparkConnect/expressions.pb.swift
@@ -36,14 +36,14 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Expression used to refer to fields, functions and similar. This can be used everywhere
 /// expressions in SQL appear.
-struct Spark_Connect_Expression: @unchecked Sendable {
+nonisolated struct Spark_Connect_Expression: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -242,7 +242,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ExprType: Equatable, Sendable {
+  nonisolated enum OneOf_ExprType: Equatable, Sendable {
     case literal(Spark_Connect_Expression.Literal)
     case unresolvedAttribute(Spark_Connect_Expression.UnresolvedAttribute)
     case unresolvedFunction(Spark_Connect_Expression.UnresolvedFunction)
@@ -271,7 +271,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   }
 
   /// Expression for the OVER clause or WINDOW clause.
-  struct Window: @unchecked Sendable {
+  nonisolated struct Window: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -313,7 +313,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// The window frame
-    struct WindowFrame: @unchecked Sendable {
+    nonisolated struct WindowFrame: @unchecked Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -346,7 +346,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      enum FrameType: SwiftProtobuf.Enum, Swift.CaseIterable {
+      nonisolated enum FrameType: SwiftProtobuf.Enum, Swift.CaseIterable {
         typealias RawValue = Int
         case undefined // = 0
 
@@ -389,7 +389,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
       }
 
-      struct FrameBoundary: @unchecked Sendable {
+      nonisolated struct FrameBoundary: @unchecked Sendable {
         // SwiftProtobuf.Message conformance is added in an extension below. See the
         // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
         // methods supported on all messages.
@@ -430,7 +430,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
         var unknownFields = SwiftProtobuf.UnknownStorage()
 
-        enum OneOf_Boundary: Equatable, Sendable {
+        nonisolated enum OneOf_Boundary: Equatable, Sendable {
           /// CURRENT ROW boundary
           case currentRow(Bool)
           /// UNBOUNDED boundary.
@@ -459,7 +459,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
   /// SortOrder is used to specify the  data ordering, it is normally used in Sort and Window.
   /// It is an unevaluable expression and cannot be evaluated, so can not be used in Projection.
-  struct SortOrder: @unchecked Sendable {
+  nonisolated struct SortOrder: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -488,7 +488,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum SortDirection: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum SortDirection: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
       case ascending // = 1
@@ -526,7 +526,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
     }
 
-    enum NullOrdering: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum NullOrdering: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case sortNullsUnspecified // = 0
       case sortNullsFirst // = 1
@@ -572,7 +572,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   /// Expression that takes a partition ID value and passes it through directly for use in
   /// shuffle partitioning. This is used with RepartitionByExpression to allow users to
   /// directly specify target partition IDs.
-  struct DirectShufflePartitionID: @unchecked Sendable {
+  nonisolated struct DirectShufflePartitionID: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -594,7 +594,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Cast: @unchecked Sendable {
+  nonisolated struct Cast: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -641,14 +641,14 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// (Required) the data type that the expr to be casted to.
-    enum OneOf_CastToType: Equatable, Sendable {
+    nonisolated enum OneOf_CastToType: Equatable, Sendable {
       case type(Spark_Connect_DataType)
       /// If this is set, Server will use Catalyst parser to parse this string to DataType.
       case typeStr(String)
 
     }
 
-    enum EvalMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum EvalMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unspecified // = 0
       case legacy // = 1
@@ -695,7 +695,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Literal: Sendable {
+  nonisolated struct Literal: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -897,7 +897,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_LiteralType: Equatable, Sendable {
+    nonisolated enum OneOf_LiteralType: Equatable, Sendable {
       case null(Spark_Connect_DataType)
       case binary(Data)
       case boolean(Bool)
@@ -926,7 +926,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
     }
 
-    struct Decimal: Sendable {
+    nonisolated struct Decimal: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -963,7 +963,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       fileprivate var _scale: Int32? = nil
     }
 
-    struct CalendarInterval: Sendable {
+    nonisolated struct CalendarInterval: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -979,7 +979,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       init() {}
     }
 
-    struct Array: Sendable {
+    nonisolated struct Array: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1008,7 +1008,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       fileprivate var _elementType: Spark_Connect_DataType? = nil
     }
 
-    struct Map: Sendable {
+    nonisolated struct Map: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1056,7 +1056,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       fileprivate var _valueType: Spark_Connect_DataType? = nil
     }
 
-    struct Struct: Sendable {
+    nonisolated struct Struct: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1086,7 +1086,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       fileprivate var _structType: Spark_Connect_DataType? = nil
     }
 
-    struct SpecializedArray: Sendable {
+    nonisolated struct SpecializedArray: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1143,7 +1143,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      enum OneOf_ValueType: Equatable, Sendable {
+      nonisolated enum OneOf_ValueType: Equatable, Sendable {
         case bools(Spark_Connect_Bools)
         case ints(Spark_Connect_Ints)
         case longs(Spark_Connect_Longs)
@@ -1156,7 +1156,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
       init() {}
     }
 
-    struct Time: Sendable {
+    nonisolated struct Time: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -1187,7 +1187,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
   /// An unresolved attribute that is not explicitly bound to a specific column, but the column
   /// is resolved during analysis by name.
-  struct UnresolvedAttribute: Sendable {
+  nonisolated struct UnresolvedAttribute: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1226,7 +1226,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
   /// An unresolved function is not explicitly bound to one explicit function, but the function
   /// is resolved during analysis following Sparks name resolution rules.
-  struct UnresolvedFunction: Sendable {
+  nonisolated struct UnresolvedFunction: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1266,7 +1266,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   }
 
   /// Expression as string.
-  struct ExpressionString: Sendable {
+  nonisolated struct ExpressionString: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1280,7 +1280,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   }
 
   /// UnresolvedStar is used to expand all the fields of a relation or struct.
-  struct UnresolvedStar: Sendable {
+  nonisolated struct UnresolvedStar: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1318,7 +1318,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
 
   /// Represents all of the input attributes to a given relational operator, for example in
   /// "SELECT `(id)?+.+` FROM ...".
-  struct UnresolvedRegex: Sendable {
+  nonisolated struct UnresolvedRegex: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1344,7 +1344,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   }
 
   /// Extracts a value or values from an Expression
-  struct UnresolvedExtractValue: @unchecked Sendable {
+  nonisolated struct UnresolvedExtractValue: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1379,7 +1379,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   }
 
   /// Add, replace or drop a field of `StructType` expression by name.
-  struct UpdateFields: @unchecked Sendable {
+  nonisolated struct UpdateFields: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1419,7 +1419,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Alias: @unchecked Sendable {
+  nonisolated struct Alias: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1459,7 +1459,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct LambdaFunction: @unchecked Sendable {
+  nonisolated struct LambdaFunction: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1490,7 +1490,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct UnresolvedNamedLambdaVariable: Sendable {
+  nonisolated struct UnresolvedNamedLambdaVariable: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1508,7 +1508,7 @@ struct Spark_Connect_Expression: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_ExpressionCommon: Sendable {
+nonisolated struct Spark_Connect_ExpressionCommon: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1530,7 +1530,7 @@ struct Spark_Connect_ExpressionCommon: Sendable {
   fileprivate var _origin: Spark_Connect_Origin? = nil
 }
 
-struct Spark_Connect_CommonInlineUserDefinedFunction: Sendable {
+nonisolated struct Spark_Connect_CommonInlineUserDefinedFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1577,7 +1577,7 @@ struct Spark_Connect_CommonInlineUserDefinedFunction: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// (Required) Indicate the function type of the user-defined function.
-  enum OneOf_Function: Equatable, Sendable {
+  nonisolated enum OneOf_Function: Equatable, Sendable {
     case pythonUdf(Spark_Connect_PythonUDF)
     case scalarScalaUdf(Spark_Connect_ScalarScalaUDF)
     case javaUdf(Spark_Connect_JavaUDF)
@@ -1587,7 +1587,7 @@ struct Spark_Connect_CommonInlineUserDefinedFunction: Sendable {
   init() {}
 }
 
-struct Spark_Connect_PythonUDF: Sendable {
+nonisolated struct Spark_Connect_PythonUDF: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1621,7 +1621,7 @@ struct Spark_Connect_PythonUDF: Sendable {
   fileprivate var _outputType: Spark_Connect_DataType? = nil
 }
 
-struct Spark_Connect_ScalarScalaUDF: Sendable {
+nonisolated struct Spark_Connect_ScalarScalaUDF: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1655,7 +1655,7 @@ struct Spark_Connect_ScalarScalaUDF: Sendable {
   fileprivate var _outputType: Spark_Connect_DataType? = nil
 }
 
-struct Spark_Connect_JavaUDF: Sendable {
+nonisolated struct Spark_Connect_JavaUDF: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1683,7 +1683,7 @@ struct Spark_Connect_JavaUDF: Sendable {
   fileprivate var _outputType: Spark_Connect_DataType? = nil
 }
 
-struct Spark_Connect_TypedAggregateExpression: Sendable {
+nonisolated struct Spark_Connect_TypedAggregateExpression: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1705,7 +1705,7 @@ struct Spark_Connect_TypedAggregateExpression: Sendable {
   fileprivate var _scalarScalaUdf: Spark_Connect_ScalarScalaUDF? = nil
 }
 
-struct Spark_Connect_CallFunction: Sendable {
+nonisolated struct Spark_Connect_CallFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1721,7 +1721,7 @@ struct Spark_Connect_CallFunction: Sendable {
   init() {}
 }
 
-struct Spark_Connect_NamedArgumentExpression: @unchecked Sendable {
+nonisolated struct Spark_Connect_NamedArgumentExpression: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1749,7 +1749,7 @@ struct Spark_Connect_NamedArgumentExpression: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_MergeAction: @unchecked Sendable {
+nonisolated struct Spark_Connect_MergeAction: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1778,7 +1778,7 @@ struct Spark_Connect_MergeAction: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum ActionType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum ActionType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case invalid // = 0
     case delete // = 1
@@ -1828,7 +1828,7 @@ struct Spark_Connect_MergeAction: @unchecked Sendable {
 
   }
 
-  struct Assignment: Sendable {
+  nonisolated struct Assignment: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1866,7 +1866,7 @@ struct Spark_Connect_MergeAction: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_SubqueryExpression: Sendable {
+nonisolated struct Spark_Connect_SubqueryExpression: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1892,7 +1892,7 @@ struct Spark_Connect_SubqueryExpression: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum SubqueryType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum SubqueryType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case scalar // = 1
@@ -1939,7 +1939,7 @@ struct Spark_Connect_SubqueryExpression: Sendable {
   }
 
   /// Nested message for table argument options.
-  struct TableArgOptions: Sendable {
+  nonisolated struct TableArgOptions: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1974,9 +1974,9 @@ struct Spark_Connect_SubqueryExpression: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_Expression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Expression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}literal\0\u{3}unresolved_attribute\0\u{3}unresolved_function\0\u{3}expression_string\0\u{3}unresolved_star\0\u{1}alias\0\u{1}cast\0\u{3}unresolved_regex\0\u{3}sort_order\0\u{3}lambda_function\0\u{1}window\0\u{3}unresolved_extract_value\0\u{3}update_fields\0\u{3}unresolved_named_lambda_variable\0\u{3}common_inline_user_defined_function\0\u{3}call_function\0\u{3}named_argument_expression\0\u{1}common\0\u{3}merge_action\0\u{3}typed_aggregate_expression\0\u{3}subquery_expression\0\u{3}direct_shuffle_partition_id\0\u{2}Q\u{f}extension\0")
 
@@ -2429,7 +2429,7 @@ extension Spark_Connect_Expression: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_Expression.Window: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Window: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".Window"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}window_function\0\u{3}partition_spec\0\u{3}order_spec\0\u{3}frame_spec\0")
 
@@ -2520,7 +2520,7 @@ extension Spark_Connect_Expression.Window: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_Expression.Window.WindowFrame: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Window.WindowFrame: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Window.protoMessageName + ".WindowFrame"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}frame_type\0\u{1}lower\0\u{1}upper\0")
 
@@ -2604,11 +2604,11 @@ extension Spark_Connect_Expression.Window.WindowFrame: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_Expression.Window.WindowFrame.FrameType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Window.WindowFrame.FrameType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0FRAME_TYPE_UNDEFINED\0\u{1}FRAME_TYPE_ROW\0\u{1}FRAME_TYPE_RANGE\0")
 }
 
-extension Spark_Connect_Expression.Window.WindowFrame.FrameBoundary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Window.WindowFrame.FrameBoundary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Window.WindowFrame.protoMessageName + ".FrameBoundary"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_row\0\u{1}unbounded\0\u{1}value\0")
 
@@ -2718,7 +2718,7 @@ extension Spark_Connect_Expression.Window.WindowFrame.FrameBoundary: SwiftProtob
   }
 }
 
-extension Spark_Connect_Expression.SortOrder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.SortOrder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".SortOrder"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}child\0\u{1}direction\0\u{3}null_ordering\0")
 
@@ -2802,15 +2802,15 @@ extension Spark_Connect_Expression.SortOrder: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_Expression.SortOrder.SortDirection: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.SortOrder.SortDirection: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SORT_DIRECTION_UNSPECIFIED\0\u{1}SORT_DIRECTION_ASCENDING\0\u{1}SORT_DIRECTION_DESCENDING\0")
 }
 
-extension Spark_Connect_Expression.SortOrder.NullOrdering: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.SortOrder.NullOrdering: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SORT_NULLS_UNSPECIFIED\0\u{1}SORT_NULLS_FIRST\0\u{1}SORT_NULLS_LAST\0")
 }
 
-extension Spark_Connect_Expression.DirectShufflePartitionID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.DirectShufflePartitionID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".DirectShufflePartitionID"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}child\0")
 
@@ -2880,7 +2880,7 @@ extension Spark_Connect_Expression.DirectShufflePartitionID: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_Expression.Cast: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Cast: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".Cast"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}expr\0\u{1}type\0\u{3}type_str\0\u{3}eval_mode\0")
 
@@ -2992,11 +2992,11 @@ extension Spark_Connect_Expression.Cast: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_Expression.Cast.EvalMode: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Cast.EvalMode: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0EVAL_MODE_UNSPECIFIED\0\u{1}EVAL_MODE_LEGACY\0\u{1}EVAL_MODE_ANSI\0\u{1}EVAL_MODE_TRY\0")
 }
 
-extension Spark_Connect_Expression.Literal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".Literal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}null\0\u{1}binary\0\u{1}boolean\0\u{1}byte\0\u{1}short\0\u{1}integer\0\u{1}long\0\u{2}\u{3}float\0\u{1}double\0\u{1}decimal\0\u{1}string\0\u{2}\u{3}date\0\u{1}timestamp\0\u{3}timestamp_ntz\0\u{3}calendar_interval\0\u{3}year_month_interval\0\u{3}day_time_interval\0\u{1}array\0\u{1}map\0\u{1}struct\0\u{3}specialized_array\0\u{1}time\0\u{4}J\u{1}data_type\0\u{c}\u{1b}\u{1}\u{c}\u{1c}\u{1}")
 
@@ -3338,7 +3338,7 @@ extension Spark_Connect_Expression.Literal: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_Expression.Literal.Decimal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.Decimal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".Decimal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}value\0\u{1}precision\0\u{1}scale\0")
 
@@ -3382,7 +3382,7 @@ extension Spark_Connect_Expression.Literal.Decimal: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_Expression.Literal.CalendarInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.CalendarInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".CalendarInterval"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}months\0\u{1}days\0\u{1}microseconds\0")
 
@@ -3422,7 +3422,7 @@ extension Spark_Connect_Expression.Literal.CalendarInterval: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_Expression.Literal.Array: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.Array: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".Array"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}element_type\0\u{1}elements\0")
 
@@ -3461,7 +3461,7 @@ extension Spark_Connect_Expression.Literal.Array: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_Expression.Literal.Map: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.Map: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".Map"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}key_type\0\u{3}value_type\0\u{1}keys\0\u{1}values\0")
 
@@ -3510,7 +3510,7 @@ extension Spark_Connect_Expression.Literal.Map: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_Expression.Literal.Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".Struct"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}struct_type\0\u{1}elements\0")
 
@@ -3549,7 +3549,7 @@ extension Spark_Connect_Expression.Literal.Struct: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_Expression.Literal.SpecializedArray: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.SpecializedArray: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".SpecializedArray"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}bools\0\u{1}ints\0\u{1}longs\0\u{1}floats\0\u{1}doubles\0\u{1}strings\0")
 
@@ -3684,7 +3684,7 @@ extension Spark_Connect_Expression.Literal.SpecializedArray: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_Expression.Literal.Time: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Literal.Time: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.Literal.protoMessageName + ".Time"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}nano\0\u{1}precision\0")
 
@@ -3723,7 +3723,7 @@ extension Spark_Connect_Expression.Literal.Time: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedAttribute: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedAttribute: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedAttribute"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unparsed_identifier\0\u{3}plan_id\0\u{3}is_metadata_column\0")
 
@@ -3767,7 +3767,7 @@ extension Spark_Connect_Expression.UnresolvedAttribute: SwiftProtobuf.Message, S
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{1}arguments\0\u{3}is_distinct\0\u{3}is_user_defined_function\0\u{3}is_internal\0")
 
@@ -3821,7 +3821,7 @@ extension Spark_Connect_Expression.UnresolvedFunction: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_Expression.ExpressionString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.ExpressionString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".ExpressionString"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}expression\0")
 
@@ -3851,7 +3851,7 @@ extension Spark_Connect_Expression.ExpressionString: SwiftProtobuf.Message, Swif
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedStar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedStar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedStar"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unparsed_target\0\u{3}plan_id\0")
 
@@ -3890,7 +3890,7 @@ extension Spark_Connect_Expression.UnresolvedStar: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedRegex: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedRegex: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedRegex"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}col_name\0\u{3}plan_id\0")
 
@@ -3929,7 +3929,7 @@ extension Spark_Connect_Expression.UnresolvedRegex: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedExtractValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedExtractValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedExtractValue"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}child\0\u{1}extraction\0")
 
@@ -4006,7 +4006,7 @@ extension Spark_Connect_Expression.UnresolvedExtractValue: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_Expression.UpdateFields: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UpdateFields: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UpdateFields"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}struct_expression\0\u{3}field_name\0\u{3}value_expression\0")
 
@@ -4090,7 +4090,7 @@ extension Spark_Connect_Expression.UpdateFields: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_Expression.Alias: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.Alias: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".Alias"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}expr\0\u{1}name\0\u{1}metadata\0")
 
@@ -4174,7 +4174,7 @@ extension Spark_Connect_Expression.Alias: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_Expression.LambdaFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.LambdaFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".LambdaFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}function\0\u{1}arguments\0")
 
@@ -4251,7 +4251,7 @@ extension Spark_Connect_Expression.LambdaFunction: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_Expression.UnresolvedNamedLambdaVariable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Expression.UnresolvedNamedLambdaVariable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Expression.protoMessageName + ".UnresolvedNamedLambdaVariable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}name_parts\0")
 
@@ -4281,7 +4281,7 @@ extension Spark_Connect_Expression.UnresolvedNamedLambdaVariable: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_ExpressionCommon: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ExpressionCommon: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExpressionCommon"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}origin\0")
 
@@ -4315,7 +4315,7 @@ extension Spark_Connect_ExpressionCommon: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_CommonInlineUserDefinedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CommonInlineUserDefinedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CommonInlineUserDefinedFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{1}deterministic\0\u{1}arguments\0\u{3}python_udf\0\u{3}scalar_scala_udf\0\u{3}java_udf\0\u{3}is_distinct\0")
 
@@ -4419,7 +4419,7 @@ extension Spark_Connect_CommonInlineUserDefinedFunction: SwiftProtobuf.Message, 
   }
 }
 
-extension Spark_Connect_PythonUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PythonUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PythonUDF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}output_type\0\u{3}eval_type\0\u{1}command\0\u{3}python_ver\0\u{3}additional_includes\0")
 
@@ -4473,7 +4473,7 @@ extension Spark_Connect_PythonUDF: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_ScalarScalaUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ScalarScalaUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ScalarScalaUDF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}payload\0\u{1}inputTypes\0\u{1}outputType\0\u{1}nullable\0\u{1}aggregate\0")
 
@@ -4527,7 +4527,7 @@ extension Spark_Connect_ScalarScalaUDF: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_JavaUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_JavaUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".JavaUDF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}class_name\0\u{3}output_type\0\u{1}aggregate\0")
 
@@ -4571,7 +4571,7 @@ extension Spark_Connect_JavaUDF: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_TypedAggregateExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_TypedAggregateExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TypedAggregateExpression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}scalar_scala_udf\0")
 
@@ -4605,7 +4605,7 @@ extension Spark_Connect_TypedAggregateExpression: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_CallFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CallFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CallFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{1}arguments\0")
 
@@ -4640,7 +4640,7 @@ extension Spark_Connect_CallFunction: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_NamedArgumentExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_NamedArgumentExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NamedArgumentExpression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
@@ -4717,7 +4717,7 @@ extension Spark_Connect_NamedArgumentExpression: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_MergeAction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MergeAction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MergeAction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}action_type\0\u{1}condition\0\u{1}assignments\0")
 
@@ -4801,11 +4801,11 @@ extension Spark_Connect_MergeAction: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_MergeAction.ActionType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MergeAction.ActionType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ACTION_TYPE_INVALID\0\u{1}ACTION_TYPE_DELETE\0\u{1}ACTION_TYPE_INSERT\0\u{1}ACTION_TYPE_INSERT_STAR\0\u{1}ACTION_TYPE_UPDATE\0\u{1}ACTION_TYPE_UPDATE_STAR\0")
 }
 
-extension Spark_Connect_MergeAction.Assignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MergeAction.Assignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MergeAction.protoMessageName + ".Assignment"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
@@ -4844,7 +4844,7 @@ extension Spark_Connect_MergeAction.Assignment: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_SubqueryExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SubqueryExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubqueryExpression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}plan_id\0\u{3}subquery_type\0\u{3}table_arg_options\0\u{3}in_subquery_values\0")
 
@@ -4893,11 +4893,11 @@ extension Spark_Connect_SubqueryExpression: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_SubqueryExpression.SubqueryType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SubqueryExpression.SubqueryType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SUBQUERY_TYPE_UNKNOWN\0\u{1}SUBQUERY_TYPE_SCALAR\0\u{1}SUBQUERY_TYPE_EXISTS\0\u{1}SUBQUERY_TYPE_TABLE_ARG\0\u{1}SUBQUERY_TYPE_IN\0")
 }
 
-extension Spark_Connect_SubqueryExpression.TableArgOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SubqueryExpression.TableArgOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_SubqueryExpression.protoMessageName + ".TableArgOptions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partition_spec\0\u{3}order_spec\0\u{3}with_single_partition\0")
 

--- a/Sources/SparkConnect/ml.pb.swift
+++ b/Sources/SparkConnect/ml.pb.swift
@@ -31,13 +31,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Command for ML
-struct Spark_Connect_MlCommand: Sendable {
+nonisolated struct Spark_Connect_MlCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -126,7 +126,7 @@ struct Spark_Connect_MlCommand: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Command: Equatable, Sendable {
+  nonisolated enum OneOf_Command: Equatable, Sendable {
     case fit(Spark_Connect_MlCommand.Fit)
     case fetch(Spark_Connect_Fetch)
     case delete(Spark_Connect_MlCommand.Delete)
@@ -141,7 +141,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Command for estimator.fit(dataset)
-  struct Fit: Sendable {
+  nonisolated struct Fit: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -187,7 +187,7 @@ struct Spark_Connect_MlCommand: Sendable {
 
   /// Command to delete the cached objects which could be a model
   /// or summary evaluated by a model
-  struct Delete: Sendable {
+  nonisolated struct Delete: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -213,7 +213,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Force to clean up all the ML cached objects
-  struct CleanCache: Sendable {
+  nonisolated struct CleanCache: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -224,7 +224,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Get the information of all the ML cached objects
-  struct GetCacheInfo: Sendable {
+  nonisolated struct GetCacheInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -235,7 +235,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Command to write ML operator
-  struct Write: Sendable {
+  nonisolated struct Write: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -290,7 +290,7 @@ struct Spark_Connect_MlCommand: Sendable {
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     /// It could be an estimator/evaluator or the cached model
-    enum OneOf_Type: Equatable, Sendable {
+    nonisolated enum OneOf_Type: Equatable, Sendable {
       /// Estimator or evaluator
       case `operator`(Spark_Connect_MlOperator)
       /// The cached model
@@ -305,7 +305,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Command to load ML operator.
-  struct Read: Sendable {
+  nonisolated struct Read: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -331,7 +331,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// Command for evaluator.evaluate(dataset)
-  struct Evaluate: Sendable {
+  nonisolated struct Evaluate: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -377,7 +377,7 @@ struct Spark_Connect_MlCommand: Sendable {
 
   /// This is for re-creating the model summary when the model summary is lost
   /// (model summary is lost when the model is offloaded and then loaded back)
-  struct CreateSummary: Sendable {
+  nonisolated struct CreateSummary: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -409,7 +409,7 @@ struct Spark_Connect_MlCommand: Sendable {
   }
 
   /// This is for query the model estimated in-memory size
-  struct GetModelSize: Sendable {
+  nonisolated struct GetModelSize: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -434,7 +434,7 @@ struct Spark_Connect_MlCommand: Sendable {
 }
 
 /// The result of MlCommand
-struct Spark_Connect_MlCommandResult: Sendable {
+nonisolated struct Spark_Connect_MlCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -470,7 +470,7 @@ struct Spark_Connect_MlCommandResult: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ResultType: Equatable, Sendable {
+  nonisolated enum OneOf_ResultType: Equatable, Sendable {
     /// The result of the attribute
     case param(Spark_Connect_Expression.Literal)
     /// Evaluate a Dataset in a model and return the cached ID of summary
@@ -481,7 +481,7 @@ struct Spark_Connect_MlCommandResult: Sendable {
   }
 
   /// Represents an operator info
-  struct MlOperatorInfo: Sendable {
+  nonisolated struct MlOperatorInfo: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -539,7 +539,7 @@ struct Spark_Connect_MlCommandResult: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_Type: Equatable, Sendable {
+    nonisolated enum OneOf_Type: Equatable, Sendable {
       /// The cached object which could be a model or summary evaluated by a model
       case objRef(Spark_Connect_ObjectRef)
       /// Operator name
@@ -559,9 +559,9 @@ struct Spark_Connect_MlCommandResult: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_MlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MlCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fit\0\u{1}fetch\0\u{1}delete\0\u{1}write\0\u{1}read\0\u{1}evaluate\0\u{3}clean_cache\0\u{3}get_cache_info\0\u{3}create_summary\0\u{3}get_model_size\0")
 
@@ -764,7 +764,7 @@ extension Spark_Connect_MlCommand: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_MlCommand.Fit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.Fit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".Fit"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}estimator\0\u{1}params\0\u{1}dataset\0")
 
@@ -808,7 +808,7 @@ extension Spark_Connect_MlCommand.Fit: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_MlCommand.Delete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.Delete: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".Delete"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}obj_refs\0\u{3}evict_only\0")
 
@@ -847,7 +847,7 @@ extension Spark_Connect_MlCommand.Delete: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_MlCommand.CleanCache: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.CleanCache: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".CleanCache"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -866,7 +866,7 @@ extension Spark_Connect_MlCommand.CleanCache: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_MlCommand.GetCacheInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.GetCacheInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".GetCacheInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -885,7 +885,7 @@ extension Spark_Connect_MlCommand.GetCacheInfo: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_MlCommand.Write: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.Write: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".Write"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}operator\0\u{3}obj_ref\0\u{1}params\0\u{1}path\0\u{3}should_overwrite\0\u{1}options\0")
 
@@ -972,7 +972,7 @@ extension Spark_Connect_MlCommand.Write: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_MlCommand.Read: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.Read: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".Read"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}operator\0\u{1}path\0")
 
@@ -1011,7 +1011,7 @@ extension Spark_Connect_MlCommand.Read: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_MlCommand.Evaluate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.Evaluate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".Evaluate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}evaluator\0\u{1}params\0\u{1}dataset\0")
 
@@ -1055,7 +1055,7 @@ extension Spark_Connect_MlCommand.Evaluate: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_MlCommand.CreateSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.CreateSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".CreateSummary"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}model_ref\0\u{1}dataset\0")
 
@@ -1094,7 +1094,7 @@ extension Spark_Connect_MlCommand.CreateSummary: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_MlCommand.GetModelSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommand.GetModelSize: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommand.protoMessageName + ".GetModelSize"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}model_ref\0")
 
@@ -1128,7 +1128,7 @@ extension Spark_Connect_MlCommand.GetModelSize: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_MlCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MlCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}param\0\u{1}summary\0\u{3}operator_info\0")
 
@@ -1207,7 +1207,7 @@ extension Spark_Connect_MlCommandResult: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_MlCommandResult.MlOperatorInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlCommandResult.MlOperatorInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlCommandResult.protoMessageName + ".MlOperatorInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}obj_ref\0\u{1}name\0\u{1}uid\0\u{1}params\0\u{3}warning_message\0")
 

--- a/Sources/SparkConnect/ml_common.pb.swift
+++ b/Sources/SparkConnect/ml_common.pb.swift
@@ -31,13 +31,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// MlParams stores param settings for ML Estimator / Transformer / Evaluator
-struct Spark_Connect_MlParams: Sendable {
+nonisolated struct Spark_Connect_MlParams: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -51,7 +51,7 @@ struct Spark_Connect_MlParams: Sendable {
 }
 
 /// MLOperator represents the ML operators like (Estimator, Transformer or Evaluator)
-struct Spark_Connect_MlOperator: Sendable {
+nonisolated struct Spark_Connect_MlOperator: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -67,7 +67,7 @@ struct Spark_Connect_MlOperator: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OperatorType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum OperatorType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
 
@@ -126,7 +126,7 @@ struct Spark_Connect_MlOperator: Sendable {
 
 /// Represents a reference to the cached object which could be a model
 /// or summary evaluated by a model
-struct Spark_Connect_ObjectRef: Sendable {
+nonisolated struct Spark_Connect_ObjectRef: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -142,9 +142,9 @@ struct Spark_Connect_ObjectRef: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_MlParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlParams: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MlParams"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}params\0")
 
@@ -174,7 +174,7 @@ extension Spark_Connect_MlParams: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_MlOperator: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlOperator: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MlOperator"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}uid\0\u{1}type\0")
 
@@ -214,11 +214,11 @@ extension Spark_Connect_MlOperator: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_MlOperator.OperatorType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlOperator.OperatorType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OPERATOR_TYPE_UNSPECIFIED\0\u{1}OPERATOR_TYPE_ESTIMATOR\0\u{1}OPERATOR_TYPE_TRANSFORMER\0\u{1}OPERATOR_TYPE_EVALUATOR\0\u{1}OPERATOR_TYPE_MODEL\0")
 }
 
-extension Spark_Connect_ObjectRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ObjectRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ObjectRef"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0")
 

--- a/Sources/SparkConnect/pipelines.pb.swift
+++ b/Sources/SparkConnect/pipelines.pb.swift
@@ -31,13 +31,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// The type of output.
-enum Spark_Connect_OutputType: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Spark_Connect_OutputType: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Safe default value. Should not be used.
@@ -94,7 +94,7 @@ enum Spark_Connect_OutputType: SwiftProtobuf.Enum, Swift.CaseIterable {
 }
 
 /// Dispatch object for pipelines commands. See each individual command for documentation.
-struct Spark_Connect_PipelineCommand: Sendable {
+nonisolated struct Spark_Connect_PipelineCommand: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -187,7 +187,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_CommandType: Equatable, Sendable {
+  nonisolated enum OneOf_CommandType: Equatable, Sendable {
     case createDataflowGraph(Spark_Connect_PipelineCommand.CreateDataflowGraph)
     case defineOutput(Spark_Connect_PipelineCommand.DefineOutput)
     case defineFlow(Spark_Connect_PipelineCommand.DefineFlow)
@@ -206,7 +206,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Request to create a new dataflow graph.
-  struct CreateDataflowGraph: Sendable {
+  nonisolated struct CreateDataflowGraph: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -243,7 +243,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Drops the graph and stops any running attached flows.
-  struct DropDataflowGraph: Sendable {
+  nonisolated struct DropDataflowGraph: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -266,7 +266,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Request to define an output: a table, a materialized view, a temporary view or a sink.
-  struct DefineOutput: Sendable {
+  nonisolated struct DefineOutput: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -349,7 +349,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_Details: Equatable, Sendable {
+    nonisolated enum OneOf_Details: Equatable, Sendable {
       case tableDetails(Spark_Connect_PipelineCommand.DefineOutput.TableDetails)
       case sinkDetails(Spark_Connect_PipelineCommand.DefineOutput.SinkDetails)
       case `extension`(SwiftProtobuf.Google_Protobuf_Any)
@@ -357,7 +357,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
     }
 
     /// Metadata that's only applicable to tables and materialized views.
-    struct TableDetails: Sendable {
+    nonisolated struct TableDetails: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -403,7 +403,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       /// Schema for the table. If unset, this will be inferred from incoming flows.
-      enum OneOf_Schema: Equatable, Sendable {
+      nonisolated enum OneOf_Schema: Equatable, Sendable {
         case schemaDataType(Spark_Connect_DataType)
         case schemaString(String)
 
@@ -415,7 +415,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
     }
 
     /// Metadata that's only applicable to sinks.
-    struct SinkDetails: Sendable {
+    nonisolated struct SinkDetails: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -450,7 +450,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Request to define a flow targeting a dataset.
-  struct DefineFlow: Sendable {
+  nonisolated struct DefineFlow: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -543,14 +543,14 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_Details: Equatable, Sendable {
+    nonisolated enum OneOf_Details: Equatable, Sendable {
       case relationFlowDetails(Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails)
       case `extension`(SwiftProtobuf.Google_Protobuf_Any)
 
     }
 
     /// A flow that is that takes the contents of a relation and writes it to the target dataset.
-    struct WriteRelationFlowDetails: Sendable {
+    nonisolated struct WriteRelationFlowDetails: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -573,7 +573,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
       fileprivate var _relation: Spark_Connect_Relation? = nil
     }
 
-    struct Response: Sendable {
+    nonisolated struct Response: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -606,7 +606,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Request to execute all flows for a single output (dataset or sink) remotely.
-  struct ExecuteOutputFlows: @unchecked Sendable {
+  nonisolated struct ExecuteOutputFlows: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -662,7 +662,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
   /// Resolves all datasets and flows and start a pipeline update. Should be called after all
   /// graph elements are registered.
-  struct StartRun: Sendable {
+  nonisolated struct StartRun: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -725,7 +725,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Parses the SQL file and registers all datasets and flows.
-  struct DefineSqlGraphElements: Sendable {
+  nonisolated struct DefineSqlGraphElements: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -771,7 +771,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
   /// Request to get the stream of query function execution signals for a graph. Responses should
   /// be a stream of PipelineQueryFunctionExecutionSignal messages.
-  struct GetQueryFunctionExecutionSignalStream: Sendable {
+  nonisolated struct GetQueryFunctionExecutionSignalStream: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -806,7 +806,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 
   /// Request from the client to update the flow function evaluation result
   /// for a previously un-analyzed flow.
-  struct DefineFlowQueryFunctionResult: Sendable {
+  nonisolated struct DefineFlowQueryFunctionResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -854,7 +854,7 @@ struct Spark_Connect_PipelineCommand: Sendable {
 }
 
 /// Dispatch object for pipelines command results.
-struct Spark_Connect_PipelineCommandResult: Sendable {
+nonisolated struct Spark_Connect_PipelineCommandResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -887,14 +887,14 @@ struct Spark_Connect_PipelineCommandResult: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ResultType: Equatable, Sendable {
+  nonisolated enum OneOf_ResultType: Equatable, Sendable {
     case createDataflowGraphResult(Spark_Connect_PipelineCommandResult.CreateDataflowGraphResult)
     case defineOutputResult(Spark_Connect_PipelineCommandResult.DefineOutputResult)
     case defineFlowResult(Spark_Connect_PipelineCommandResult.DefineFlowResult)
 
   }
 
-  struct CreateDataflowGraphResult: Sendable {
+  nonisolated struct CreateDataflowGraphResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -916,7 +916,7 @@ struct Spark_Connect_PipelineCommandResult: Sendable {
     fileprivate var _dataflowGraphID: String? = nil
   }
 
-  struct DefineOutputResult: Sendable {
+  nonisolated struct DefineOutputResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -938,7 +938,7 @@ struct Spark_Connect_PipelineCommandResult: Sendable {
     fileprivate var _resolvedIdentifier: Spark_Connect_ResolvedIdentifier? = nil
   }
 
-  struct DefineFlowResult: Sendable {
+  nonisolated struct DefineFlowResult: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -964,7 +964,7 @@ struct Spark_Connect_PipelineCommandResult: Sendable {
 }
 
 /// A response containing an event emitted during the run of a pipeline.
-struct Spark_Connect_PipelineEventResult: Sendable {
+nonisolated struct Spark_Connect_PipelineEventResult: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -985,7 +985,7 @@ struct Spark_Connect_PipelineEventResult: Sendable {
   fileprivate var _event: Spark_Connect_PipelineEvent? = nil
 }
 
-struct Spark_Connect_PipelineEvent: Sendable {
+nonisolated struct Spark_Connect_PipelineEvent: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1019,7 +1019,7 @@ struct Spark_Connect_PipelineEvent: Sendable {
 }
 
 /// Source code location information associated with a particular dataset or flow.
-struct Spark_Connect_SourceCodeLocation: Sendable {
+nonisolated struct Spark_Connect_SourceCodeLocation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1071,7 +1071,7 @@ struct Spark_Connect_SourceCodeLocation: Sendable {
 
 /// A signal from the server to the client to execute the query function for one or more flows, and
 /// to register their results with the server.
-struct Spark_Connect_PipelineQueryFunctionExecutionSignal: Sendable {
+nonisolated struct Spark_Connect_PipelineQueryFunctionExecutionSignal: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1084,7 +1084,7 @@ struct Spark_Connect_PipelineQueryFunctionExecutionSignal: Sendable {
 }
 
 /// Metadata providing context about the pipeline during Spark Connect query analysis.
-struct Spark_Connect_PipelineAnalysisContext: Sendable {
+nonisolated struct Spark_Connect_PipelineAnalysisContext: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1133,13 +1133,13 @@ struct Spark_Connect_PipelineAnalysisContext: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_OutputType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_OutputType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OUTPUT_TYPE_UNSPECIFIED\0\u{1}MATERIALIZED_VIEW\0\u{1}TABLE\0\u{1}TEMPORARY_VIEW\0\u{1}SINK\0")
 }
 
-extension Spark_Connect_PipelineCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineCommand"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}create_dataflow_graph\0\u{3}define_output\0\u{3}define_flow\0\u{3}drop_dataflow_graph\0\u{3}start_run\0\u{3}define_sql_graph_elements\0\u{3}get_query_function_execution_signal_stream\0\u{3}define_flow_query_function_result\0\u{3}execute_output_flows\0\u{2}^\u{f}extension\0")
 
@@ -1342,7 +1342,7 @@ extension Spark_Connect_PipelineCommand: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_PipelineCommand.CreateDataflowGraph: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.CreateDataflowGraph: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".CreateDataflowGraph"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}default_catalog\0\u{3}default_database\0\u{4}\u{3}sql_conf\0")
 
@@ -1386,7 +1386,7 @@ extension Spark_Connect_PipelineCommand.CreateDataflowGraph: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_PipelineCommand.DropDataflowGraph: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DropDataflowGraph: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DropDataflowGraph"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0")
 
@@ -1420,7 +1420,7 @@ extension Spark_Connect_PipelineCommand.DropDataflowGraph: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineOutput: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineOutput"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}output_name\0\u{3}output_type\0\u{1}comment\0\u{3}source_code_location\0\u{3}table_details\0\u{3}sink_details\0\u{2}`\u{f}extension\0")
 
@@ -1529,7 +1529,7 @@ extension Spark_Connect_PipelineCommand.DefineOutput: SwiftProtobuf.Message, Swi
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineOutput.TableDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineOutput.TableDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.DefineOutput.protoMessageName + ".TableDetails"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_properties\0\u{3}partition_cols\0\u{1}format\0\u{3}schema_data_type\0\u{3}schema_string\0\u{3}clustering_columns\0")
 
@@ -1611,7 +1611,7 @@ extension Spark_Connect_PipelineCommand.DefineOutput.TableDetails: SwiftProtobuf
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineOutput.SinkDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineOutput.SinkDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.DefineOutput.protoMessageName + ".SinkDetails"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}options\0\u{1}format\0")
 
@@ -1650,7 +1650,7 @@ extension Spark_Connect_PipelineCommand.DefineOutput.SinkDetails: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineFlow: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlow: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineFlow"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}flow_name\0\u{3}target_dataset_name\0\u{3}sql_conf\0\u{3}client_id\0\u{3}source_code_location\0\u{3}relation_flow_details\0\u{1}once\0\u{2}_\u{f}extension\0")
 
@@ -1747,7 +1747,7 @@ extension Spark_Connect_PipelineCommand.DefineFlow: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.DefineFlow.protoMessageName + ".WriteRelationFlowDetails"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}relation\0")
 
@@ -1781,7 +1781,7 @@ extension Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails: Swi
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineFlow.Response: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.Response: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.DefineFlow.protoMessageName + ".Response"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_name\0")
 
@@ -1815,7 +1815,7 @@ extension Spark_Connect_PipelineCommand.DefineFlow.Response: SwiftProtobuf.Messa
   }
 }
 
-extension Spark_Connect_PipelineCommand.ExecuteOutputFlows: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.ExecuteOutputFlows: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".ExecuteOutputFlows"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}define_output\0\u{3}define_flows\0\u{3}full_refresh\0\u{1}storage\0\u{2}c\u{f}extension\0")
 
@@ -1913,7 +1913,7 @@ extension Spark_Connect_PipelineCommand.ExecuteOutputFlows: SwiftProtobuf.Messag
   }
 }
 
-extension Spark_Connect_PipelineCommand.StartRun: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.StartRun: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".StartRun"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}full_refresh_selection\0\u{3}full_refresh_all\0\u{3}refresh_selection\0\u{1}dry\0\u{1}storage\0")
 
@@ -1972,7 +1972,7 @@ extension Spark_Connect_PipelineCommand.StartRun: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineSqlGraphElements: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineSqlGraphElements: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineSqlGraphElements"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}sql_file_path\0\u{3}sql_text\0")
 
@@ -2016,7 +2016,7 @@ extension Spark_Connect_PipelineCommand.DefineSqlGraphElements: SwiftProtobuf.Me
   }
 }
 
-extension Spark_Connect_PipelineCommand.GetQueryFunctionExecutionSignalStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.GetQueryFunctionExecutionSignalStream: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".GetQueryFunctionExecutionSignalStream"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}client_id\0")
 
@@ -2055,7 +2055,7 @@ extension Spark_Connect_PipelineCommand.GetQueryFunctionExecutionSignalStream: S
   }
 }
 
-extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineFlowQueryFunctionResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_name\0\u{3}dataflow_graph_id\0\u{1}relation\0")
 
@@ -2099,7 +2099,7 @@ extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult: SwiftProt
   }
 }
 
-extension Spark_Connect_PipelineCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommandResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineCommandResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}create_dataflow_graph_result\0\u{3}define_output_result\0\u{3}define_flow_result\0")
 
@@ -2183,7 +2183,7 @@ extension Spark_Connect_PipelineCommandResult: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_PipelineCommandResult.CreateDataflowGraphResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommandResult.CreateDataflowGraphResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommandResult.protoMessageName + ".CreateDataflowGraphResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0")
 
@@ -2217,7 +2217,7 @@ extension Spark_Connect_PipelineCommandResult.CreateDataflowGraphResult: SwiftPr
   }
 }
 
-extension Spark_Connect_PipelineCommandResult.DefineOutputResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommandResult.DefineOutputResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommandResult.protoMessageName + ".DefineOutputResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resolved_identifier\0")
 
@@ -2251,7 +2251,7 @@ extension Spark_Connect_PipelineCommandResult.DefineOutputResult: SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_PipelineCommandResult.DefineFlowResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineCommandResult.DefineFlowResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommandResult.protoMessageName + ".DefineFlowResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resolved_identifier\0")
 
@@ -2285,7 +2285,7 @@ extension Spark_Connect_PipelineCommandResult.DefineFlowResult: SwiftProtobuf.Me
   }
 }
 
-extension Spark_Connect_PipelineEventResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineEventResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineEventResult"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}event\0")
 
@@ -2319,7 +2319,7 @@ extension Spark_Connect_PipelineEventResult: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_PipelineEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineEvent"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}timestamp\0\u{1}message\0")
 
@@ -2358,7 +2358,7 @@ extension Spark_Connect_PipelineEvent: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_SourceCodeLocation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SourceCodeLocation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SourceCodeLocation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}file_name\0\u{3}line_number\0\u{3}definition_path\0\u{2}d\u{f}extension\0")
 
@@ -2407,7 +2407,7 @@ extension Spark_Connect_SourceCodeLocation: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineQueryFunctionExecutionSignal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_names\0")
 
@@ -2437,7 +2437,7 @@ extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftProtobuf.Mess
   }
 }
 
-extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineAnalysisContext"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}definition_path\0\u{3}flow_name\0\u{2}d\u{f}extension\0")
 

--- a/Sources/SparkConnect/relations.pb.swift
+++ b/Sources/SparkConnect/relations.pb.swift
@@ -36,7 +36,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -45,7 +45,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// that has exactly one explicit relation type set.
 ///
 /// When adding new relation types, they have to be registered here.
-struct Spark_Connect_Relation: @unchecked Sendable {
+nonisolated struct Spark_Connect_Relation: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -544,7 +544,7 @@ struct Spark_Connect_Relation: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_RelType: Equatable, Sendable {
+  nonisolated enum OneOf_RelType: Equatable, Sendable {
     case read(Spark_Connect_Read)
     case project(Spark_Connect_Project)
     case filter(Spark_Connect_Filter)
@@ -619,7 +619,7 @@ struct Spark_Connect_Relation: @unchecked Sendable {
 }
 
 /// Relation to represent ML world
-struct Spark_Connect_MlRelation: @unchecked Sendable {
+nonisolated struct Spark_Connect_MlRelation: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -657,7 +657,7 @@ struct Spark_Connect_MlRelation: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_MlType: Equatable, Sendable {
+  nonisolated enum OneOf_MlType: Equatable, Sendable {
     case transform(Spark_Connect_MlRelation.Transform)
     case fetch(Spark_Connect_Fetch)
 
@@ -665,7 +665,7 @@ struct Spark_Connect_MlRelation: @unchecked Sendable {
 
   /// Relation to represent transform(input) of the operator
   /// which could be a cached model or a new transformer
-  struct Transform: @unchecked Sendable {
+  nonisolated struct Transform: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -715,7 +715,7 @@ struct Spark_Connect_MlRelation: @unchecked Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum OneOf_Operator: Equatable, Sendable {
+    nonisolated enum OneOf_Operator: Equatable, Sendable {
       /// Object reference
       case objRef(Spark_Connect_ObjectRef)
       /// Could be an ML transformer like VectorAssembler
@@ -738,7 +738,7 @@ struct Spark_Connect_MlRelation: @unchecked Sendable {
 /// Command: model.coefficients, model.summary.weightedPrecision which
 /// returns the final literal result
 /// Relation: model.summary.roc which returns a DataFrame (Relation)
-struct Spark_Connect_Fetch: Sendable {
+nonisolated struct Spark_Connect_Fetch: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -759,7 +759,7 @@ struct Spark_Connect_Fetch: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Represents a method with inclusion of method name and its arguments
-  struct Method: Sendable {
+  nonisolated struct Method: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -772,7 +772,7 @@ struct Spark_Connect_Fetch: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct Args: Sendable {
+    nonisolated struct Args: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -797,7 +797,7 @@ struct Spark_Connect_Fetch: Sendable {
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
-      enum OneOf_ArgsType: Equatable, Sendable {
+      nonisolated enum OneOf_ArgsType: Equatable, Sendable {
         case param(Spark_Connect_Expression.Literal)
         case input(Spark_Connect_Relation)
 
@@ -815,7 +815,7 @@ struct Spark_Connect_Fetch: Sendable {
 }
 
 /// Used for testing purposes only.
-struct Spark_Connect_Unknown: Sendable {
+nonisolated struct Spark_Connect_Unknown: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -826,7 +826,7 @@ struct Spark_Connect_Unknown: Sendable {
 }
 
 /// Common metadata of all relations.
-struct Spark_Connect_RelationCommon: Sendable {
+nonisolated struct Spark_Connect_RelationCommon: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -865,7 +865,7 @@ struct Spark_Connect_RelationCommon: Sendable {
 }
 
 /// Relation that uses a SQL query to generate the output.
-struct Spark_Connect_SQL: Sendable {
+nonisolated struct Spark_Connect_SQL: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -903,7 +903,7 @@ struct Spark_Connect_SQL: Sendable {
 /// (using RelationCommon.plan_id).
 ///
 /// This relation can be used to implement CTEs, describe DAGs, or to reduce tree depth.
-struct Spark_Connect_WithRelations: @unchecked Sendable {
+nonisolated struct Spark_Connect_WithRelations: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -935,7 +935,7 @@ struct Spark_Connect_WithRelations: @unchecked Sendable {
 
 /// Relation that reads from a file / table or other data source. Does not have additional
 /// inputs.
-struct Spark_Connect_Read: Sendable {
+nonisolated struct Spark_Connect_Read: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -963,13 +963,13 @@ struct Spark_Connect_Read: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_ReadType: Equatable, Sendable {
+  nonisolated enum OneOf_ReadType: Equatable, Sendable {
     case namedTable(Spark_Connect_Read.NamedTable)
     case dataSource(Spark_Connect_Read.DataSource)
 
   }
 
-  struct NamedTable: Sendable {
+  nonisolated struct NamedTable: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -985,7 +985,7 @@ struct Spark_Connect_Read: Sendable {
     init() {}
   }
 
-  struct DataSource: Sendable {
+  nonisolated struct DataSource: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1055,7 +1055,7 @@ struct Spark_Connect_Read: Sendable {
 ///
 /// The input relation must be specified.
 /// The projected expression can be an arbitrary expression.
-struct Spark_Connect_Project: @unchecked Sendable {
+nonisolated struct Spark_Connect_Project: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1087,7 +1087,7 @@ struct Spark_Connect_Project: @unchecked Sendable {
 
 /// Relation that applies a boolean expression `condition` on each row of `input` to produce
 /// the output result.
-struct Spark_Connect_Filter: @unchecked Sendable {
+nonisolated struct Spark_Connect_Filter: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1122,7 +1122,7 @@ struct Spark_Connect_Filter: @unchecked Sendable {
 /// Relation of type [[Join]].
 ///
 /// `left` and `right` must be present.
-struct Spark_Connect_Join: @unchecked Sendable {
+nonisolated struct Spark_Connect_Join: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1187,7 +1187,7 @@ struct Spark_Connect_Join: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum JoinType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum JoinType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case inner // = 1
@@ -1245,7 +1245,7 @@ struct Spark_Connect_Join: @unchecked Sendable {
 
   }
 
-  struct JoinDataType: Sendable {
+  nonisolated struct JoinDataType: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1267,7 +1267,7 @@ struct Spark_Connect_Join: @unchecked Sendable {
 }
 
 /// Relation of type [[SetOperation]]
-struct Spark_Connect_SetOperation: @unchecked Sendable {
+nonisolated struct Spark_Connect_SetOperation: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1337,7 +1337,7 @@ struct Spark_Connect_SetOperation: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum SetOpType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum SetOpType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case intersect // = 1
@@ -1385,7 +1385,7 @@ struct Spark_Connect_SetOperation: @unchecked Sendable {
 }
 
 /// Relation of type [[Limit]] that is used to `limit` rows from the input relation.
-struct Spark_Connect_Limit: @unchecked Sendable {
+nonisolated struct Spark_Connect_Limit: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1415,7 +1415,7 @@ struct Spark_Connect_Limit: @unchecked Sendable {
 
 /// Relation of type [[Offset]] that is used to read rows staring from the `offset` on
 /// the input relation.
-struct Spark_Connect_Offset: @unchecked Sendable {
+nonisolated struct Spark_Connect_Offset: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1444,7 +1444,7 @@ struct Spark_Connect_Offset: @unchecked Sendable {
 }
 
 /// Relation of type [[Tail]] that is used to fetch `limit` rows from the last of the input relation.
-struct Spark_Connect_Tail: @unchecked Sendable {
+nonisolated struct Spark_Connect_Tail: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1473,7 +1473,7 @@ struct Spark_Connect_Tail: @unchecked Sendable {
 }
 
 /// Relation of type [[Aggregate]].
-struct Spark_Connect_Aggregate: @unchecked Sendable {
+nonisolated struct Spark_Connect_Aggregate: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1524,7 +1524,7 @@ struct Spark_Connect_Aggregate: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum GroupType: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum GroupType: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case groupby // = 1
@@ -1574,7 +1574,7 @@ struct Spark_Connect_Aggregate: @unchecked Sendable {
 
   }
 
-  struct Pivot: Sendable {
+  nonisolated struct Pivot: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1602,7 +1602,7 @@ struct Spark_Connect_Aggregate: @unchecked Sendable {
     fileprivate var _col: Spark_Connect_Expression? = nil
   }
 
-  struct GroupingSets: Sendable {
+  nonisolated struct GroupingSets: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1621,7 +1621,7 @@ struct Spark_Connect_Aggregate: @unchecked Sendable {
 }
 
 /// Relation of type [[Sort]].
-struct Spark_Connect_Sort: @unchecked Sendable {
+nonisolated struct Spark_Connect_Sort: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1660,7 +1660,7 @@ struct Spark_Connect_Sort: @unchecked Sendable {
 }
 
 /// Drop specified columns.
-struct Spark_Connect_Drop: @unchecked Sendable {
+nonisolated struct Spark_Connect_Drop: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1696,7 +1696,7 @@ struct Spark_Connect_Drop: @unchecked Sendable {
 
 /// Relation of type [[Deduplicate]] which have duplicate rows removed, could consider either only
 /// the subset of columns or all the columns.
-struct Spark_Connect_Deduplicate: @unchecked Sendable {
+nonisolated struct Spark_Connect_Deduplicate: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1749,7 +1749,7 @@ struct Spark_Connect_Deduplicate: @unchecked Sendable {
 }
 
 /// A relation that does not need to be qualified by name.
-struct Spark_Connect_LocalRelation: Sendable {
+nonisolated struct Spark_Connect_LocalRelation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1789,7 +1789,7 @@ struct Spark_Connect_LocalRelation: Sendable {
 
 /// A local relation that has been cached already.
 /// CachedLocalRelation doesn't support LocalRelations of size over 2GB.
-struct Spark_Connect_CachedLocalRelation: Sendable {
+nonisolated struct Spark_Connect_CachedLocalRelation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1803,7 +1803,7 @@ struct Spark_Connect_CachedLocalRelation: Sendable {
 }
 
 /// A local relation that has been cached already.
-struct Spark_Connect_ChunkedCachedLocalRelation: Sendable {
+nonisolated struct Spark_Connect_ChunkedCachedLocalRelation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1834,7 +1834,7 @@ struct Spark_Connect_ChunkedCachedLocalRelation: Sendable {
 }
 
 /// Represents a remote relation that has been cached on server.
-struct Spark_Connect_CachedRemoteRelation: Sendable {
+nonisolated struct Spark_Connect_CachedRemoteRelation: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1848,7 +1848,7 @@ struct Spark_Connect_CachedRemoteRelation: Sendable {
 }
 
 /// Relation of type [[Sample]] that samples a fraction of the dataset.
-struct Spark_Connect_Sample: @unchecked Sendable {
+nonisolated struct Spark_Connect_Sample: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1913,7 +1913,7 @@ struct Spark_Connect_Sample: @unchecked Sendable {
 }
 
 /// Relation of type [[Range]] that generates a sequence of integers.
-struct Spark_Connect_Range: Sendable {
+nonisolated struct Spark_Connect_Range: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1954,7 +1954,7 @@ struct Spark_Connect_Range: Sendable {
 }
 
 /// Relation alias.
-struct Spark_Connect_SubqueryAlias: @unchecked Sendable {
+nonisolated struct Spark_Connect_SubqueryAlias: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1989,7 +1989,7 @@ struct Spark_Connect_SubqueryAlias: @unchecked Sendable {
 }
 
 /// Relation repartition.
-struct Spark_Connect_Repartition: @unchecked Sendable {
+nonisolated struct Spark_Connect_Repartition: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2029,7 +2029,7 @@ struct Spark_Connect_Repartition: @unchecked Sendable {
 
 /// Compose the string representing rows for output.
 /// It will invoke 'Dataset.showString' to compute the results.
-struct Spark_Connect_ShowString: @unchecked Sendable {
+nonisolated struct Spark_Connect_ShowString: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2072,7 +2072,7 @@ struct Spark_Connect_ShowString: @unchecked Sendable {
 
 /// Compose the string representing rows for output.
 /// It will invoke 'Dataset.htmlString' to compute the results.
-struct Spark_Connect_HtmlString: @unchecked Sendable {
+nonisolated struct Spark_Connect_HtmlString: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2110,7 +2110,7 @@ struct Spark_Connect_HtmlString: @unchecked Sendable {
 /// Computes specified statistics for numeric and string columns.
 /// It will invoke 'Dataset.summary' (same as 'StatFunctions.summary')
 /// to compute the results.
-struct Spark_Connect_StatSummary: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatSummary: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2154,7 +2154,7 @@ struct Spark_Connect_StatSummary: @unchecked Sendable {
 /// Computes basic statistics for numeric and string columns, including count, mean, stddev, min,
 /// and max. If no columns are given, this function computes statistics for all numerical or
 /// string columns.
-struct Spark_Connect_StatDescribe: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatDescribe: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2185,7 +2185,7 @@ struct Spark_Connect_StatDescribe: @unchecked Sendable {
 /// Computes a pair-wise frequency table of the given columns. Also known as a contingency table.
 /// It will invoke 'Dataset.stat.crosstab' (same as 'StatFunctions.crossTabulate')
 /// to compute the results.
-struct Spark_Connect_StatCrosstab: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatCrosstab: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2225,7 +2225,7 @@ struct Spark_Connect_StatCrosstab: @unchecked Sendable {
 
 /// Calculate the sample covariance of two numerical columns of a DataFrame.
 /// It will invoke 'Dataset.stat.cov' (same as 'StatFunctions.calculateCov') to compute the results.
-struct Spark_Connect_StatCov: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatCov: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2262,7 +2262,7 @@ struct Spark_Connect_StatCov: @unchecked Sendable {
 /// Calculates the correlation of two columns of a DataFrame. Currently only supports the Pearson
 /// Correlation Coefficient. It will invoke 'Dataset.stat.corr' (same as
 /// 'StatFunctions.pearsonCorrelation') to compute the results.
-struct Spark_Connect_StatCorr: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatCorr: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2311,7 +2311,7 @@ struct Spark_Connect_StatCorr: @unchecked Sendable {
 /// Calculates the approximate quantiles of numerical columns of a DataFrame.
 /// It will invoke 'Dataset.stat.approxQuantile' (same as 'StatFunctions.approxQuantile')
 /// to compute the results.
-struct Spark_Connect_StatApproxQuantile: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatApproxQuantile: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2360,7 +2360,7 @@ struct Spark_Connect_StatApproxQuantile: @unchecked Sendable {
 /// Finding frequent items for columns, possibly with false positives.
 /// It will invoke 'Dataset.stat.freqItems' (same as 'StatFunctions.freqItems')
 /// to compute the results.
-struct Spark_Connect_StatFreqItems: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatFreqItems: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2403,7 +2403,7 @@ struct Spark_Connect_StatFreqItems: @unchecked Sendable {
 /// given on each stratum.
 /// It will invoke 'Dataset.stat.freqItems' (same as 'StatFunctions.freqItems')
 /// to compute the results.
-struct Spark_Connect_StatSampleBy: @unchecked Sendable {
+nonisolated struct Spark_Connect_StatSampleBy: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2450,7 +2450,7 @@ struct Spark_Connect_StatSampleBy: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Fraction: Sendable {
+  nonisolated struct Fraction: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2489,7 +2489,7 @@ struct Spark_Connect_StatSampleBy: @unchecked Sendable {
 ///    replaces null values in specified columns.
 ///  3, 'values' contains more than 1 items, then 'cols' is required to have the same length:
 ///    replaces each specified column with corresponding value.
-struct Spark_Connect_NAFill: @unchecked Sendable {
+nonisolated struct Spark_Connect_NAFill: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2528,7 +2528,7 @@ struct Spark_Connect_NAFill: @unchecked Sendable {
 
 /// Drop rows containing null values.
 /// It will invoke 'Dataset.na.drop' (same as 'DataFrameNaFunctions.drop') to compute the results.
-struct Spark_Connect_NADrop: @unchecked Sendable {
+nonisolated struct Spark_Connect_NADrop: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2578,7 +2578,7 @@ struct Spark_Connect_NADrop: @unchecked Sendable {
 /// Replaces old values with the corresponding values.
 /// It will invoke 'Dataset.na.replace' (same as 'DataFrameNaFunctions.replace')
 /// to compute the results.
-struct Spark_Connect_NAReplace: @unchecked Sendable {
+nonisolated struct Spark_Connect_NAReplace: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2609,7 +2609,7 @@ struct Spark_Connect_NAReplace: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Replacement: Sendable {
+  nonisolated struct Replacement: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2652,7 +2652,7 @@ struct Spark_Connect_NAReplace: @unchecked Sendable {
 }
 
 /// Rename columns on the input relation by the same length of names.
-struct Spark_Connect_ToDF: @unchecked Sendable {
+nonisolated struct Spark_Connect_ToDF: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2684,7 +2684,7 @@ struct Spark_Connect_ToDF: @unchecked Sendable {
 }
 
 /// Rename columns on the input relation by a map with name to name mapping.
-struct Spark_Connect_WithColumnsRenamed: @unchecked Sendable {
+nonisolated struct Spark_Connect_WithColumnsRenamed: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2719,7 +2719,7 @@ struct Spark_Connect_WithColumnsRenamed: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Rename: Sendable {
+  nonisolated struct Rename: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2741,7 +2741,7 @@ struct Spark_Connect_WithColumnsRenamed: @unchecked Sendable {
 }
 
 /// Adding columns or replacing the existing columns that have the same names.
-struct Spark_Connect_WithColumns: @unchecked Sendable {
+nonisolated struct Spark_Connect_WithColumns: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2777,7 +2777,7 @@ struct Spark_Connect_WithColumns: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_WithWatermark: @unchecked Sendable {
+nonisolated struct Spark_Connect_WithWatermark: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2812,7 +2812,7 @@ struct Spark_Connect_WithWatermark: @unchecked Sendable {
 }
 
 /// Specify a hint over a relation. Hint should have a name and optional parameters.
-struct Spark_Connect_Hint: @unchecked Sendable {
+nonisolated struct Spark_Connect_Hint: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2851,7 +2851,7 @@ struct Spark_Connect_Hint: @unchecked Sendable {
 }
 
 /// Unpivot a DataFrame from wide format to long format, optionally leaving identifier columns set.
-struct Spark_Connect_Unpivot: @unchecked Sendable {
+nonisolated struct Spark_Connect_Unpivot: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2896,7 +2896,7 @@ struct Spark_Connect_Unpivot: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Values: Sendable {
+  nonisolated struct Values: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -2916,7 +2916,7 @@ struct Spark_Connect_Unpivot: @unchecked Sendable {
 /// Transpose a DataFrame, switching rows to columns.
 /// Transforms the DataFrame such that the values in the specified index column
 /// become the new columns of the DataFrame.
-struct Spark_Connect_Transpose: @unchecked Sendable {
+nonisolated struct Spark_Connect_Transpose: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2945,7 +2945,7 @@ struct Spark_Connect_Transpose: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_UnresolvedTableValuedFunction: Sendable {
+nonisolated struct Spark_Connect_UnresolvedTableValuedFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2961,7 +2961,7 @@ struct Spark_Connect_UnresolvedTableValuedFunction: Sendable {
   init() {}
 }
 
-struct Spark_Connect_ToSchema: @unchecked Sendable {
+nonisolated struct Spark_Connect_ToSchema: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2995,7 +2995,7 @@ struct Spark_Connect_ToSchema: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_RepartitionByExpression: @unchecked Sendable {
+nonisolated struct Spark_Connect_RepartitionByExpression: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3033,7 +3033,7 @@ struct Spark_Connect_RepartitionByExpression: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_MapPartitions: @unchecked Sendable {
+nonisolated struct Spark_Connect_MapPartitions: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3085,7 +3085,7 @@ struct Spark_Connect_MapPartitions: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_GroupMap: @unchecked Sendable {
+nonisolated struct Spark_Connect_GroupMap: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3198,7 +3198,7 @@ struct Spark_Connect_GroupMap: @unchecked Sendable {
 }
 
 /// Additional input parameters used for TransformWithState operator.
-struct Spark_Connect_TransformWithStateInfo: Sendable {
+nonisolated struct Spark_Connect_TransformWithStateInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3235,7 +3235,7 @@ struct Spark_Connect_TransformWithStateInfo: Sendable {
   fileprivate var _outputSchema: Spark_Connect_DataType? = nil
 }
 
-struct Spark_Connect_CoGroupMap: @unchecked Sendable {
+nonisolated struct Spark_Connect_CoGroupMap: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3301,7 +3301,7 @@ struct Spark_Connect_CoGroupMap: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_ApplyInPandasWithState: @unchecked Sendable {
+nonisolated struct Spark_Connect_ApplyInPandasWithState: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3363,7 +3363,7 @@ struct Spark_Connect_ApplyInPandasWithState: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_CommonInlineUserDefinedTableFunction: Sendable {
+nonisolated struct Spark_Connect_CommonInlineUserDefinedTableFunction: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3391,7 +3391,7 @@ struct Spark_Connect_CommonInlineUserDefinedTableFunction: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// (Required) Type of the user-defined table function.
-  enum OneOf_Function: Equatable, Sendable {
+  nonisolated enum OneOf_Function: Equatable, Sendable {
     case pythonUdtf(Spark_Connect_PythonUDTF)
 
   }
@@ -3399,7 +3399,7 @@ struct Spark_Connect_CommonInlineUserDefinedTableFunction: Sendable {
   init() {}
 }
 
-struct Spark_Connect_PythonUDTF: Sendable {
+nonisolated struct Spark_Connect_PythonUDTF: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3430,7 +3430,7 @@ struct Spark_Connect_PythonUDTF: Sendable {
   fileprivate var _returnType: Spark_Connect_DataType? = nil
 }
 
-struct Spark_Connect_CommonInlineUserDefinedDataSource: Sendable {
+nonisolated struct Spark_Connect_CommonInlineUserDefinedDataSource: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3452,7 +3452,7 @@ struct Spark_Connect_CommonInlineUserDefinedDataSource: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// (Required) The data source type.
-  enum OneOf_DataSource: Equatable, Sendable {
+  nonisolated enum OneOf_DataSource: Equatable, Sendable {
     case pythonDataSource(Spark_Connect_PythonDataSource)
 
   }
@@ -3460,7 +3460,7 @@ struct Spark_Connect_CommonInlineUserDefinedDataSource: Sendable {
   init() {}
 }
 
-struct Spark_Connect_PythonDataSource: Sendable {
+nonisolated struct Spark_Connect_PythonDataSource: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3477,7 +3477,7 @@ struct Spark_Connect_PythonDataSource: Sendable {
 }
 
 /// Collect arbitrary (named) metrics from a dataset.
-struct Spark_Connect_CollectMetrics: @unchecked Sendable {
+nonisolated struct Spark_Connect_CollectMetrics: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3511,7 +3511,7 @@ struct Spark_Connect_CollectMetrics: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Spark_Connect_Parse: @unchecked Sendable {
+nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3550,7 +3550,7 @@ struct Spark_Connect_Parse: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum ParseFormat: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum ParseFormat: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case csv // = 1
@@ -3596,7 +3596,7 @@ struct Spark_Connect_Parse: @unchecked Sendable {
 /// Relation of type [[AsOfJoin]].
 ///
 /// `left` and `right` must be present.
-struct Spark_Connect_AsOfJoin: @unchecked Sendable {
+nonisolated struct Spark_Connect_AsOfJoin: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3701,7 +3701,7 @@ struct Spark_Connect_AsOfJoin: @unchecked Sendable {
 /// Relation of type [[LateralJoin]].
 ///
 /// `left` and `right` must be present.
-struct Spark_Connect_LateralJoin: @unchecked Sendable {
+nonisolated struct Spark_Connect_LateralJoin: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -3751,9 +3751,9 @@ struct Spark_Connect_LateralJoin: @unchecked Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Relation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}common\0\u{1}read\0\u{1}project\0\u{1}filter\0\u{1}join\0\u{3}set_op\0\u{1}sort\0\u{1}limit\0\u{1}aggregate\0\u{1}sql\0\u{3}local_relation\0\u{1}sample\0\u{1}offset\0\u{1}deduplicate\0\u{1}range\0\u{3}subquery_alias\0\u{1}repartition\0\u{3}to_df\0\u{3}with_columns_renamed\0\u{3}show_string\0\u{1}drop\0\u{1}tail\0\u{3}with_columns\0\u{1}hint\0\u{1}unpivot\0\u{3}to_schema\0\u{3}repartition_by_expression\0\u{3}map_partitions\0\u{3}collect_metrics\0\u{1}parse\0\u{3}group_map\0\u{3}co_group_map\0\u{3}with_watermark\0\u{3}apply_in_pandas_with_state\0\u{3}html_string\0\u{3}cached_local_relation\0\u{3}cached_remote_relation\0\u{3}common_inline_user_defined_table_function\0\u{3}as_of_join\0\u{3}common_inline_user_defined_data_source\0\u{3}with_relations\0\u{1}transpose\0\u{3}unresolved_table_valued_function\0\u{3}lateral_join\0\u{3}chunked_cached_local_relation\0\u{4}-fill_na\0\u{3}drop_na\0\u{1}replace\0\u{2}\u{8}summary\0\u{1}crosstab\0\u{1}describe\0\u{1}cov\0\u{1}corr\0\u{3}approx_quantile\0\u{3}freq_items\0\u{3}sample_by\0\u{2}]\u{1}catalog\0\u{4}d\u{1}ml_relation\0\u{2}z\u{a}extension\0\u{1}unknown\0")
 
@@ -4832,7 +4832,7 @@ extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_MlRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MlRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}transform\0\u{1}fetch\0\u{3}model_summary_dataset\0")
 
@@ -4942,7 +4942,7 @@ extension Spark_Connect_MlRelation: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_MlRelation.Transform: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MlRelation.Transform: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_MlRelation.protoMessageName + ".Transform"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}obj_ref\0\u{1}transformer\0\u{1}input\0\u{1}params\0")
 
@@ -5059,7 +5059,7 @@ extension Spark_Connect_MlRelation.Transform: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_Fetch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Fetch: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Fetch"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}obj_ref\0\u{1}methods\0")
 
@@ -5098,7 +5098,7 @@ extension Spark_Connect_Fetch: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_Fetch.Method: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Fetch.Method: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Fetch.protoMessageName + ".Method"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}method\0\u{1}args\0")
 
@@ -5133,7 +5133,7 @@ extension Spark_Connect_Fetch.Method: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_Fetch.Method.Args: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Fetch.Method.Args: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Fetch.Method.protoMessageName + ".Args"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}param\0\u{1}input\0")
 
@@ -5200,7 +5200,7 @@ extension Spark_Connect_Fetch.Method.Args: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_Unknown: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Unknown: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Unknown"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -5219,7 +5219,7 @@ extension Spark_Connect_Unknown: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_RelationCommon: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RelationCommon: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RelationCommon"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}source_info\0\u{3}plan_id\0\u{1}origin\0")
 
@@ -5263,7 +5263,7 @@ extension Spark_Connect_RelationCommon: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_SQL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SQL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SQL"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}query\0\u{1}args\0\u{3}pos_args\0\u{3}named_arguments\0\u{3}pos_arguments\0")
 
@@ -5313,7 +5313,7 @@ extension Spark_Connect_SQL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension Spark_Connect_WithRelations: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WithRelations: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WithRelations"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}root\0\u{1}references\0")
 
@@ -5390,7 +5390,7 @@ extension Spark_Connect_WithRelations: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_Read: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Read: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Read"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}named_table\0\u{3}data_source\0\u{3}is_streaming\0")
 
@@ -5462,7 +5462,7 @@ extension Spark_Connect_Read: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Read.NamedTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Read.NamedTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Read.protoMessageName + ".NamedTable"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unparsed_identifier\0\u{1}options\0")
 
@@ -5497,7 +5497,7 @@ extension Spark_Connect_Read.NamedTable: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_Read.DataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Read.DataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Read.protoMessageName + ".DataSource"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}format\0\u{1}schema\0\u{1}options\0\u{1}paths\0\u{1}predicates\0\u{3}source_name\0")
 
@@ -5556,7 +5556,7 @@ extension Spark_Connect_Read.DataSource: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_Project: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Project: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Project"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{2}\u{2}expressions\0")
 
@@ -5633,7 +5633,7 @@ extension Spark_Connect_Project: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_Filter: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Filter: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Filter"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}condition\0")
 
@@ -5710,7 +5710,7 @@ extension Spark_Connect_Filter: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_Join: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Join: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Join"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}left\0\u{1}right\0\u{3}join_condition\0\u{3}join_type\0\u{3}using_columns\0\u{3}join_data_type\0")
 
@@ -5815,11 +5815,11 @@ extension Spark_Connect_Join: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Join.JoinType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Join.JoinType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0JOIN_TYPE_UNSPECIFIED\0\u{1}JOIN_TYPE_INNER\0\u{1}JOIN_TYPE_FULL_OUTER\0\u{1}JOIN_TYPE_LEFT_OUTER\0\u{1}JOIN_TYPE_RIGHT_OUTER\0\u{1}JOIN_TYPE_LEFT_ANTI\0\u{1}JOIN_TYPE_LEFT_SEMI\0\u{1}JOIN_TYPE_CROSS\0")
 }
 
-extension Spark_Connect_Join.JoinDataType: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Join.JoinDataType: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Join.protoMessageName + ".JoinDataType"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}is_left_struct\0\u{3}is_right_struct\0")
 
@@ -5854,7 +5854,7 @@ extension Spark_Connect_Join.JoinDataType: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_SetOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SetOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SetOperation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}left_input\0\u{3}right_input\0\u{3}set_op_type\0\u{3}is_all\0\u{3}by_name\0\u{3}allow_missing_columns\0")
 
@@ -5959,11 +5959,11 @@ extension Spark_Connect_SetOperation: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_SetOperation.SetOpType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SetOperation.SetOpType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SET_OP_TYPE_UNSPECIFIED\0\u{1}SET_OP_TYPE_INTERSECT\0\u{1}SET_OP_TYPE_UNION\0\u{1}SET_OP_TYPE_EXCEPT\0")
 }
 
-extension Spark_Connect_Limit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Limit: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Limit"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}limit\0")
 
@@ -6040,7 +6040,7 @@ extension Spark_Connect_Limit: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_Offset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Offset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Offset"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}offset\0")
 
@@ -6117,7 +6117,7 @@ extension Spark_Connect_Offset: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_Tail: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Tail: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Tail"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}limit\0")
 
@@ -6194,7 +6194,7 @@ extension Spark_Connect_Tail: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Aggregate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Aggregate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Aggregate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}group_type\0\u{3}grouping_expressions\0\u{3}aggregate_expressions\0\u{1}pivot\0\u{3}grouping_sets\0")
 
@@ -6299,11 +6299,11 @@ extension Spark_Connect_Aggregate: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_Aggregate.GroupType: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Aggregate.GroupType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0GROUP_TYPE_UNSPECIFIED\0\u{1}GROUP_TYPE_GROUPBY\0\u{1}GROUP_TYPE_ROLLUP\0\u{1}GROUP_TYPE_CUBE\0\u{1}GROUP_TYPE_PIVOT\0\u{1}GROUP_TYPE_GROUPING_SETS\0")
 }
 
-extension Spark_Connect_Aggregate.Pivot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Aggregate.Pivot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Aggregate.protoMessageName + ".Pivot"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}col\0\u{1}values\0")
 
@@ -6342,7 +6342,7 @@ extension Spark_Connect_Aggregate.Pivot: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_Aggregate.GroupingSets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Aggregate.GroupingSets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Aggregate.protoMessageName + ".GroupingSets"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grouping_set\0")
 
@@ -6372,7 +6372,7 @@ extension Spark_Connect_Aggregate.GroupingSets: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_Sort: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Sort: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Sort"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}order\0\u{3}is_global\0")
 
@@ -6456,7 +6456,7 @@ extension Spark_Connect_Sort: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Drop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Drop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Drop"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}columns\0\u{3}column_names\0")
 
@@ -6540,7 +6540,7 @@ extension Spark_Connect_Drop: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Deduplicate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Deduplicate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Deduplicate"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}column_names\0\u{3}all_columns_as_keys\0\u{3}within_watermark\0")
 
@@ -6631,7 +6631,7 @@ extension Spark_Connect_Deduplicate: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_LocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_LocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LocalRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}data\0\u{1}schema\0")
 
@@ -6670,7 +6670,7 @@ extension Spark_Connect_LocalRelation: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_CachedLocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CachedLocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CachedLocalRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{3}hash\0\u{b}userId\0\u{b}sessionId\0\u{c}\u{1}\u{1}\u{c}\u{2}\u{1}")
 
@@ -6700,7 +6700,7 @@ extension Spark_Connect_CachedLocalRelation: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Spark_Connect_ChunkedCachedLocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ChunkedCachedLocalRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChunkedCachedLocalRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dataHashes\0\u{1}schemaHash\0")
 
@@ -6739,7 +6739,7 @@ extension Spark_Connect_ChunkedCachedLocalRelation: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_CachedRemoteRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CachedRemoteRelation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CachedRemoteRelation"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}relation_id\0")
 
@@ -6769,7 +6769,7 @@ extension Spark_Connect_CachedRemoteRelation: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_Sample: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Sample: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Sample"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}lower_bound\0\u{3}upper_bound\0\u{3}with_replacement\0\u{1}seed\0\u{3}deterministic_order\0")
 
@@ -6874,7 +6874,7 @@ extension Spark_Connect_Sample: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_Range: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Range: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Range"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}start\0\u{1}end\0\u{1}step\0\u{3}num_partitions\0")
 
@@ -6923,7 +6923,7 @@ extension Spark_Connect_Range: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_SubqueryAlias: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_SubqueryAlias: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SubqueryAlias"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}alias\0\u{1}qualifier\0")
 
@@ -7007,7 +7007,7 @@ extension Spark_Connect_SubqueryAlias: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_Repartition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Repartition: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Repartition"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}num_partitions\0\u{1}shuffle\0")
 
@@ -7091,7 +7091,7 @@ extension Spark_Connect_Repartition: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_ShowString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ShowString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ShowString"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}num_rows\0\u{1}truncate\0\u{1}vertical\0")
 
@@ -7182,7 +7182,7 @@ extension Spark_Connect_ShowString: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_HtmlString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_HtmlString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".HtmlString"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}num_rows\0\u{1}truncate\0")
 
@@ -7266,7 +7266,7 @@ extension Spark_Connect_HtmlString: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_StatSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatSummary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatSummary"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}statistics\0")
 
@@ -7343,7 +7343,7 @@ extension Spark_Connect_StatSummary: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_StatDescribe: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatDescribe: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatDescribe"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0")
 
@@ -7420,7 +7420,7 @@ extension Spark_Connect_StatDescribe: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_StatCrosstab: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatCrosstab: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatCrosstab"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}col1\0\u{1}col2\0")
 
@@ -7504,7 +7504,7 @@ extension Spark_Connect_StatCrosstab: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_StatCov: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatCov: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatCov"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}col1\0\u{1}col2\0")
 
@@ -7588,7 +7588,7 @@ extension Spark_Connect_StatCov: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_StatCorr: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatCorr: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatCorr"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}col1\0\u{1}col2\0\u{1}method\0")
 
@@ -7679,7 +7679,7 @@ extension Spark_Connect_StatCorr: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_StatApproxQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatApproxQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatApproxQuantile"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0\u{1}probabilities\0\u{3}relative_error\0")
 
@@ -7770,7 +7770,7 @@ extension Spark_Connect_StatApproxQuantile: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_StatFreqItems: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatFreqItems: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatFreqItems"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0\u{1}support\0")
 
@@ -7854,7 +7854,7 @@ extension Spark_Connect_StatFreqItems: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_StatSampleBy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatSampleBy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StatSampleBy"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}col\0\u{1}fractions\0\u{2}\u{2}seed\0")
 
@@ -7945,7 +7945,7 @@ extension Spark_Connect_StatSampleBy: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_StatSampleBy.Fraction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_StatSampleBy.Fraction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_StatSampleBy.protoMessageName + ".Fraction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}stratum\0\u{1}fraction\0")
 
@@ -7984,7 +7984,7 @@ extension Spark_Connect_StatSampleBy.Fraction: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_NAFill: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_NAFill: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NAFill"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0\u{1}values\0")
 
@@ -8068,7 +8068,7 @@ extension Spark_Connect_NAFill: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_NADrop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_NADrop: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NADrop"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0\u{3}min_non_nulls\0")
 
@@ -8152,7 +8152,7 @@ extension Spark_Connect_NADrop: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
   }
 }
 
-extension Spark_Connect_NAReplace: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_NAReplace: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NAReplace"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}cols\0\u{1}replacements\0")
 
@@ -8236,7 +8236,7 @@ extension Spark_Connect_NAReplace: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_NAReplace.Replacement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_NAReplace.Replacement: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_NAReplace.protoMessageName + ".Replacement"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}old_value\0\u{3}new_value\0")
 
@@ -8275,7 +8275,7 @@ extension Spark_Connect_NAReplace.Replacement: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_ToDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ToDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ToDF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}column_names\0")
 
@@ -8352,7 +8352,7 @@ extension Spark_Connect_ToDF: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_WithColumnsRenamed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WithColumnsRenamed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WithColumnsRenamed"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}rename_columns_map\0\u{1}renames\0")
 
@@ -8436,7 +8436,7 @@ extension Spark_Connect_WithColumnsRenamed: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_WithColumnsRenamed.Rename: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WithColumnsRenamed.Rename: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_WithColumnsRenamed.protoMessageName + ".Rename"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}col_name\0\u{3}new_col_name\0")
 
@@ -8471,7 +8471,7 @@ extension Spark_Connect_WithColumnsRenamed.Rename: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_WithColumns: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WithColumns: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WithColumns"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}aliases\0")
 
@@ -8548,7 +8548,7 @@ extension Spark_Connect_WithColumns: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Spark_Connect_WithWatermark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_WithWatermark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WithWatermark"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}event_time\0\u{3}delay_threshold\0")
 
@@ -8632,7 +8632,7 @@ extension Spark_Connect_WithWatermark: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_Hint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Hint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Hint"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}name\0\u{1}parameters\0")
 
@@ -8716,7 +8716,7 @@ extension Spark_Connect_Hint: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 }
 
-extension Spark_Connect_Unpivot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Unpivot: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Unpivot"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}ids\0\u{1}values\0\u{3}variable_column_name\0\u{3}value_column_name\0")
 
@@ -8814,7 +8814,7 @@ extension Spark_Connect_Unpivot: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 }
 
-extension Spark_Connect_Unpivot.Values: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Unpivot.Values: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_Unpivot.protoMessageName + ".Values"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
@@ -8844,7 +8844,7 @@ extension Spark_Connect_Unpivot.Values: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_Transpose: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Transpose: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Transpose"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}index_columns\0")
 
@@ -8921,7 +8921,7 @@ extension Spark_Connect_Transpose: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 }
 
-extension Spark_Connect_UnresolvedTableValuedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_UnresolvedTableValuedFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UnresolvedTableValuedFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{1}arguments\0")
 
@@ -8956,7 +8956,7 @@ extension Spark_Connect_UnresolvedTableValuedFunction: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Spark_Connect_ToSchema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ToSchema: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ToSchema"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}schema\0")
 
@@ -9033,7 +9033,7 @@ extension Spark_Connect_ToSchema: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_RepartitionByExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_RepartitionByExpression: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RepartitionByExpression"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}partition_exprs\0\u{3}num_partitions\0")
 
@@ -9117,7 +9117,7 @@ extension Spark_Connect_RepartitionByExpression: SwiftProtobuf.Message, SwiftPro
   }
 }
 
-extension Spark_Connect_MapPartitions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_MapPartitions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MapPartitions"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}func\0\u{3}is_barrier\0\u{3}profile_id\0")
 
@@ -9208,7 +9208,7 @@ extension Spark_Connect_MapPartitions: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_GroupMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_GroupMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GroupMap"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}grouping_expressions\0\u{1}func\0\u{3}sorting_expressions\0\u{3}initial_input\0\u{3}initial_grouping_expressions\0\u{3}is_map_groups_with_state\0\u{3}output_mode\0\u{3}timeout_conf\0\u{3}state_schema\0\u{3}transform_with_state_info\0")
 
@@ -9348,7 +9348,7 @@ extension Spark_Connect_GroupMap: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_TransformWithStateInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_TransformWithStateInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TransformWithStateInfo"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_mode\0\u{3}event_time_column_name\0\u{3}output_schema\0")
 
@@ -9392,7 +9392,7 @@ extension Spark_Connect_TransformWithStateInfo: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_CoGroupMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CoGroupMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CoGroupMap"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}input_grouping_expressions\0\u{1}other\0\u{3}other_grouping_expressions\0\u{1}func\0\u{3}input_sorting_expressions\0\u{3}other_sorting_expressions\0")
 
@@ -9504,7 +9504,7 @@ extension Spark_Connect_CoGroupMap: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_ApplyInPandasWithState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_ApplyInPandasWithState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ApplyInPandasWithState"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}grouping_expressions\0\u{1}func\0\u{3}output_schema\0\u{3}state_schema\0\u{3}output_mode\0\u{3}timeout_conf\0")
 
@@ -9616,7 +9616,7 @@ extension Spark_Connect_ApplyInPandasWithState: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_CommonInlineUserDefinedTableFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CommonInlineUserDefinedTableFunction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CommonInlineUserDefinedTableFunction"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}function_name\0\u{1}deterministic\0\u{1}arguments\0\u{3}python_udtf\0")
 
@@ -9677,7 +9677,7 @@ extension Spark_Connect_CommonInlineUserDefinedTableFunction: SwiftProtobuf.Mess
   }
 }
 
-extension Spark_Connect_PythonUDTF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PythonUDTF: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PythonUDTF"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}return_type\0\u{3}eval_type\0\u{1}command\0\u{3}python_ver\0")
 
@@ -9726,7 +9726,7 @@ extension Spark_Connect_PythonUDTF: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 }
 
-extension Spark_Connect_CommonInlineUserDefinedDataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CommonInlineUserDefinedDataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CommonInlineUserDefinedDataSource"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}python_data_source\0")
 
@@ -9777,7 +9777,7 @@ extension Spark_Connect_CommonInlineUserDefinedDataSource: SwiftProtobuf.Message
   }
 }
 
-extension Spark_Connect_PythonDataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_PythonDataSource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PythonDataSource"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}command\0\u{3}python_ver\0")
 
@@ -9812,7 +9812,7 @@ extension Spark_Connect_PythonDataSource: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_CollectMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_CollectMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CollectMetrics"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}name\0\u{1}metrics\0")
 
@@ -9896,7 +9896,7 @@ extension Spark_Connect_CollectMetrics: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_Parse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Parse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Parse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}format\0\u{1}schema\0\u{1}options\0")
 
@@ -9987,11 +9987,11 @@ extension Spark_Connect_Parse: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
   }
 }
 
-extension Spark_Connect_Parse.ParseFormat: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_Parse.ParseFormat: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PARSE_FORMAT_UNSPECIFIED\0\u{1}PARSE_FORMAT_CSV\0\u{1}PARSE_FORMAT_JSON\0")
 }
 
-extension Spark_Connect_AsOfJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_AsOfJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AsOfJoin"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}left\0\u{1}right\0\u{3}left_as_of\0\u{3}right_as_of\0\u{3}join_expr\0\u{3}using_columns\0\u{3}join_type\0\u{1}tolerance\0\u{3}allow_exact_matches\0\u{1}direction\0")
 
@@ -10124,7 +10124,7 @@ extension Spark_Connect_AsOfJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_LateralJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_LateralJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LateralJoin"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}left\0\u{1}right\0\u{3}join_condition\0\u{3}join_type\0")
 

--- a/Sources/SparkConnect/types.pb.swift
+++ b/Sources/SparkConnect/types.pb.swift
@@ -31,14 +31,14 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// This message describes the logical [[DataType]] of something. It does not carry the value
 /// itself but only describes it.
-struct Spark_Connect_DataType: @unchecked Sendable {
+nonisolated struct Spark_Connect_DataType: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -282,7 +282,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_Kind: Equatable, Sendable {
+  nonisolated enum OneOf_Kind: Equatable, Sendable {
     case null(Spark_Connect_DataType.NULL)
     case binary(Spark_Connect_DataType.Binary)
     case boolean(Spark_Connect_DataType.Boolean)
@@ -322,7 +322,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
 
   }
 
-  struct Boolean: Sendable {
+  nonisolated struct Boolean: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -334,7 +334,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Byte: Sendable {
+  nonisolated struct Byte: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -346,7 +346,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Short: Sendable {
+  nonisolated struct Short: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -358,7 +358,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Integer: Sendable {
+  nonisolated struct Integer: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -370,7 +370,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Long: Sendable {
+  nonisolated struct Long: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -382,7 +382,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct FloatMessage: Sendable {
+  nonisolated struct FloatMessage: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -394,7 +394,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct DoubleMessage: Sendable {
+  nonisolated struct DoubleMessage: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -406,7 +406,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct StringMessage: Sendable {
+  nonisolated struct StringMessage: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -420,7 +420,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Binary: Sendable {
+  nonisolated struct Binary: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -432,7 +432,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct NULL: Sendable {
+  nonisolated struct NULL: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -444,7 +444,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Timestamp: Sendable {
+  nonisolated struct Timestamp: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -456,7 +456,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Date: Sendable {
+  nonisolated struct Date: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -468,7 +468,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct TimestampNTZ: Sendable {
+  nonisolated struct TimestampNTZ: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -480,7 +480,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Time: Sendable {
+  nonisolated struct Time: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -503,7 +503,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _precision: Int32? = nil
   }
 
-  struct CalendarInterval: Sendable {
+  nonisolated struct CalendarInterval: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -515,7 +515,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct YearMonthInterval: Sendable {
+  nonisolated struct YearMonthInterval: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -548,7 +548,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _endField: Int32? = nil
   }
 
-  struct DayTimeInterval: Sendable {
+  nonisolated struct DayTimeInterval: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -582,7 +582,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
   }
 
   /// Start compound types.
-  struct Char: Sendable {
+  nonisolated struct Char: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -596,7 +596,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct VarChar: Sendable {
+  nonisolated struct VarChar: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -610,7 +610,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Decimal: Sendable {
+  nonisolated struct Decimal: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -643,7 +643,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _precision: Int32? = nil
   }
 
-  struct StructField: Sendable {
+  nonisolated struct StructField: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -678,7 +678,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _metadata: String? = nil
   }
 
-  struct Struct: Sendable {
+  nonisolated struct Struct: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -692,7 +692,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Array: @unchecked Sendable {
+  nonisolated struct Array: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -723,7 +723,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Map: @unchecked Sendable {
+  nonisolated struct Map: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -763,7 +763,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Geometry: Sendable {
+  nonisolated struct Geometry: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -777,7 +777,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Geography: Sendable {
+  nonisolated struct Geography: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -791,7 +791,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct Variant: Sendable {
+  nonisolated struct Variant: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -803,7 +803,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     init() {}
   }
 
-  struct UDT: @unchecked Sendable {
+  nonisolated struct UDT: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -860,7 +860,7 @@ struct Spark_Connect_DataType: @unchecked Sendable {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  struct Unparsed: Sendable {
+  nonisolated struct Unparsed: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -880,9 +880,9 @@ struct Spark_Connect_DataType: @unchecked Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "spark.connect"
+fileprivate nonisolated let _protobuf_package = "spark.connect"
 
-extension Spark_Connect_DataType: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DataType"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}null\0\u{1}binary\0\u{1}boolean\0\u{1}byte\0\u{1}short\0\u{1}integer\0\u{1}long\0\u{1}float\0\u{1}double\0\u{1}decimal\0\u{1}string\0\u{1}char\0\u{3}var_char\0\u{1}date\0\u{1}timestamp\0\u{3}timestamp_ntz\0\u{3}calendar_interval\0\u{3}year_month_interval\0\u{3}day_time_interval\0\u{1}array\0\u{1}struct\0\u{1}map\0\u{1}udt\0\u{1}unparsed\0\u{1}variant\0\u{1}geometry\0\u{1}geography\0\u{1}time\0")
 
@@ -1427,7 +1427,7 @@ extension Spark_Connect_DataType: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-extension Spark_Connect_DataType.Boolean: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Boolean: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Boolean"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1457,7 +1457,7 @@ extension Spark_Connect_DataType.Boolean: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_DataType.Byte: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Byte: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Byte"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1487,7 +1487,7 @@ extension Spark_Connect_DataType.Byte: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.Short: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Short: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Short"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1517,7 +1517,7 @@ extension Spark_Connect_DataType.Short: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_DataType.Integer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Integer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Integer"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1547,7 +1547,7 @@ extension Spark_Connect_DataType.Integer: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_DataType.Long: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Long: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Long"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1577,7 +1577,7 @@ extension Spark_Connect_DataType.Long: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.FloatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.FloatMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Float"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1607,7 +1607,7 @@ extension Spark_Connect_DataType.FloatMessage: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_DataType.DoubleMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.DoubleMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Double"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1637,7 +1637,7 @@ extension Spark_Connect_DataType.DoubleMessage: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_DataType.StringMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.StringMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".String"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0\u{1}collation\0")
 
@@ -1672,7 +1672,7 @@ extension Spark_Connect_DataType.StringMessage: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Spark_Connect_DataType.Binary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Binary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Binary"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1702,7 +1702,7 @@ extension Spark_Connect_DataType.Binary: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_DataType.NULL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.NULL: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".NULL"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1732,7 +1732,7 @@ extension Spark_Connect_DataType.NULL: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.Timestamp: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Timestamp: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Timestamp"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1762,7 +1762,7 @@ extension Spark_Connect_DataType.Timestamp: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_DataType.Date: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Date: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Date"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1792,7 +1792,7 @@ extension Spark_Connect_DataType.Date: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.TimestampNTZ: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.TimestampNTZ: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".TimestampNTZ"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1822,7 +1822,7 @@ extension Spark_Connect_DataType.TimestampNTZ: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Spark_Connect_DataType.Time: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Time: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Time"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}precision\0\u{3}type_variation_reference\0")
 
@@ -1861,7 +1861,7 @@ extension Spark_Connect_DataType.Time: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.CalendarInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.CalendarInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".CalendarInterval"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -1891,7 +1891,7 @@ extension Spark_Connect_DataType.CalendarInterval: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Spark_Connect_DataType.YearMonthInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.YearMonthInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".YearMonthInterval"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_field\0\u{3}end_field\0\u{3}type_variation_reference\0")
 
@@ -1935,7 +1935,7 @@ extension Spark_Connect_DataType.YearMonthInterval: SwiftProtobuf.Message, Swift
   }
 }
 
-extension Spark_Connect_DataType.DayTimeInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.DayTimeInterval: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".DayTimeInterval"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}start_field\0\u{3}end_field\0\u{3}type_variation_reference\0")
 
@@ -1979,7 +1979,7 @@ extension Spark_Connect_DataType.DayTimeInterval: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Spark_Connect_DataType.Char: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Char: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Char"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}length\0\u{3}type_variation_reference\0")
 
@@ -2014,7 +2014,7 @@ extension Spark_Connect_DataType.Char: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 }
 
-extension Spark_Connect_DataType.VarChar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.VarChar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".VarChar"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}length\0\u{3}type_variation_reference\0")
 
@@ -2049,7 +2049,7 @@ extension Spark_Connect_DataType.VarChar: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_DataType.Decimal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Decimal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Decimal"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scale\0\u{1}precision\0\u{3}type_variation_reference\0")
 
@@ -2093,7 +2093,7 @@ extension Spark_Connect_DataType.Decimal: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_DataType.StructField: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.StructField: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".StructField"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}data_type\0\u{1}nullable\0\u{1}metadata\0")
 
@@ -2142,7 +2142,7 @@ extension Spark_Connect_DataType.StructField: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Spark_Connect_DataType.Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Struct"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}fields\0\u{3}type_variation_reference\0")
 
@@ -2177,7 +2177,7 @@ extension Spark_Connect_DataType.Struct: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Spark_Connect_DataType.Array: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Array: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Array"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}element_type\0\u{3}contains_null\0\u{3}type_variation_reference\0")
 
@@ -2261,7 +2261,7 @@ extension Spark_Connect_DataType.Array: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Spark_Connect_DataType.Map: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Map: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Map"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}key_type\0\u{3}value_type\0\u{3}value_contains_null\0\u{3}type_variation_reference\0")
 
@@ -2352,7 +2352,7 @@ extension Spark_Connect_DataType.Map: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_DataType.Geometry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Geometry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Geometry"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}srid\0\u{3}type_variation_reference\0")
 
@@ -2387,7 +2387,7 @@ extension Spark_Connect_DataType.Geometry: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Spark_Connect_DataType.Geography: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Geography: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Geography"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}srid\0\u{3}type_variation_reference\0")
 
@@ -2422,7 +2422,7 @@ extension Spark_Connect_DataType.Geography: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Spark_Connect_DataType.Variant: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Variant: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Variant"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}type_variation_reference\0")
 
@@ -2452,7 +2452,7 @@ extension Spark_Connect_DataType.Variant: SwiftProtobuf.Message, SwiftProtobuf._
   }
 }
 
-extension Spark_Connect_DataType.UDT: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.UDT: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".UDT"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{3}jvm_class\0\u{3}python_class\0\u{3}serialized_python_class\0\u{3}sql_type\0")
 
@@ -2550,7 +2550,7 @@ extension Spark_Connect_DataType.UDT: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Spark_Connect_DataType.Unparsed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Spark_Connect_DataType.Unparsed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_DataType.protoMessageName + ".Unparsed"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_type_string\0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to regenerate `Spark Connect`-generated Swift source code with `protoc-gen-grpc-swift-2` 2.4.0

### Why are the changes needed?

To apply new rule to generate Swift code.

- https://formulae.brew.sh/formula/protoc-gen-grpc-swift
  - https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.0 (2026-05-18)

In short, `nonisolated` keywords are added.

```
-  struct Geography: Sendable {
+  nonisolated struct Geography: Sendable {
```

Please note that I used the same Apache Spark tag which is `4.2.0-preview3` to avoid any change from Apache Spark side.
- #309

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.