### PR TITLE
[SPARK-57045] Support `drop(Table|View)` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -504,4 +504,40 @@ public actor Catalog: Sendable {
     })
     return try await df.collect()[0].getAsBool(0)
   }
+
+  /// Drops the table with the given table name in the catalog.
+  /// - Parameters:
+  ///   - tableName: The name of the table to be dropped.
+  ///   - ifExists: If true, no exception is thrown if the table does not exist.
+  ///   - purge: If true, the table is purged.
+  public func dropTable(
+    _ tableName: String, ifExists: Bool = false, purge: Bool = false
+  ) async throws {
+    let df = getDataFrame({
+      var dropTable = Spark_Connect_DropTable()
+      dropTable.tableName = tableName
+      dropTable.ifExists = ifExists
+      dropTable.purge = purge
+      var catalog = Spark_Connect_Catalog()
+      catalog.dropTable = dropTable
+      return catalog
+    })
+    try await df.count()
+  }
+
+  /// Drops the view with the given view name in the catalog.
+  /// - Parameters:
+  ///   - viewName: The name of the view to be dropped.
+  ///   - ifExists: If true, no exception is thrown if the view does not exist.
+  public func dropView(_ viewName: String, ifExists: Bool = false) async throws {
+    let df = getDataFrame({
+      var dropView = Spark_Connect_DropView()
+      dropView.viewName = viewName
+      dropView.ifExists = ifExists
+      var catalog = Spark_Connect_Catalog()
+      catalog.dropView = dropView
+      return catalog
+    })
+    try await df.count()
+  }
 }

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -370,6 +370,46 @@ struct CatalogTests {
   }
 
   @Test
+  func dropTable() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withTable(spark, tableName)({
+        try await spark.range(1).write.saveAsTable(tableName)
+        #expect(try await spark.catalog.tableExists(tableName))
+        try await spark.catalog.dropTable(tableName)
+        #expect(try await spark.catalog.tableExists(tableName) == false)
+      })
+
+      try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+        try await spark.catalog.dropTable("non_exist_table")
+      }
+      try await spark.catalog.dropTable("non_exist_table", ifExists: true)
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func dropView() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let viewName = "VIEW_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withTable(spark, viewName)({
+        try await spark.sql("CREATE VIEW \(viewName) AS SELECT 1").count()
+        #expect(try await spark.catalog.tableExists(viewName))
+        try await spark.catalog.dropView(viewName)
+        #expect(try await spark.catalog.tableExists(viewName) == false)
+      })
+
+      try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+        try await spark.catalog.dropView("non_exist_view")
+      }
+      try await spark.catalog.dropView("non_exist_view", ifExists: true)
+    }
+    await spark.stop()
+  }
+
+  @Test
   func cacheTable() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark_Connect_DropTable` and `Spark_Connect_DropView` messages added in Apache Spark Connect 4.2.0-preview5
- https://github.com/apache/spark/pull/55025

### Why are the changes needed?

To provide new functionality.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7