### PR TITLE
[SPARK-57014] Update `Spark Connect`-generated `Swift` source code with `4.2.0-preview5`

### DIFF
--- a/Sources/SparkConnect/catalog.pb.swift
+++ b/Sources/SparkConnect/catalog.pb.swift
@@ -252,6 +252,86 @@ nonisolated struct Spark_Connect_Catalog: Sendable {
     set {catType = .listCatalogs(newValue)}
   }
 
+  var dropTable: Spark_Connect_DropTable {
+    get {
+      if case .dropTable(let v)? = catType {return v}
+      return Spark_Connect_DropTable()
+    }
+    set {catType = .dropTable(newValue)}
+  }
+
+  var dropView: Spark_Connect_DropView {
+    get {
+      if case .dropView(let v)? = catType {return v}
+      return Spark_Connect_DropView()
+    }
+    set {catType = .dropView(newValue)}
+  }
+
+  var createDatabase: Spark_Connect_CreateDatabase {
+    get {
+      if case .createDatabase(let v)? = catType {return v}
+      return Spark_Connect_CreateDatabase()
+    }
+    set {catType = .createDatabase(newValue)}
+  }
+
+  var dropDatabase: Spark_Connect_DropDatabase {
+    get {
+      if case .dropDatabase(let v)? = catType {return v}
+      return Spark_Connect_DropDatabase()
+    }
+    set {catType = .dropDatabase(newValue)}
+  }
+
+  var listPartitions: Spark_Connect_ListPartitions {
+    get {
+      if case .listPartitions(let v)? = catType {return v}
+      return Spark_Connect_ListPartitions()
+    }
+    set {catType = .listPartitions(newValue)}
+  }
+
+  var listViews: Spark_Connect_ListViews {
+    get {
+      if case .listViews(let v)? = catType {return v}
+      return Spark_Connect_ListViews()
+    }
+    set {catType = .listViews(newValue)}
+  }
+
+  var getTableProperties: Spark_Connect_GetTableProperties {
+    get {
+      if case .getTableProperties(let v)? = catType {return v}
+      return Spark_Connect_GetTableProperties()
+    }
+    set {catType = .getTableProperties(newValue)}
+  }
+
+  var getCreateTableString: Spark_Connect_GetCreateTableString {
+    get {
+      if case .getCreateTableString(let v)? = catType {return v}
+      return Spark_Connect_GetCreateTableString()
+    }
+    set {catType = .getCreateTableString(newValue)}
+  }
+
+  var truncateTable: Spark_Connect_TruncateTable {
+    get {
+      if case .truncateTable(let v)? = catType {return v}
+      return Spark_Connect_TruncateTable()
+    }
+    set {catType = .truncateTable(newValue)}
+  }
+
+  var analyzeTable: Spark_Connect_AnalyzeTable {
+    get {
+      if case .analyzeTable(let v)? = catType {return v}
+      return Spark_Connect_AnalyzeTable()
+    }
+    set {catType = .analyzeTable(newValue)}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   nonisolated enum OneOf_CatType: Equatable, Sendable {
@@ -281,6 +361,16 @@ nonisolated struct Spark_Connect_Catalog: Sendable {
     case currentCatalog(Spark_Connect_CurrentCatalog)
     case setCurrentCatalog(Spark_Connect_SetCurrentCatalog)
     case listCatalogs(Spark_Connect_ListCatalogs)
+    case dropTable(Spark_Connect_DropTable)
+    case dropView(Spark_Connect_DropView)
+    case createDatabase(Spark_Connect_CreateDatabase)
+    case dropDatabase(Spark_Connect_DropDatabase)
+    case listPartitions(Spark_Connect_ListPartitions)
+    case listViews(Spark_Connect_ListViews)
+    case getTableProperties(Spark_Connect_GetTableProperties)
+    case getCreateTableString(Spark_Connect_GetCreateTableString)
+    case truncateTable(Spark_Connect_TruncateTable)
+    case analyzeTable(Spark_Connect_AnalyzeTable)
 
   }
 
@@ -859,13 +949,191 @@ nonisolated struct Spark_Connect_ListCatalogs: Sendable {
   fileprivate var _pattern: String? = nil
 }
 
+/// See `spark.catalog.dropTable`
+nonisolated struct Spark_Connect_DropTable: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var ifExists: Bool = false
+
+  var purge: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.dropView`
+nonisolated struct Spark_Connect_DropView: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var viewName: String = String()
+
+  var ifExists: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.createDatabase`
+nonisolated struct Spark_Connect_CreateDatabase: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var dbName: String = String()
+
+  var ifNotExists: Bool = false
+
+  var properties: Dictionary<String,String> = [:]
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.dropDatabase`
+nonisolated struct Spark_Connect_DropDatabase: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var dbName: String = String()
+
+  var ifExists: Bool = false
+
+  var cascade: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.listPartitions`
+nonisolated struct Spark_Connect_ListPartitions: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.listViews`
+nonisolated struct Spark_Connect_ListViews: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Optional)
+  var dbName: String {
+    get {_dbName ?? String()}
+    set {_dbName = newValue}
+  }
+  /// Returns true if `dbName` has been explicitly set.
+  var hasDbName: Bool {self._dbName != nil}
+  /// Clears the value of `dbName`. Subsequent reads from it will return its default value.
+  mutating func clearDbName() {self._dbName = nil}
+
+  /// (Optional) The pattern that the view name needs to match
+  var pattern: String {
+    get {_pattern ?? String()}
+    set {_pattern = newValue}
+  }
+  /// Returns true if `pattern` has been explicitly set.
+  var hasPattern: Bool {self._pattern != nil}
+  /// Clears the value of `pattern`. Subsequent reads from it will return its default value.
+  mutating func clearPattern() {self._pattern = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _dbName: String? = nil
+  fileprivate var _pattern: String? = nil
+}
+
+/// See `spark.catalog.getTableProperties`
+nonisolated struct Spark_Connect_GetTableProperties: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.getCreateTableString`
+nonisolated struct Spark_Connect_GetCreateTableString: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var asSerde: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.truncateTable`
+nonisolated struct Spark_Connect_TruncateTable: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+/// See `spark.catalog.analyzeTable`
+nonisolated struct Spark_Connect_AnalyzeTable: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required)
+  var tableName: String = String()
+
+  var noScan: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate nonisolated let _protobuf_package = "spark.connect"
 
 nonisolated extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Catalog"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_database\0\u{3}set_current_database\0\u{3}list_databases\0\u{3}list_tables\0\u{3}list_functions\0\u{3}list_columns\0\u{3}get_database\0\u{3}get_table\0\u{3}get_function\0\u{3}database_exists\0\u{3}table_exists\0\u{3}function_exists\0\u{3}create_external_table\0\u{3}create_table\0\u{3}drop_temp_view\0\u{3}drop_global_temp_view\0\u{3}recover_partitions\0\u{3}is_cached\0\u{3}cache_table\0\u{3}uncache_table\0\u{3}clear_cache\0\u{3}refresh_table\0\u{3}refresh_by_path\0\u{3}current_catalog\0\u{3}set_current_catalog\0\u{3}list_catalogs\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}current_database\0\u{3}set_current_database\0\u{3}list_databases\0\u{3}list_tables\0\u{3}list_functions\0\u{3}list_columns\0\u{3}get_database\0\u{3}get_table\0\u{3}get_function\0\u{3}database_exists\0\u{3}table_exists\0\u{3}function_exists\0\u{3}create_external_table\0\u{3}create_table\0\u{3}drop_temp_view\0\u{3}drop_global_temp_view\0\u{3}recover_partitions\0\u{3}is_cached\0\u{3}cache_table\0\u{3}uncache_table\0\u{3}clear_cache\0\u{3}refresh_table\0\u{3}refresh_by_path\0\u{3}current_catalog\0\u{3}set_current_catalog\0\u{3}list_catalogs\0\u{3}drop_table\0\u{3}drop_view\0\u{3}create_database\0\u{3}drop_database\0\u{3}list_partitions\0\u{3}list_views\0\u{3}get_table_properties\0\u{3}get_create_table_string\0\u{3}truncate_table\0\u{3}analyze_table\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1211,6 +1479,136 @@ nonisolated extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobu
           self.catType = .listCatalogs(v)
         }
       }()
+      case 27: try {
+        var v: Spark_Connect_DropTable?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .dropTable(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .dropTable(v)
+        }
+      }()
+      case 28: try {
+        var v: Spark_Connect_DropView?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .dropView(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .dropView(v)
+        }
+      }()
+      case 29: try {
+        var v: Spark_Connect_CreateDatabase?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .createDatabase(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .createDatabase(v)
+        }
+      }()
+      case 30: try {
+        var v: Spark_Connect_DropDatabase?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .dropDatabase(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .dropDatabase(v)
+        }
+      }()
+      case 31: try {
+        var v: Spark_Connect_ListPartitions?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .listPartitions(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .listPartitions(v)
+        }
+      }()
+      case 32: try {
+        var v: Spark_Connect_ListViews?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .listViews(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .listViews(v)
+        }
+      }()
+      case 33: try {
+        var v: Spark_Connect_GetTableProperties?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .getTableProperties(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .getTableProperties(v)
+        }
+      }()
+      case 34: try {
+        var v: Spark_Connect_GetCreateTableString?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .getCreateTableString(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .getCreateTableString(v)
+        }
+      }()
+      case 35: try {
+        var v: Spark_Connect_TruncateTable?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .truncateTable(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .truncateTable(v)
+        }
+      }()
+      case 36: try {
+        var v: Spark_Connect_AnalyzeTable?
+        var hadOneofValue = false
+        if let current = self.catType {
+          hadOneofValue = true
+          if case .analyzeTable(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.catType = .analyzeTable(v)
+        }
+      }()
       default: break
       }
     }
@@ -1325,6 +1723,46 @@ nonisolated extension Spark_Connect_Catalog: SwiftProtobuf.Message, SwiftProtobu
     case .listCatalogs?: try {
       guard case .listCatalogs(let v)? = self.catType else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 26)
+    }()
+    case .dropTable?: try {
+      guard case .dropTable(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 27)
+    }()
+    case .dropView?: try {
+      guard case .dropView(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 28)
+    }()
+    case .createDatabase?: try {
+      guard case .createDatabase(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 29)
+    }()
+    case .dropDatabase?: try {
+      guard case .dropDatabase(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 30)
+    }()
+    case .listPartitions?: try {
+      guard case .listPartitions(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 31)
+    }()
+    case .listViews?: try {
+      guard case .listViews(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 32)
+    }()
+    case .getTableProperties?: try {
+      guard case .getTableProperties(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 33)
+    }()
+    case .getCreateTableString?: try {
+      guard case .getCreateTableString(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 34)
+    }()
+    case .truncateTable?: try {
+      guard case .truncateTable(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 35)
+    }()
+    case .analyzeTable?: try {
+      guard case .analyzeTable(let v)? = self.catType else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 36)
     }()
     case nil: break
     }
@@ -2213,6 +2651,360 @@ nonisolated extension Spark_Connect_ListCatalogs: SwiftProtobuf.Message, SwiftPr
 
   static func ==(lhs: Spark_Connect_ListCatalogs, rhs: Spark_Connect_ListCatalogs) -> Bool {
     if lhs._pattern != rhs._pattern {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_DropTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".DropTable"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}if_exists\0\u{1}purge\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.ifExists) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.purge) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    if self.ifExists != false {
+      try visitor.visitSingularBoolField(value: self.ifExists, fieldNumber: 2)
+    }
+    if self.purge != false {
+      try visitor.visitSingularBoolField(value: self.purge, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_DropTable, rhs: Spark_Connect_DropTable) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.ifExists != rhs.ifExists {return false}
+    if lhs.purge != rhs.purge {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_DropView: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".DropView"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}view_name\0\u{3}if_exists\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.viewName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.ifExists) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.viewName.isEmpty {
+      try visitor.visitSingularStringField(value: self.viewName, fieldNumber: 1)
+    }
+    if self.ifExists != false {
+      try visitor.visitSingularBoolField(value: self.ifExists, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_DropView, rhs: Spark_Connect_DropView) -> Bool {
+    if lhs.viewName != rhs.viewName {return false}
+    if lhs.ifExists != rhs.ifExists {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_CreateDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".CreateDatabase"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0\u{3}if_not_exists\0\u{1}properties\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dbName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.ifNotExists) }()
+      case 3: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.properties) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dbName.isEmpty {
+      try visitor.visitSingularStringField(value: self.dbName, fieldNumber: 1)
+    }
+    if self.ifNotExists != false {
+      try visitor.visitSingularBoolField(value: self.ifNotExists, fieldNumber: 2)
+    }
+    if !self.properties.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.properties, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_CreateDatabase, rhs: Spark_Connect_CreateDatabase) -> Bool {
+    if lhs.dbName != rhs.dbName {return false}
+    if lhs.ifNotExists != rhs.ifNotExists {return false}
+    if lhs.properties != rhs.properties {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_DropDatabase: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".DropDatabase"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0\u{3}if_exists\0\u{1}cascade\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dbName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.ifExists) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.cascade) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dbName.isEmpty {
+      try visitor.visitSingularStringField(value: self.dbName, fieldNumber: 1)
+    }
+    if self.ifExists != false {
+      try visitor.visitSingularBoolField(value: self.ifExists, fieldNumber: 2)
+    }
+    if self.cascade != false {
+      try visitor.visitSingularBoolField(value: self.cascade, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_DropDatabase, rhs: Spark_Connect_DropDatabase) -> Bool {
+    if lhs.dbName != rhs.dbName {return false}
+    if lhs.ifExists != rhs.ifExists {return false}
+    if lhs.cascade != rhs.cascade {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_ListPartitions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".ListPartitions"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_ListPartitions, rhs: Spark_Connect_ListPartitions) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_ListViews: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".ListViews"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}db_name\0\u{1}pattern\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._dbName) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._pattern) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._dbName {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    } }()
+    try { if let v = self._pattern {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_ListViews, rhs: Spark_Connect_ListViews) -> Bool {
+    if lhs._dbName != rhs._dbName {return false}
+    if lhs._pattern != rhs._pattern {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_GetTableProperties: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".GetTableProperties"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_GetTableProperties, rhs: Spark_Connect_GetTableProperties) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_GetCreateTableString: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".GetCreateTableString"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}as_serde\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.asSerde) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    if self.asSerde != false {
+      try visitor.visitSingularBoolField(value: self.asSerde, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_GetCreateTableString, rhs: Spark_Connect_GetCreateTableString) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.asSerde != rhs.asSerde {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_TruncateTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".TruncateTable"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_TruncateTable, rhs: Spark_Connect_TruncateTable) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_AnalyzeTable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AnalyzeTable"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}table_name\0\u{3}no_scan\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.tableName) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.noScan) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.tableName.isEmpty {
+      try visitor.visitSingularStringField(value: self.tableName, fieldNumber: 1)
+    }
+    if self.noScan != false {
+      try visitor.visitSingularBoolField(value: self.noScan, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_AnalyzeTable, rhs: Spark_Connect_AnalyzeTable) -> Bool {
+    if lhs.tableName != rhs.tableName {return false}
+    if lhs.noScan != rhs.noScan {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SparkConnect/pipelines.pb.swift
+++ b/Sources/SparkConnect/pipelines.pb.swift
@@ -811,7 +811,11 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
-    /// The fully qualified name of the flow being updated.
+    /// (Deprecated) The fully qualified name of the flow being updated.
+    ///
+    /// This field is deprecated since Spark 4.2+. Use flow_identifier field instead.
+    ///
+    /// NOTE: This field was marked as deprecated in the .proto file.
     var flowName: String {
       get {_flowName ?? String()}
       set {_flowName = newValue}
@@ -820,6 +824,16 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
     var hasFlowName: Bool {self._flowName != nil}
     /// Clears the value of `flowName`. Subsequent reads from it will return its default value.
     mutating func clearFlowName() {self._flowName = nil}
+
+    /// The fully qualified identifier of the flow being updated.
+    var flowIdentifier: Spark_Connect_ResolvedIdentifier {
+      get {_flowIdentifier ?? Spark_Connect_ResolvedIdentifier()}
+      set {_flowIdentifier = newValue}
+    }
+    /// Returns true if `flowIdentifier` has been explicitly set.
+    var hasFlowIdentifier: Bool {self._flowIdentifier != nil}
+    /// Clears the value of `flowIdentifier`. Subsequent reads from it will return its default value.
+    mutating func clearFlowIdentifier() {self._flowIdentifier = nil}
 
     /// The ID of the graph this flow belongs to.
     var dataflowGraphID: String {
@@ -846,6 +860,7 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
     init() {}
 
     fileprivate var _flowName: String? = nil
+    fileprivate var _flowIdentifier: Spark_Connect_ResolvedIdentifier? = nil
     fileprivate var _dataflowGraphID: String? = nil
     fileprivate var _relation: Spark_Connect_Relation? = nil
   }
@@ -1076,7 +1091,15 @@ nonisolated struct Spark_Connect_PipelineQueryFunctionExecutionSignal: Sendable 
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// (Deprecated) The name of flows that are ready to be re-evaluated.
+  ///
+  /// This field is deprecated since Spark 4.2+. Use flow_identifiers field instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var flowNames: [String] = []
+
+  /// The identifier of flows that are ready to be re-evaluated
+  var flowIdentifiers: [Spark_Connect_ResolvedIdentifier] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1109,7 +1132,11 @@ nonisolated struct Spark_Connect_PipelineAnalysisContext: Sendable {
   /// Clears the value of `definitionPath`. Subsequent reads from it will return its default value.
   mutating func clearDefinitionPath() {self._definitionPath = nil}
 
-  /// The name of the Flow involved in this analysis
+  /// (Deprecated) The name of the Flow involved in this analysis
+  ///
+  /// This field is deprecated since Spark 4.2+. Use flow_identifier field instead.
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   var flowName: String {
     get {_flowName ?? String()}
     set {_flowName = newValue}
@@ -1118,6 +1145,16 @@ nonisolated struct Spark_Connect_PipelineAnalysisContext: Sendable {
   var hasFlowName: Bool {self._flowName != nil}
   /// Clears the value of `flowName`. Subsequent reads from it will return its default value.
   mutating func clearFlowName() {self._flowName = nil}
+
+  /// The identifier of the Flow involved in this analysis
+  var flowIdentifier: Spark_Connect_ResolvedIdentifier {
+    get {_flowIdentifier ?? Spark_Connect_ResolvedIdentifier()}
+    set {_flowIdentifier = newValue}
+  }
+  /// Returns true if `flowIdentifier` has been explicitly set.
+  var hasFlowIdentifier: Bool {self._flowIdentifier != nil}
+  /// Clears the value of `flowIdentifier`. Subsequent reads from it will return its default value.
+  mutating func clearFlowIdentifier() {self._flowIdentifier = nil}
 
   /// Reserved field for protocol extensions.
   var `extension`: [SwiftProtobuf.Google_Protobuf_Any] = []
@@ -1129,6 +1166,7 @@ nonisolated struct Spark_Connect_PipelineAnalysisContext: Sendable {
   fileprivate var _dataflowGraphID: String? = nil
   fileprivate var _definitionPath: String? = nil
   fileprivate var _flowName: String? = nil
+  fileprivate var _flowIdentifier: Spark_Connect_ResolvedIdentifier? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -2057,7 +2095,7 @@ nonisolated extension Spark_Connect_PipelineCommand.GetQueryFunctionExecutionSig
 
 nonisolated extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineFlowQueryFunctionResult"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_name\0\u{3}dataflow_graph_id\0\u{1}relation\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_name\0\u{3}dataflow_graph_id\0\u{1}relation\0\u{3}flow_identifier\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2068,6 +2106,7 @@ nonisolated extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResul
       case 1: try { try decoder.decodeSingularStringField(value: &self._flowName) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._dataflowGraphID) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._relation) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._flowIdentifier) }()
       default: break
       }
     }
@@ -2087,11 +2126,15 @@ nonisolated extension Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResul
     try { if let v = self._relation {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._flowIdentifier {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult, rhs: Spark_Connect_PipelineCommand.DefineFlowQueryFunctionResult) -> Bool {
     if lhs._flowName != rhs._flowName {return false}
+    if lhs._flowIdentifier != rhs._flowIdentifier {return false}
     if lhs._dataflowGraphID != rhs._dataflowGraphID {return false}
     if lhs._relation != rhs._relation {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -2409,7 +2452,7 @@ nonisolated extension Spark_Connect_SourceCodeLocation: SwiftProtobuf.Message, S
 
 nonisolated extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineQueryFunctionExecutionSignal"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_names\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}flow_names\0\u{3}flow_identifiers\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2418,6 +2461,7 @@ nonisolated extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftP
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeRepeatedStringField(value: &self.flowNames) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.flowIdentifiers) }()
       default: break
       }
     }
@@ -2427,11 +2471,15 @@ nonisolated extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftP
     if !self.flowNames.isEmpty {
       try visitor.visitRepeatedStringField(value: self.flowNames, fieldNumber: 1)
     }
+    if !self.flowIdentifiers.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.flowIdentifiers, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Spark_Connect_PipelineQueryFunctionExecutionSignal, rhs: Spark_Connect_PipelineQueryFunctionExecutionSignal) -> Bool {
     if lhs.flowNames != rhs.flowNames {return false}
+    if lhs.flowIdentifiers != rhs.flowIdentifiers {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2439,7 +2487,7 @@ nonisolated extension Spark_Connect_PipelineQueryFunctionExecutionSignal: SwiftP
 
 nonisolated extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PipelineAnalysisContext"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}definition_path\0\u{3}flow_name\0\u{2}d\u{f}extension\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}definition_path\0\u{3}flow_name\0\u{3}flow_identifier\0\u{2}c\u{f}extension\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2450,6 +2498,7 @@ nonisolated extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Messa
       case 1: try { try decoder.decodeSingularStringField(value: &self._dataflowGraphID) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._definitionPath) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self._flowName) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._flowIdentifier) }()
       case 999: try { try decoder.decodeRepeatedMessageField(value: &self.`extension`) }()
       default: break
       }
@@ -2470,6 +2519,9 @@ nonisolated extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Messa
     try { if let v = self._flowName {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     } }()
+    try { if let v = self._flowIdentifier {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     if !self.`extension`.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.`extension`, fieldNumber: 999)
     }
@@ -2480,6 +2532,7 @@ nonisolated extension Spark_Connect_PipelineAnalysisContext: SwiftProtobuf.Messa
     if lhs._dataflowGraphID != rhs._dataflowGraphID {return false}
     if lhs._definitionPath != rhs._definitionPath {return false}
     if lhs._flowName != rhs._flowName {return false}
+    if lhs._flowIdentifier != rhs._flowIdentifier {return false}
     if lhs.`extension` != rhs.`extension` {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Sources/SparkConnect/relations.pb.swift
+++ b/Sources/SparkConnect/relations.pb.swift
@@ -416,6 +416,14 @@ nonisolated struct Spark_Connect_Relation: @unchecked Sendable {
     set {_uniqueStorage()._relType = .chunkedCachedLocalRelation(newValue)}
   }
 
+  var relationChanges: Spark_Connect_RelationChanges {
+    get {
+      if case .relationChanges(let v)? = _storage._relType {return v}
+      return Spark_Connect_RelationChanges()
+    }
+    set {_uniqueStorage()._relType = .relationChanges(newValue)}
+  }
+
   /// NA functions
   var fillNa: Spark_Connect_NAFill {
     get {
@@ -589,6 +597,7 @@ nonisolated struct Spark_Connect_Relation: @unchecked Sendable {
     case unresolvedTableValuedFunction(Spark_Connect_UnresolvedTableValuedFunction)
     case lateralJoin(Spark_Connect_LateralJoin)
     case chunkedCachedLocalRelation(Spark_Connect_ChunkedCachedLocalRelation)
+    case relationChanges(Spark_Connect_RelationChanges)
     /// NA functions
     case fillNa(Spark_Connect_NAFill)
     case dropNa(Spark_Connect_NADrop)
@@ -1047,6 +1056,33 @@ nonisolated struct Spark_Connect_Read: Sendable {
     fileprivate var _schema: String? = nil
     fileprivate var _sourceName: String? = nil
   }
+
+  init() {}
+}
+
+/// Reads Change Data Capture (CDC) changes for a named table.
+///
+/// This corresponds to the `DataFrameReader.changes()` or `DataStreamReader.changes()` API.
+/// CDC-specific options (startingVersion, endingVersion, startingTimestamp, endingTimestamp,
+/// deduplicationMode, computeUpdates, etc.) are passed in the options map.
+nonisolated struct Spark_Connect_RelationChanges: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required) Unparsed identifier for the table.
+  var unparsedIdentifier: String = String()
+
+  /// Options for the CDC query. The map key is case insensitive.
+  /// Supported keys include: startingVersion, endingVersion, startingTimestamp,
+  /// endingTimestamp, deduplicationMode, computeUpdates, startingBoundInclusive,
+  /// endingBoundInclusive.
+  var options: Dictionary<String,String> = [:]
+
+  /// (Optional) Indicates if this is a streaming CDC read.
+  var isStreaming: Bool = false
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 }
@@ -3542,7 +3578,7 @@ nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
   /// Clears the value of `schema`. Subsequent reads from it will return its default value.
   mutating func clearSchema() {_uniqueStorage()._schema = nil}
 
-  /// Options for the csv/json parser. The map key is case insensitive.
+  /// Options for the csv/json/xml parser. The map key is case insensitive.
   var options: Dictionary<String,String> {
     get {_storage._options}
     set {_uniqueStorage()._options = newValue}
@@ -3555,6 +3591,7 @@ nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
     case unspecified // = 0
     case csv // = 1
     case json // = 2
+    case xml // = 3
     case UNRECOGNIZED(Int)
 
     init() {
@@ -3566,6 +3603,7 @@ nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
       case 0: self = .unspecified
       case 1: self = .csv
       case 2: self = .json
+      case 3: self = .xml
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
@@ -3575,6 +3613,7 @@ nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
       case .unspecified: return 0
       case .csv: return 1
       case .json: return 2
+      case .xml: return 3
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -3584,6 +3623,7 @@ nonisolated struct Spark_Connect_Parse: @unchecked Sendable {
       .unspecified,
       .csv,
       .json,
+      .xml,
     ]
 
   }
@@ -3755,7 +3795,7 @@ fileprivate nonisolated let _protobuf_package = "spark.connect"
 
 nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Relation"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}common\0\u{1}read\0\u{1}project\0\u{1}filter\0\u{1}join\0\u{3}set_op\0\u{1}sort\0\u{1}limit\0\u{1}aggregate\0\u{1}sql\0\u{3}local_relation\0\u{1}sample\0\u{1}offset\0\u{1}deduplicate\0\u{1}range\0\u{3}subquery_alias\0\u{1}repartition\0\u{3}to_df\0\u{3}with_columns_renamed\0\u{3}show_string\0\u{1}drop\0\u{1}tail\0\u{3}with_columns\0\u{1}hint\0\u{1}unpivot\0\u{3}to_schema\0\u{3}repartition_by_expression\0\u{3}map_partitions\0\u{3}collect_metrics\0\u{1}parse\0\u{3}group_map\0\u{3}co_group_map\0\u{3}with_watermark\0\u{3}apply_in_pandas_with_state\0\u{3}html_string\0\u{3}cached_local_relation\0\u{3}cached_remote_relation\0\u{3}common_inline_user_defined_table_function\0\u{3}as_of_join\0\u{3}common_inline_user_defined_data_source\0\u{3}with_relations\0\u{1}transpose\0\u{3}unresolved_table_valued_function\0\u{3}lateral_join\0\u{3}chunked_cached_local_relation\0\u{4}-fill_na\0\u{3}drop_na\0\u{1}replace\0\u{2}\u{8}summary\0\u{1}crosstab\0\u{1}describe\0\u{1}cov\0\u{1}corr\0\u{3}approx_quantile\0\u{3}freq_items\0\u{3}sample_by\0\u{2}]\u{1}catalog\0\u{4}d\u{1}ml_relation\0\u{2}z\u{a}extension\0\u{1}unknown\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}common\0\u{1}read\0\u{1}project\0\u{1}filter\0\u{1}join\0\u{3}set_op\0\u{1}sort\0\u{1}limit\0\u{1}aggregate\0\u{1}sql\0\u{3}local_relation\0\u{1}sample\0\u{1}offset\0\u{1}deduplicate\0\u{1}range\0\u{3}subquery_alias\0\u{1}repartition\0\u{3}to_df\0\u{3}with_columns_renamed\0\u{3}show_string\0\u{1}drop\0\u{1}tail\0\u{3}with_columns\0\u{1}hint\0\u{1}unpivot\0\u{3}to_schema\0\u{3}repartition_by_expression\0\u{3}map_partitions\0\u{3}collect_metrics\0\u{1}parse\0\u{3}group_map\0\u{3}co_group_map\0\u{3}with_watermark\0\u{3}apply_in_pandas_with_state\0\u{3}html_string\0\u{3}cached_local_relation\0\u{3}cached_remote_relation\0\u{3}common_inline_user_defined_table_function\0\u{3}as_of_join\0\u{3}common_inline_user_defined_data_source\0\u{3}with_relations\0\u{1}transpose\0\u{3}unresolved_table_valued_function\0\u{3}lateral_join\0\u{3}chunked_cached_local_relation\0\u{3}relation_changes\0\u{4},fill_na\0\u{3}drop_na\0\u{1}replace\0\u{2}\u{8}summary\0\u{1}crosstab\0\u{1}describe\0\u{1}cov\0\u{1}corr\0\u{3}approx_quantile\0\u{3}freq_items\0\u{3}sample_by\0\u{2}]\u{1}catalog\0\u{4}d\u{1}ml_relation\0\u{2}z\u{a}extension\0\u{1}unknown\0")
 
   fileprivate class _StorageClass {
     var _common: Spark_Connect_RelationCommon? = nil
@@ -4363,6 +4403,19 @@ nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtob
             _storage._relType = .chunkedCachedLocalRelation(v)
           }
         }()
+        case 46: try {
+          var v: Spark_Connect_RelationChanges?
+          var hadOneofValue = false
+          if let current = _storage._relType {
+            hadOneofValue = true
+            if case .relationChanges(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._relType = .relationChanges(v)
+          }
+        }()
         case 90: try {
           var v: Spark_Connect_NAFill?
           var hadOneofValue = false
@@ -4749,6 +4802,10 @@ nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtob
       case .chunkedCachedLocalRelation?: try {
         guard case .chunkedCachedLocalRelation(let v)? = _storage._relType else { preconditionFailure() }
         try visitor.visitSingularMessageField(value: v, fieldNumber: 45)
+      }()
+      case .relationChanges?: try {
+        guard case .relationChanges(let v)? = _storage._relType else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 46)
       }()
       case .fillNa?: try {
         guard case .fillNa(let v)? = _storage._relType else { preconditionFailure() }
@@ -5551,6 +5608,46 @@ nonisolated extension Spark_Connect_Read.DataSource: SwiftProtobuf.Message, Swif
     if lhs.paths != rhs.paths {return false}
     if lhs.predicates != rhs.predicates {return false}
     if lhs._sourceName != rhs._sourceName {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_RelationChanges: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".RelationChanges"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unparsed_identifier\0\u{1}options\0\u{3}is_streaming\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.unparsedIdentifier) }()
+      case 2: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.options) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.isStreaming) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.unparsedIdentifier.isEmpty {
+      try visitor.visitSingularStringField(value: self.unparsedIdentifier, fieldNumber: 1)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.options, fieldNumber: 2)
+    }
+    if self.isStreaming != false {
+      try visitor.visitSingularBoolField(value: self.isStreaming, fieldNumber: 3)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_RelationChanges, rhs: Spark_Connect_RelationChanges) -> Bool {
+    if lhs.unparsedIdentifier != rhs.unparsedIdentifier {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs.isStreaming != rhs.isStreaming {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9988,7 +10085,7 @@ nonisolated extension Spark_Connect_Parse: SwiftProtobuf.Message, SwiftProtobuf.
 }
 
 nonisolated extension Spark_Connect_Parse.ParseFormat: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PARSE_FORMAT_UNSPECIFIED\0\u{1}PARSE_FORMAT_CSV\0\u{1}PARSE_FORMAT_JSON\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PARSE_FORMAT_UNSPECIFIED\0\u{1}PARSE_FORMAT_CSV\0\u{1}PARSE_FORMAT_JSON\0\u{1}PARSE_FORMAT_XML\0")
 }
 
 nonisolated extension Spark_Connect_AsOfJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `Spark Connect`-generated Swift source code by regenerating with `4.2.0-preview5`.

- apache/spark#54740
- apache/spark#55025
- apache/spark#55139
- apache/spark#55332

### Why are the changes needed?

To keep the generated Swift source code in sync with Apache Spark `4.2.0-preview5` protobuf definitions and the latest `grpc-swift`/`swift-protobuf` code generators.

```
$ git clone -b v4.2.0-preview5 https://github.com/apache/spark.git
$ cd spark/sql/connect/common/src/main/protobuf/
$ protoc --swift_out=. spark/connect/*.proto
$ protoc --grpc-swift_out=. spark/connect/*.proto

// Remove empty GRPC files
$ cd spark/connect
$ grep 'This file contained no services' * | awk -F: '{print $1}' | xargs rm
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7