### PR TITLE
[SPARK-57044] Support `(create|drop)Database` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -161,6 +161,54 @@ public actor Catalog: Sendable {
     try await df.count()
   }
 
+  /// Creates a database with the specified name.
+  /// - Parameters:
+  ///   - dbName: name of the database to create.
+  ///   - ifNotExists: if true, no error is thrown if the database already exists.
+  ///   - properties: additional database properties.
+  public func createDatabase(
+    _ dbName: String,
+    ifNotExists: Bool = false,
+    properties: [String: String]? = nil
+  ) async throws {
+    let df = getDataFrame({
+      var createDatabase = Spark_Connect_CreateDatabase()
+      createDatabase.dbName = dbName
+      createDatabase.ifNotExists = ifNotExists
+      if let properties {
+        for (k, v) in properties {
+          createDatabase.properties[k] = v
+        }
+      }
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .createDatabase(createDatabase)
+      return catalog
+    })
+    try await df.count()
+  }
+
+  /// Drops the database with the specified name.
+  /// - Parameters:
+  ///   - dbName: name of the database to drop.
+  ///   - ifExists: if true, no error is thrown if the database does not exist.
+  ///   - cascade: if true, drops the database and all its tables/functions.
+  public func dropDatabase(
+    _ dbName: String,
+    ifExists: Bool = false,
+    cascade: Bool = false
+  ) async throws {
+    let df = getDataFrame({
+      var dropDatabase = Spark_Connect_DropDatabase()
+      dropDatabase.dbName = dbName
+      dropDatabase.ifExists = ifExists
+      dropDatabase.cascade = cascade
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .dropDatabase(dropDatabase)
+      return catalog
+    })
+    try await df.count()
+  }
+
   /// Returns a list of databases available across all sessions.
   /// - Parameter pattern: The pattern that the database name needs to match.
   /// - Returns: A list of ``Database``.

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -110,6 +110,45 @@ struct CatalogTests {
   }
 
   @Test
+  func createDatabase() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let dbName = "DB_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withDatabase(spark, dbName)({
+        #expect(try await spark.catalog.databaseExists(dbName) == false)
+        try await spark.catalog.createDatabase(dbName)
+        #expect(try await spark.catalog.databaseExists(dbName))
+
+        try await #require(throws: Error.self) {
+          try await spark.catalog.createDatabase(dbName)
+        }
+        try await spark.catalog.createDatabase(dbName, ifNotExists: true)
+      })
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func dropDatabase() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let dbName = "DB_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withDatabase(spark, dbName)({
+        try await spark.catalog.createDatabase(dbName)
+        #expect(try await spark.catalog.databaseExists(dbName))
+        try await spark.catalog.dropDatabase(dbName)
+        #expect(try await spark.catalog.databaseExists(dbName) == false)
+
+        try await #require(throws: SparkConnectError.SchemaNotFound) {
+          try await spark.catalog.dropDatabase(dbName)
+        }
+        try await spark.catalog.dropDatabase(dbName, ifExists: true)
+      })
+    }
+    await spark.stop()
+  }
+
+  @Test
   func databaseExists() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(try await spark.catalog.databaseExists("default"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `Catalog.createDatabase` and `Catalog.dropDatabase` to the Spark Connect Swift client.

### Why are the changes needed?

The `Spark_Connect_CreateDatabase` and `Spark_Connect_DropDatabase` proto messages were added in Spark Connect 4.2.0-preview5
- https://github.com/apache/spark/pull/55025

### Does this PR introduce _any_ user-facing change?

No, these are new methods.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)