### PR TITLE
[SPARK-57047] Support `listViews` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -241,6 +241,36 @@ public actor Catalog: Sendable {
     }
   }
 
+  /// Returns a list of views in the given database (or the current database).
+  /// - Parameters:
+  ///   - dbName: The name of the database to list views from.
+  ///   - pattern: The pattern that the view name needs to match.
+  /// - Returns: A list of ``SparkTable``.
+  public func listViews(dbName: String? = nil, pattern: String? = nil) async throws -> [SparkTable]
+  {
+    let df = getDataFrame({
+      var listViews = Spark_Connect_ListViews()
+      if let dbName {
+        listViews.dbName = dbName
+      }
+      if let pattern {
+        listViews.pattern = pattern
+      }
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .listViews(listViews)
+      return catalog
+    })
+    return try await df.collect().map {
+      try SparkTable(
+        name: $0[0] as! String,
+        catalog: $0[1] as? String,
+        namespace: $0[2] as? [String],
+        description: $0[3] as? String,
+        tableType: $0[4] as! String,
+        isTemporary: $0[5] as! Bool)
+    }
+  }
+
   /// Creates a table from the given path and returns the corresponding ``DataFrame``.
   /// - Parameters:
   ///   - tableName: A qualified or unqualified name that designates a table. If no database

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -152,6 +152,31 @@ struct CatalogTests {
   }
 
   @Test
+  func listViews() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      #expect(try await spark.catalog.listViews().count == 0)
+
+      let viewName = ("VIEW_" + UUID().uuidString.replacingOccurrences(of: "-", with: ""))
+        .lowercased()
+      try await SQLHelper.withTempView(spark, viewName)({
+        try await spark.range(1).createTempView(viewName)
+
+        let views = try await spark.catalog.listViews()
+        #expect(views.count == 1)
+        #expect(views[0].name == viewName)
+        #expect(views[0].catalog == nil)
+        #expect(views[0].namespace == [])
+        #expect(views[0].description == nil)
+        #expect(views[0].isTemporary == true)
+        #expect(try await spark.catalog.listViews(pattern: "*") == views)
+        #expect(try await spark.catalog.listViews(pattern: "non_exist").count == 0)
+      })
+    }
+    await spark.stop()
+  }
+
+  @Test
   func getTable() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark_Connect_ListViews` added in Apache Spark Connect 4.2.0-preview5
- https://github.com/apache/spark/pull/55025

### Why are the changes needed?

For feature parity with other Spark Connect clients.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)