### PR TITLE
[SPARK-57334] Upgrade `gRPC Swift NIO Transport` to 2.8.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.7.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.8.0"),
     .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.6.5")
   ],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Swift 6.3.2 (May 2026)](https://swift.org)
 - [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
 - [gRPC Swift Protobuf 2.4.0 (May 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.0)
-- [gRPC Swift NIO Transport 2.7.0 (April 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.7.0)
+- [gRPC Swift NIO Transport 2.8.0 (June 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.8.0)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `grpc-swift-nio-transport` dependency to `2.8.0`.

### Why are the changes needed?

To adopt the latest `grpc-swift-nio-transport` release (`2.8.0`).
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.8.0
  - https://github.com/grpc/grpc-swift-nio-transport/pull/175
  - https://github.com/grpc/grpc-swift-nio-transport/pull/177
  - https://github.com/grpc/grpc-swift-nio-transport/pull/181

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)