### PR TITLE
[SPARK-57390] Use `apache/spark:4.0.2-scala` image in `integration-test-ubuntu`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       SPARK_REMOTE: "sc://localhost:15003"
     services:
       spark:
-        image: apache/spark:4.0.2
+        image: apache/spark:4.0.2-scala
         env:
           SPARK_NO_DAEMONIZE: 1
         ports:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `apache/spark:4.0.2-scala` image instead of `apache/spark:4.0.2` in `integration-test-ubuntu` job.

### Why are the changes needed?

The `-scala` image variant is smaller than the default image because it doesn't include Python/R. This minimizes the image download overhead in CI.

Note that the other integration test jobs are already using the `-scala` variants, `apache/spark:4.1.2-scala` and `apache/spark:4.2.0-preview5-scala`. This makes `integration-test-ubuntu` consistent with them.

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Pass the CIs including `integration-test-ubuntu` job.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)