### PR TITLE
[SPARK-57051] Support `getCreateTableString` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -379,6 +379,25 @@ public actor Catalog: Sendable {
     }.first!
   }
 
+  /// Returns the CREATE TABLE statement string for the given table.
+  /// - Parameters:
+  ///   - tableName: A qualified or unqualified name that designates a table.
+  ///   - asSerde: If true, returns the CREATE TABLE statement in Hive `SERDE` format.
+  /// - Returns: The CREATE TABLE statement string.
+  public func getCreateTableString(_ tableName: String, asSerde: Bool = false) async throws
+    -> String
+  {
+    let df = getDataFrame({
+      var getCreateTableString = Spark_Connect_GetCreateTableString()
+      getCreateTableString.tableName = tableName
+      getCreateTableString.asSerde = asSerde
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .getCreateTableString(getCreateTableString)
+      return catalog
+    })
+    return try await df.collect()[0][0] as! String
+  }
+
   /// Check if the table or view with the specified name exists. This can either be a temporary
   /// view or a table/view.
   /// - Parameter tableName: a qualified or unqualified name that designates a table/view. It follows the same

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -529,6 +529,25 @@ struct CatalogTests {
   }
 
   @Test
+  func getCreateTableString() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+      try await SQLHelper.withTable(spark, tableName)({
+        try await spark.range(1).write.saveAsTable(tableName)
+        let stmt = try await spark.catalog.getCreateTableString(tableName)
+        #expect(stmt.contains("CREATE TABLE"))
+        #expect(stmt.contains(tableName))
+      })
+
+      try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+        try await spark.catalog.getCreateTableString("not_exist_table")
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
   func truncateTable() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     if await spark.version >= "4.2" {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark_Connect_GetCreateTableString` message added in Apache Spark Connect 4.2.0-preview5.
- https://github.com/apache/spark/pull/55025

### Why are the changes needed?

For feature parity with Spark Connect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7