### PR TITLE
[SPARK-57086] Support `recoverPartitions` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -584,6 +584,20 @@ public actor Catalog: Sendable {
     try await df.count()
   }
 
+  /// Recovers all the partitions in the directory of a table and update the catalog.
+  /// - Parameter tableName: A qualified or unqualified name that designates a table.
+  /// If no database identifier is provided, it refers to a table in the current database.
+  public func recoverPartitions(_ tableName: String) async throws {
+    let df = getDataFrame({
+      var recoverPartitions = Spark_Connect_RecoverPartitions()
+      recoverPartitions.tableName = tableName
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .recoverPartitions(recoverPartitions)
+      return catalog
+    })
+    try await df.count()
+  }
+
   /// Analyzes the given table to compute statistics that can be used by the query optimizer.
   /// - Parameters:
   ///   - tableName: A qualified or unqualified name that designates a table.

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -609,6 +609,23 @@ struct CatalogTests {
   }
 
   @Test
+  func recoverPartitions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    try await SQLHelper.withTable(spark, tableName)({
+      try await spark.sql(
+        "CREATE TABLE \(tableName) (id INT) USING PARQUET PARTITIONED BY (p INT)"
+      ).count()
+      try await spark.catalog.recoverPartitions(tableName)
+    })
+
+    try await #require(throws: SparkConnectError.TableOrViewNotFound) {
+      try await spark.catalog.recoverPartitions("not_exist_table")
+    }
+    await spark.stop()
+  }
+
+  @Test
   func analyzeTable() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     if await spark.version >= "4.2" {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `recoverPartitions` in `Catalog`.

### Why are the changes needed?

For feature parity with `spark.catalog.recoverPartitions`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with a new test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7