### PR TITLE
[SPARK-57310] Support `stat.freqItems` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/DataFrameStatFunctions.swift
+++ b/Sources/SparkConnect/DataFrameStatFunctions.swift
@@ -66,6 +66,21 @@ public actor DataFrameStatFunctions: Sendable {
     return try await collectDouble { SparkConnectClient.getStatCorr($0, col1, col2, method) }
   }
 
+  /// Finds frequent items for columns, possibly with false positives. Uses the frequent element
+  /// count algorithm described in "https://doi.org/10.1145/762471.762473", proposed by Karp,
+  /// Schenker, and Papadimitriou.
+  /// - Parameters:
+  ///   - cols: The names of the columns to search frequent items in.
+  ///   - support: The minimum frequency for an item to be considered `frequent`. Should be greater
+  ///     than 1e-4.
+  /// - Returns: A ``DataFrame`` with the frequent items for each column. The output columns are
+  ///   named `{column}_freqItems`.
+  public func freqItems(_ cols: [String], support: Double = 0.01) async throws -> DataFrame {
+    let plan = await df.getPlan() as! Plan
+    return DataFrame(
+      spark: await df.spark, plan: SparkConnectClient.getFreqItems(plan.root, cols, support))
+  }
+
   // MARK: - Helpers
 
   /// Builds a single-value ``DataFrame`` from this ``DataFrame``'s plan using the given plan

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -639,6 +639,14 @@ public actor SparkConnectClient {
     return createPlan { $0.corr = corr }
   }
 
+  static func getFreqItems(_ child: Relation, _ cols: [String], _ support: Double) -> Plan {
+    var freqItems = Spark_Connect_StatFreqItems()
+    freqItems.input = child
+    freqItems.cols = cols
+    freqItems.support = support
+    return createPlan { $0.freqItems = freqItems }
+  }
+
   static func getSort(_ child: Relation, _ cols: [String]) -> Plan {
     var sort = Sort()
     sort.input = child

--- a/Tests/SparkConnectTests/DataFrameStatFunctionsTests.swift
+++ b/Tests/SparkConnectTests/DataFrameStatFunctionsTests.swift
@@ -57,4 +57,16 @@ struct DataFrameStatFunctionsTests {
     #expect(try await df.stat.corr("c1", "c2", method: "pearson") == 1.0)
     await spark.stop()
   }
+
+  @Test
+  func freqItems() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT * FROM VALUES (1, 2), (1, 2), (1, 2) AS T(a, b)")
+    // The result is a single-row `DataFrame` whose columns are named `{column}_freqItems`.
+    #expect(try await df.stat.freqItems(["a", "b"]).columns == ["a_freqItems", "b_freqItems"])
+    #expect(try await df.stat.freqItems(["a", "b"]).collect() == [Row(Array([1]), Array([2]))])
+    // `support` can be specified explicitly.
+    #expect(try await df.stat.freqItems(["a"], support: 0.5).collect() == [Row(Array([1]))])
+    await spark.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `freqItems` for `DataFrame` by wiring the `StatFreqItems`
Spark Connect relation through `DataFrameStatFunctions`, exposed via `DataFrame.stat`
like PySpark/Scala.

```swift
public func freqItems(_ cols: [String], support: Double = 0.01) async throws -> DataFrame
```

Like `stat.crosstab`, `freqItems` returns a `DataFrame` whose output columns are named
`<column>_freqItems`. The optional `support` (the minimum frequency for an item to be
considered frequent) defaults to `0.01`, matching PySpark/Scala.

### Why are the changes needed?

To improve API coverage by mirroring PySpark/Scala `DataFrameStatFunctions`.

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds a new API, `DataFrame.stat.freqItems`.

### How was this patch tested?

Pass the CIs with a newly added test, `DataFrameStatFunctionsTests.freqItems`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)