### PR TITLE
[SPARK-57347] Remove `spark.sql.geospatial.enabled=true` from `integration-test-mac-spark42`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -159,7 +159,7 @@ jobs:
         tar xvfz spark-4.2.0-bin-hadoop3.tgz && rm spark-4.2.0-bin-hadoop3.tgz
         mv spark-4.2.0-bin-hadoop3/ /tmp/spark
         cd /tmp/spark/sbin
-        ./start-connect-server.sh -c spark.sql.geospatial.enabled=true -c spark.sql.timeType.enabled=true
+        ./start-connect-server.sh -c spark.sql.timeType.enabled=true
         cd -
         swift test --no-parallel -c release
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the `-c spark.sql.geospatial.enabled=true` configuration from the `start-connect-server.sh` invocation in the `integration-test-mac-spark42` job of `.github/workflows/build_and_test.yml`.

```diff
- ./start-connect-server.sh -c spark.sql.geospatial.enabled=true -c spark.sql.timeType.enabled=true
+ ./start-connect-server.sh -c spark.sql.timeType.enabled=true
```

### Why are the changes needed?

From Apache Spark 4.2.0 RC1, geospatial support (`GEOMETRY`/`GEOGRAPHY` types) is enabled by default, so explicitly passing `spark.sql.geospatial.enabled=true` is redundant.

- https://github.com/apache/spark/pull/55734

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CI, specifically the `integration-test-mac-spark42` job which runs the full test suite (including the `geography.sql` and `geometry.sql` golden tests) against a Spark 4.2.0 RC1 Connect server.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)