### PR TITLE
[SPARK-57046] Support `truncateTable` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -434,6 +434,20 @@ public actor Catalog: Sendable {
     try await df.count()
   }
 
+  /// Removes all rows from the table.
+  /// - Parameter tableName: A qualified or unqualified name that designates a table.
+  /// If no database identifier is provided, it refers to a table in the current database.
+  public func truncateTable(_ tableName: String) async throws {
+    let df = getDataFrame({
+      var truncateTable = Spark_Connect_TruncateTable()
+      truncateTable.tableName = tableName
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .truncateTable(truncateTable)
+      return catalog
+    })
+    try await df.count()
+  }
+
   /// Invalidates and refreshes all the cached data (and the associated metadata) for any ``DataFrame``
   /// that contains the given data source path. Path matching is by checking for sub-directories,
   /// i.e. "/" would invalidate everything that is cached and "/test/parent" would invalidate

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -425,6 +425,25 @@ struct CatalogTests {
   }
 
   @Test
+  func truncateTable() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withTable(spark, tableName)({
+        try await spark.range(10).write.saveAsTable(tableName)
+        #expect(try await spark.table(tableName).count() == 10)
+        try await spark.catalog.truncateTable(tableName)
+        #expect(try await spark.table(tableName).count() == 0)
+      })
+
+      try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+        try await spark.catalog.truncateTable("not_exist_table")
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
   func refreshByPath() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark_Connect_TruncateTable` message added in Apache Spark Connect 4.2.0-preview5
- https://github.com/apache/spark/pull/55025

### Why are the changes needed?

For feature parity with Spark Connect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7