### PR TITLE
[SPARK-57050] Support `getTableProperties` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -379,6 +379,24 @@ public actor Catalog: Sendable {
     }.first!
   }
 
+  /// Get the table properties of the table with the specified name.
+  /// - Parameter tableName: a qualified or unqualified name that designates a table.
+  /// - Returns: A dictionary of table properties.
+  public func getTableProperties(_ tableName: String) async throws -> [String: String] {
+    let df = getDataFrame({
+      var getTableProperties = Spark_Connect_GetTableProperties()
+      getTableProperties.tableName = tableName
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .getTableProperties(getTableProperties)
+      return catalog
+    })
+    var properties: [String: String] = [:]
+    for row in try await df.collect() {
+      properties[try row.get(0) as! String] = try row.get(1) as? String
+    }
+    return properties
+  }
+
   /// Check if the table or view with the specified name exists. This can either be a temporary
   /// view or a table/view.
   /// - Parameter tableName: a qualified or unqualified name that designates a table/view. It follows the same

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -239,6 +239,28 @@ struct CatalogTests {
   }
 
   @Test
+  func getTableProperties() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let tableName = ("TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: ""))
+        .lowercased()
+      try await SQLHelper.withTable(spark, tableName)({
+        try await spark.sql(
+          "CREATE TABLE \(tableName) (id INT) TBLPROPERTIES ('k1'='v1', 'k2'='v2')"
+        ).count()
+        let properties = try await spark.catalog.getTableProperties(tableName)
+        #expect(properties["k1"] == "v1")
+        #expect(properties["k2"] == "v2")
+      })
+
+      try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+        try await spark.catalog.getTableProperties("not_exist_table")
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
   func createTable() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark_Connect_GetTableProperties` added in Apache Spark Connect 4.2.0-preview5.
- https://github.com/apache/spark/pull/55025

### Why are the changes needed?

For feature parity with other Spark Connect clients.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)