### PR TITLE
[SPARK-57087] Support `listFunctions` in `Catalog`

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -293,6 +293,37 @@ public actor Catalog: Sendable {
     }
   }
 
+  /// Returns a list of functions registered in the specified database (or the current database).
+  /// This includes all temporary functions.
+  /// - Parameters:
+  ///   - dbName: An optional database name. Defaults to the current database.
+  ///   - pattern: The pattern that the function name needs to match.
+  /// - Returns: A list of ``Function``.
+  public func listFunctions(dbName: String? = nil, pattern: String? = nil) async throws -> [Function]
+  {
+    let df = getDataFrame({
+      var listFunctions = Spark_Connect_ListFunctions()
+      if let dbName {
+        listFunctions.dbName = dbName
+      }
+      if let pattern {
+        listFunctions.pattern = pattern
+      }
+      var catalog = Spark_Connect_Catalog()
+      catalog.catType = .listFunctions(listFunctions)
+      return catalog
+    })
+    return try await df.collect().map {
+      try Function(
+        name: $0[0] as! String,
+        catalog: $0[1] as? String,
+        namespace: $0[2] as? [String],
+        description: $0[3] as? String,
+        className: ($0[4] as? String) ?? "",
+        isTemporary: $0[5] as! Bool)
+    }
+  }
+
   /// Returns a list of views in the given database (or the current database).
   /// - Parameters:
   ///   - dbName: The name of the database to list views from.

--- a/Tests/SparkConnectTests/CatalogTests.swift
+++ b/Tests/SparkConnectTests/CatalogTests.swift
@@ -363,6 +363,20 @@ struct CatalogTests {
   }
 
   @Test
+  func listFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    #expect(try await spark.catalog.listFunctions().count > 0)
+
+    let base64 = try await spark.catalog.listFunctions(pattern: "base64")
+    #expect(base64.count == 1)
+    #expect(base64[0].name == "base64")
+    #expect(base64[0].isTemporary == true)
+
+    #expect(try await spark.catalog.listFunctions(pattern: "non_exist_function").count == 0)
+    await spark.stop()
+  }
+
+  @Test
   func createTempView() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let viewName = "VIEW_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `listFunctions` in `Catalog`.

### Why are the changes needed?

For feature parity with Apache Spark's `Catalog.listFunctions` API.

### Does this PR introduce _any_ user-facing change?

No, this is a new API.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code