### PR TITLE
[SPARK-57312] Use 4.0.3 RC1 for Spark 4.0 integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -176,9 +176,9 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.0.2/spark-4.0.2-bin-hadoop3.tgz?action=download
-        tar xvfz spark-4.0.2-bin-hadoop3.tgz && rm spark-4.0.2-bin-hadoop3.tgz
-        mv spark-4.0.2-bin-hadoop3 /tmp/spark
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.0.3-rc1-bin/spark-4.0.3-bin-hadoop3.tgz
+        tar xvfz spark-4.0.3-bin-hadoop3.tgz && rm spark-4.0.3-bin-hadoop3.tgz
+        mv spark-4.0.3-bin-hadoop3 /tmp/spark
         cd /tmp/spark/sbin
         ./start-connect-server.sh
         cd -


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `integration-test-mac` and `integration-test-mac-spark4-iceberg` CI jobs to use `Apache Spark 4.0.3` RC1.

### Why are the changes needed?

To test against the latest `Apache Spark 4.0.3` RC1.
- https://dist.apache.org/repos/dist/dev/spark/v4.0.3-rc1-bin/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.
- https://github.com/dongjoon-hyun/spark-connect-swift/actions/runs/27114872726/job/80019783778
```
x spark-4.0.3-bin-hadoop3/
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8