### PR TITLE
[SPARK-57279] Add `SECURITY.md` for scan-agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,11 @@ This repo follows standard Apache Spark process.
 - Test failures are usually "no server" or version mismatch, not code bugs —
   confirm a Spark Connect server is running and reachable at `SPARK_REMOTE`.
 - Keep dependency versions as `exact` pins.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md`
+for the project's threat model, in-scope / out-of-scope
+declarations, and known non-findings before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security policy
+
+## Reporting a vulnerability
+
+To report a security vulnerability in apache/spark-connect-swift,
+follow the ASF security process at
+<https://www.apache.org/security/>. Reports can be sent privately
+to security@apache.org or to private@spark.apache.org.
+
+## Threat model
+
+This repository implements the Swift client for the Spark Connect
+RPC protocol. Apache Spark's security guidance for operators is
+documented at:
+
+<https://spark.apache.org/docs/latest/security.html>
+
+That document covers authentication, encryption, access
+control, Kerberos integration, trust boundaries, environmental
+assumptions, security properties provided and not provided,
+and downstream operator responsibilities. The client-side
+trust assumptions for Spark Connect (RPC channel, credential
+material, TLS validation) inherit from that model.
+
+Automated security scanning agents should consult that
+document for the project's in-scope / out-of-scope
+declarations before reporting issues.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SECURITY.md` for scan-agent discoverability.

### Why are the changes needed?

Like Apache Spark main repository, we had better provide this.
- https://github.com/apache/spark/blob/master/SECURITY.md

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.