### PR TITLE
[SPARK-57013] Drop Spark 3.5 Support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -208,60 +208,6 @@ jobs:
         cd -
         swift test --no-parallel -c release
 
-  integration-test-mac-spark3:
-    runs-on: macos-26
-    timeout-minutes: 20
-    env:
-      SPARK_LOCAL_IP: localhost
-    steps:
-    - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
-    - name: Install Java
-      uses: actions/setup-java@v5
-      with:
-        distribution: zulu
-        java-version: 17
-    - name: Build
-      run: swift test --filter NOTHING -c release
-    - name: Test
-      run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz?action=download
-        tar xvfz spark-3.5.8-bin-hadoop3.tgz && rm spark-3.5.8-bin-hadoop3.tgz
-        mv spark-3.5.8-bin-hadoop3 /tmp/spark
-        cd /tmp/spark/sbin
-        ./start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.8
-        cd -
-        swift test --no-parallel -c release
-
-  integration-test-mac-spark3-iceberg:
-    runs-on: macos-26
-    timeout-minutes: 20
-    env:
-      SPARK_LOCAL_IP: localhost
-      SPARK_ICEBERG_TEST_ENABLED: "true"
-    steps:
-    - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
-    - name: Install Java
-      uses: actions/setup-java@v5
-      with:
-        distribution: zulu
-        java-version: 17
-    - name: Build
-      run: swift test --filter NOTHING -c release
-    - name: Test
-      run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz?action=download
-        tar xvfz spark-3.5.8-bin-hadoop3.tgz && rm spark-3.5.8-bin-hadoop3.tgz
-        mv spark-3.5.8-bin-hadoop3 /tmp/spark
-        cd /tmp/spark/sbin
-        ./start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.8,org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.11.0 -c spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog -c spark.sql.catalog.local.type=hadoop -c spark.sql.catalog.local.warehouse=/tmp/spark/warehouse -c spark.sql.defaultCatalog=local
-        cd -
-        swift test --filter DataFrameWriterV2Tests -c release
-        swift test --filter IcebergTest -c release
-
   integration-test-mac-spark4-iceberg:
     runs-on: macos-26
     timeout-minutes: 20

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -100,7 +100,7 @@ struct SparkSessionTests {
     await SparkSession.builder.clear()
     let spark = try await SparkSession.builder.getOrCreate()
     let version = await spark.version
-    #expect(version.starts(with: "4.") || version.starts(with: "3.5."))
+    #expect(version.starts(with: "4."))
     await spark.stop()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes Apache Spark 3.5 related contents and code.

### Why are the changes needed?

According to the Apache Spark EOL policy, we drop Spark 3.5 support. Spark 3.5.x reached **the planned EOL on 2026-04-12**. The only exception is the extension to the main repository which is irrelevant to `Apache Spark Connect Swift Client` as mentioned in the website.

- https://spark.apache.org/versioning-policy.html

<img width="981" height="348" alt="Screenshot 2026-05-22 at 13 03 12" src="https://github.com/user-attachments/assets/602f66d1-20ab-4b99-a046-86aa57d9f95f" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7