### PR TITLE
[SPARK-57063] Support `csv(DataFrame)` in `DataFrameReader`

### DIFF
--- a/Sources/SparkConnect/DataFrameReader.swift
+++ b/Sources/SparkConnect/DataFrameReader.swift
@@ -194,6 +194,27 @@ public actor DataFrameReader: Sendable {
     return load(paths)
   }
 
+  /// Loads a CSV dataset and returns the result as a ``DataFrame``.
+  /// The input ``DataFrame`` must have a single string column whose values are CSV records.
+  /// - Parameter csvDataset: A ``DataFrame`` with a single string column.
+  /// - Returns: A ``DataFrame``.
+  public func csv(_ csvDataset: DataFrame) async -> DataFrame {
+    var parse = Parse()
+    parse.format = .csv
+    parse.options = self.extraOptions.toStringDictionary()
+    if case .root(let input) = await csvDataset.plan.opType {
+      parse.input = input
+    }
+
+    var relation = Relation()
+    relation.parse = parse
+
+    var plan = Plan()
+    plan.opType = .root(relation)
+
+    return DataFrame(spark: sparkSession, plan: plan)
+  }
+
   /// Loads a JSON file and returns the result as a ``DataFrame``.
   /// - Parameter path: A path string
   /// - Returns: A ``DataFrame``.

--- a/Tests/SparkConnectTests/DataFrameReaderTests.swift
+++ b/Tests/SparkConnectTests/DataFrameReaderTests.swift
@@ -40,6 +40,20 @@ struct DataFrameReaderTests {
   }
 
   @Test
+  func csvDataset() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2.0" {
+      let csvDF = try await spark.sql(
+        "SELECT * FROM VALUES "
+          + "('Alice,25'), "
+          + "('Bob,30') AS T(value)"
+      )
+      #expect(try await spark.read.csv(csvDF).count() == 2)
+    }
+    await spark.stop()
+  }
+
+  @Test
   func json() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let path = "../examples/src/main/resources/people.json"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `csv(DataFrame)` overload in `DataFrameReader`.

### Why are the changes needed?

For feature parity with PySpark/Scala `spark.read.csv(csvDataset)`, and to exercise `Spark_Connect_Parse.ParseFormat.csv` (Apache Spark 4.2.0+).
- https://github.com/apache/spark/pull/55274

### Does this PR introduce _any_ user-facing change?

No behavior change. New public overload added.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7