### PR TITLE
[SPARK-57094] Use `exact` always instead of `branch` in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.7.0"),
-    .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.12.19-2026-02-06-03fffb2"),
+    .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.6.4")
   ],
   targets: [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `exact` always instead of `branch` in `Package.swift`

### Why are the changes needed?

A `branch:` reference is mutable. Pinning to the matching tag makes the dependency reproducible and consistent with the other four dependencies, which all use `exact:`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`swift package resolve` keeps `Package.resolved` at the same revision `03fffb25e2d777462b719cb4964249c30b19d58f` for `flatbuffer`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7