### PR TITLE
[SPARK-57522] Update `Spark Connect`-generated `Swift` source code with `4.2.0-rc3`

### DIFF
--- a/Sources/SparkConnect/commands.pb.swift
+++ b/Sources/SparkConnect/commands.pb.swift
@@ -453,6 +453,9 @@ nonisolated struct Spark_Connect_WriteOperation: Sendable {
   /// (Optional) Columns used for clustering the table.
   var clusteringColumns: [String] = []
 
+  /// (Optional) Whether schema evolution is enabled for the write.
+  var withSchemaEvolution: Bool = false
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// (Optional)
@@ -642,6 +645,9 @@ nonisolated struct Spark_Connect_WriteOperationV2: Sendable {
 
   /// (Optional) Columns used for clustering the table.
   var clusteringColumns: [String] = []
+
+  /// (Optional) Whether schema evolution is enabled for the write.
+  var withSchemaEvolution: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2352,7 +2358,7 @@ nonisolated extension Spark_Connect_CreateDataFrameViewCommand: SwiftProtobuf.Me
 
 nonisolated extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteOperation"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}source\0\u{1}path\0\u{1}table\0\u{1}mode\0\u{3}sort_column_names\0\u{3}partitioning_columns\0\u{3}bucket_by\0\u{1}options\0\u{3}clustering_columns\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{1}source\0\u{1}path\0\u{1}table\0\u{1}mode\0\u{3}sort_column_names\0\u{3}partitioning_columns\0\u{3}bucket_by\0\u{1}options\0\u{3}clustering_columns\0\u{3}with_schema_evolution\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2389,6 +2395,7 @@ nonisolated extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, Swift
       case 8: try { try decoder.decodeSingularMessageField(value: &self._bucketBy) }()
       case 9: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.options) }()
       case 10: try { try decoder.decodeRepeatedStringField(value: &self.clusteringColumns) }()
+      case 11: try { try decoder.decodeSingularBoolField(value: &self.withSchemaEvolution) }()
       default: break
       }
     }
@@ -2434,6 +2441,9 @@ nonisolated extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, Swift
     if !self.clusteringColumns.isEmpty {
       try visitor.visitRepeatedStringField(value: self.clusteringColumns, fieldNumber: 10)
     }
+    if self.withSchemaEvolution != false {
+      try visitor.visitSingularBoolField(value: self.withSchemaEvolution, fieldNumber: 11)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2447,6 +2457,7 @@ nonisolated extension Spark_Connect_WriteOperation: SwiftProtobuf.Message, Swift
     if lhs._bucketBy != rhs._bucketBy {return false}
     if lhs.options != rhs.options {return false}
     if lhs.clusteringColumns != rhs.clusteringColumns {return false}
+    if lhs.withSchemaEvolution != rhs.withSchemaEvolution {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2532,7 +2543,7 @@ nonisolated extension Spark_Connect_WriteOperation.BucketBy: SwiftProtobuf.Messa
 
 nonisolated extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WriteOperationV2"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}table_name\0\u{1}provider\0\u{3}partitioning_columns\0\u{1}options\0\u{3}table_properties\0\u{1}mode\0\u{3}overwrite_condition\0\u{3}clustering_columns\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}input\0\u{3}table_name\0\u{1}provider\0\u{3}partitioning_columns\0\u{1}options\0\u{3}table_properties\0\u{1}mode\0\u{3}overwrite_condition\0\u{3}clustering_columns\0\u{3}with_schema_evolution\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2549,6 +2560,7 @@ nonisolated extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, Swi
       case 7: try { try decoder.decodeSingularEnumField(value: &self.mode) }()
       case 8: try { try decoder.decodeSingularMessageField(value: &self._overwriteCondition) }()
       case 9: try { try decoder.decodeRepeatedStringField(value: &self.clusteringColumns) }()
+      case 10: try { try decoder.decodeSingularBoolField(value: &self.withSchemaEvolution) }()
       default: break
       }
     }
@@ -2586,6 +2598,9 @@ nonisolated extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, Swi
     if !self.clusteringColumns.isEmpty {
       try visitor.visitRepeatedStringField(value: self.clusteringColumns, fieldNumber: 9)
     }
+    if self.withSchemaEvolution != false {
+      try visitor.visitSingularBoolField(value: self.withSchemaEvolution, fieldNumber: 10)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2599,6 +2614,7 @@ nonisolated extension Spark_Connect_WriteOperationV2: SwiftProtobuf.Message, Swi
     if lhs.mode != rhs.mode {return false}
     if lhs._overwriteCondition != rhs._overwriteCondition {return false}
     if lhs.clusteringColumns != rhs.clusteringColumns {return false}
+    if lhs.withSchemaEvolution != rhs.withSchemaEvolution {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SparkConnect/pipelines.pb.swift
+++ b/Sources/SparkConnect/pipelines.pb.swift
@@ -450,81 +450,95 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
   }
 
   /// Request to define a flow targeting a dataset.
-  nonisolated struct DefineFlow: Sendable {
+  nonisolated struct DefineFlow: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     /// The graph to attach this flow to.
     var dataflowGraphID: String {
-      get {_dataflowGraphID ?? String()}
-      set {_dataflowGraphID = newValue}
+      get {_storage._dataflowGraphID ?? String()}
+      set {_uniqueStorage()._dataflowGraphID = newValue}
     }
     /// Returns true if `dataflowGraphID` has been explicitly set.
-    var hasDataflowGraphID: Bool {self._dataflowGraphID != nil}
+    var hasDataflowGraphID: Bool {_storage._dataflowGraphID != nil}
     /// Clears the value of `dataflowGraphID`. Subsequent reads from it will return its default value.
-    mutating func clearDataflowGraphID() {self._dataflowGraphID = nil}
+    mutating func clearDataflowGraphID() {_uniqueStorage()._dataflowGraphID = nil}
 
     /// Name of the flow. For standalone flows, this must be a single-part name.
     var flowName: String {
-      get {_flowName ?? String()}
-      set {_flowName = newValue}
+      get {_storage._flowName ?? String()}
+      set {_uniqueStorage()._flowName = newValue}
     }
     /// Returns true if `flowName` has been explicitly set.
-    var hasFlowName: Bool {self._flowName != nil}
+    var hasFlowName: Bool {_storage._flowName != nil}
     /// Clears the value of `flowName`. Subsequent reads from it will return its default value.
-    mutating func clearFlowName() {self._flowName = nil}
+    mutating func clearFlowName() {_uniqueStorage()._flowName = nil}
 
     /// Name of the dataset this flow writes to. Can be partially or fully qualified.
     var targetDatasetName: String {
-      get {_targetDatasetName ?? String()}
-      set {_targetDatasetName = newValue}
+      get {_storage._targetDatasetName ?? String()}
+      set {_uniqueStorage()._targetDatasetName = newValue}
     }
     /// Returns true if `targetDatasetName` has been explicitly set.
-    var hasTargetDatasetName: Bool {self._targetDatasetName != nil}
+    var hasTargetDatasetName: Bool {_storage._targetDatasetName != nil}
     /// Clears the value of `targetDatasetName`. Subsequent reads from it will return its default value.
-    mutating func clearTargetDatasetName() {self._targetDatasetName = nil}
+    mutating func clearTargetDatasetName() {_uniqueStorage()._targetDatasetName = nil}
 
     /// SQL configurations set when running this flow.
-    var sqlConf: Dictionary<String,String> = [:]
+    var sqlConf: Dictionary<String,String> {
+      get {_storage._sqlConf}
+      set {_uniqueStorage()._sqlConf = newValue}
+    }
 
     /// Identifier for the client making the request. The server uses this to determine what flow
     /// evaluation request stream to dispatch evaluation requests to for this flow.
     var clientID: String {
-      get {_clientID ?? String()}
-      set {_clientID = newValue}
+      get {_storage._clientID ?? String()}
+      set {_uniqueStorage()._clientID = newValue}
     }
     /// Returns true if `clientID` has been explicitly set.
-    var hasClientID: Bool {self._clientID != nil}
+    var hasClientID: Bool {_storage._clientID != nil}
     /// Clears the value of `clientID`. Subsequent reads from it will return its default value.
-    mutating func clearClientID() {self._clientID = nil}
+    mutating func clearClientID() {_uniqueStorage()._clientID = nil}
 
     /// The location in source code that this flow was defined.
     var sourceCodeLocation: Spark_Connect_SourceCodeLocation {
-      get {_sourceCodeLocation ?? Spark_Connect_SourceCodeLocation()}
-      set {_sourceCodeLocation = newValue}
+      get {_storage._sourceCodeLocation ?? Spark_Connect_SourceCodeLocation()}
+      set {_uniqueStorage()._sourceCodeLocation = newValue}
     }
     /// Returns true if `sourceCodeLocation` has been explicitly set.
-    var hasSourceCodeLocation: Bool {self._sourceCodeLocation != nil}
+    var hasSourceCodeLocation: Bool {_storage._sourceCodeLocation != nil}
     /// Clears the value of `sourceCodeLocation`. Subsequent reads from it will return its default value.
-    mutating func clearSourceCodeLocation() {self._sourceCodeLocation = nil}
+    mutating func clearSourceCodeLocation() {_uniqueStorage()._sourceCodeLocation = nil}
 
-    var details: Spark_Connect_PipelineCommand.DefineFlow.OneOf_Details? = nil
+    var details: OneOf_Details? {
+      get {return _storage._details}
+      set {_uniqueStorage()._details = newValue}
+    }
 
     var relationFlowDetails: Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails {
       get {
-        if case .relationFlowDetails(let v)? = details {return v}
+        if case .relationFlowDetails(let v)? = _storage._details {return v}
         return Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails()
       }
-      set {details = .relationFlowDetails(newValue)}
+      set {_uniqueStorage()._details = .relationFlowDetails(newValue)}
+    }
+
+    var autoCdcFlowDetails: Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails {
+      get {
+        if case .autoCdcFlowDetails(let v)? = _storage._details {return v}
+        return Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails()
+      }
+      set {_uniqueStorage()._details = .autoCdcFlowDetails(newValue)}
     }
 
     var `extension`: SwiftProtobuf.Google_Protobuf_Any {
       get {
-        if case .extension(let v)? = details {return v}
+        if case .extension(let v)? = _storage._details {return v}
         return SwiftProtobuf.Google_Protobuf_Any()
       }
-      set {details = .extension(newValue)}
+      set {_uniqueStorage()._details = .extension(newValue)}
     }
 
     /// If true, define the flow as a one-time flow, such as for backfill.
@@ -533,19 +547,55 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
     ///     the flow will run again.
     ///   - The flow function must be a batch DataFrame, not a streaming DataFrame.
     var once: Bool {
-      get {_once ?? false}
-      set {_once = newValue}
+      get {_storage._once ?? false}
+      set {_uniqueStorage()._once = newValue}
     }
     /// Returns true if `once` has been explicitly set.
-    var hasOnce: Bool {self._once != nil}
+    var hasOnce: Bool {_storage._once != nil}
     /// Clears the value of `once`. Subsequent reads from it will return its default value.
-    mutating func clearOnce() {self._once = nil}
+    mutating func clearOnce() {_uniqueStorage()._once = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     nonisolated enum OneOf_Details: Equatable, Sendable {
       case relationFlowDetails(Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails)
+      case autoCdcFlowDetails(Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails)
       case `extension`(SwiftProtobuf.Google_Protobuf_Any)
+
+    }
+
+    /// SCD Type for Auto CDC target tables.
+    nonisolated enum SCDType: SwiftProtobuf.Enum, Swift.CaseIterable {
+      typealias RawValue = Int
+      case unspecified // = 0
+      case scdType1 // = 1
+      case UNRECOGNIZED(Int)
+
+      init() {
+        self = .unspecified
+      }
+
+      init?(rawValue: Int) {
+        switch rawValue {
+        case 0: self = .unspecified
+        case 1: self = .scdType1
+        default: self = .UNRECOGNIZED(rawValue)
+        }
+      }
+
+      var rawValue: Int {
+        switch self {
+        case .unspecified: return 0
+        case .scdType1: return 1
+        case .UNRECOGNIZED(let i): return i
+        }
+      }
+
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      static let allCases: [Spark_Connect_PipelineCommand.DefineFlow.SCDType] = [
+        .unspecified,
+        .scdType1,
+      ]
 
     }
 
@@ -573,6 +623,80 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
       fileprivate var _relation: Spark_Connect_Relation? = nil
     }
 
+    /// Details for Auto CDC flows.
+    nonisolated struct AutoCdcFlowDetails: Sendable {
+      // SwiftProtobuf.Message conformance is added in an extension below. See the
+      // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+      // methods supported on all messages.
+
+      /// The name of the CDC source to stream from.
+      var source: String {
+        get {_source ?? String()}
+        set {_source = newValue}
+      }
+      /// Returns true if `source` has been explicitly set.
+      var hasSource: Bool {self._source != nil}
+      /// Clears the value of `source`. Subsequent reads from it will return its default value.
+      mutating func clearSource() {self._source = nil}
+
+      /// Column(s) that uniquely identify a row in source and target data.
+      var keys: [Spark_Connect_Expression] = []
+
+      /// Expression to order the source data.
+      var sequenceBy: Spark_Connect_Expression {
+        get {_sequenceBy ?? Spark_Connect_Expression()}
+        set {_sequenceBy = newValue}
+      }
+      /// Returns true if `sequenceBy` has been explicitly set.
+      var hasSequenceBy: Bool {self._sequenceBy != nil}
+      /// Clears the value of `sequenceBy`. Subsequent reads from it will return its default value.
+      mutating func clearSequenceBy() {self._sequenceBy = nil}
+
+      /// Delete condition for the merged operation.
+      var applyAsDeletes: Spark_Connect_Expression {
+        get {_applyAsDeletes ?? Spark_Connect_Expression()}
+        set {_applyAsDeletes = newValue}
+      }
+      /// Returns true if `applyAsDeletes` has been explicitly set.
+      var hasApplyAsDeletes: Bool {self._applyAsDeletes != nil}
+      /// Clears the value of `applyAsDeletes`. Subsequent reads from it will return its default value.
+      mutating func clearApplyAsDeletes() {self._applyAsDeletes = nil}
+
+      /// Truncate condition for the merged operation.
+      var applyAsTruncates: Spark_Connect_Expression {
+        get {_applyAsTruncates ?? Spark_Connect_Expression()}
+        set {_applyAsTruncates = newValue}
+      }
+      /// Returns true if `applyAsTruncates` has been explicitly set.
+      var hasApplyAsTruncates: Bool {self._applyAsTruncates != nil}
+      /// Clears the value of `applyAsTruncates`. Subsequent reads from it will return its default value.
+      mutating func clearApplyAsTruncates() {self._applyAsTruncates = nil}
+
+      /// Columns included in the output table.
+      var columnList: [Spark_Connect_Expression] = []
+
+      /// Columns excluded from the output table.
+      var exceptColumnList: [Spark_Connect_Expression] = []
+
+      /// SCD Type for target table.
+      var storedAsScdType: Spark_Connect_PipelineCommand.DefineFlow.SCDType = .unspecified
+
+      /// Subset of columns to ignore null in updates.
+      var ignoreNullUpdatesColumnList: [Spark_Connect_Expression] = []
+
+      /// Subset of columns excluded from ignoring null in updates.
+      var ignoreNullUpdatesExceptColumnList: [Spark_Connect_Expression] = []
+
+      var unknownFields = SwiftProtobuf.UnknownStorage()
+
+      init() {}
+
+      fileprivate var _source: String? = nil
+      fileprivate var _sequenceBy: Spark_Connect_Expression? = nil
+      fileprivate var _applyAsDeletes: Spark_Connect_Expression? = nil
+      fileprivate var _applyAsTruncates: Spark_Connect_Expression? = nil
+    }
+
     nonisolated struct Response: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -597,12 +721,7 @@ nonisolated struct Spark_Connect_PipelineCommand: Sendable {
 
     init() {}
 
-    fileprivate var _dataflowGraphID: String? = nil
-    fileprivate var _flowName: String? = nil
-    fileprivate var _targetDatasetName: String? = nil
-    fileprivate var _clientID: String? = nil
-    fileprivate var _sourceCodeLocation: Spark_Connect_SourceCodeLocation? = nil
-    fileprivate var _once: Bool? = nil
+    fileprivate var _storage = _StorageClass.defaultInstance
   }
 
   /// Request to execute all flows for a single output (dataset or sink) remotely.
@@ -1690,99 +1809,174 @@ nonisolated extension Spark_Connect_PipelineCommand.DefineOutput.SinkDetails: Sw
 
 nonisolated extension Spark_Connect_PipelineCommand.DefineFlow: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Spark_Connect_PipelineCommand.protoMessageName + ".DefineFlow"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}flow_name\0\u{3}target_dataset_name\0\u{3}sql_conf\0\u{3}client_id\0\u{3}source_code_location\0\u{3}relation_flow_details\0\u{1}once\0\u{2}_\u{f}extension\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}dataflow_graph_id\0\u{3}flow_name\0\u{3}target_dataset_name\0\u{3}sql_conf\0\u{3}client_id\0\u{3}source_code_location\0\u{3}relation_flow_details\0\u{1}once\0\u{4}\u{2}auto_cdc_flow_details\0\u{2}]\u{f}extension\0")
+
+  fileprivate class _StorageClass {
+    var _dataflowGraphID: String? = nil
+    var _flowName: String? = nil
+    var _targetDatasetName: String? = nil
+    var _sqlConf: Dictionary<String,String> = [:]
+    var _clientID: String? = nil
+    var _sourceCodeLocation: Spark_Connect_SourceCodeLocation? = nil
+    var _details: Spark_Connect_PipelineCommand.DefineFlow.OneOf_Details?
+    var _once: Bool? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _dataflowGraphID = source._dataflowGraphID
+      _flowName = source._flowName
+      _targetDatasetName = source._targetDatasetName
+      _sqlConf = source._sqlConf
+      _clientID = source._clientID
+      _sourceCodeLocation = source._sourceCodeLocation
+      _details = source._details
+      _once = source._once
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self._dataflowGraphID) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self._flowName) }()
-      case 3: try { try decoder.decodeSingularStringField(value: &self._targetDatasetName) }()
-      case 4: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.sqlConf) }()
-      case 5: try { try decoder.decodeSingularStringField(value: &self._clientID) }()
-      case 6: try { try decoder.decodeSingularMessageField(value: &self._sourceCodeLocation) }()
-      case 7: try {
-        var v: Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails?
-        var hadOneofValue = false
-        if let current = self.details {
-          hadOneofValue = true
-          if case .relationFlowDetails(let m) = current {v = m}
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._dataflowGraphID) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._flowName) }()
+        case 3: try { try decoder.decodeSingularStringField(value: &_storage._targetDatasetName) }()
+        case 4: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._sqlConf) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._clientID) }()
+        case 6: try { try decoder.decodeSingularMessageField(value: &_storage._sourceCodeLocation) }()
+        case 7: try {
+          var v: Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails?
+          var hadOneofValue = false
+          if let current = _storage._details {
+            hadOneofValue = true
+            if case .relationFlowDetails(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._details = .relationFlowDetails(v)
+          }
+        }()
+        case 8: try { try decoder.decodeSingularBoolField(value: &_storage._once) }()
+        case 10: try {
+          var v: Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails?
+          var hadOneofValue = false
+          if let current = _storage._details {
+            hadOneofValue = true
+            if case .autoCdcFlowDetails(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._details = .autoCdcFlowDetails(v)
+          }
+        }()
+        case 999: try {
+          var v: SwiftProtobuf.Google_Protobuf_Any?
+          var hadOneofValue = false
+          if let current = _storage._details {
+            hadOneofValue = true
+            if case .extension(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._details = .extension(v)
+          }
+        }()
+        default: break
         }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.details = .relationFlowDetails(v)
-        }
-      }()
-      case 8: try { try decoder.decodeSingularBoolField(value: &self._once) }()
-      case 999: try {
-        var v: SwiftProtobuf.Google_Protobuf_Any?
-        var hadOneofValue = false
-        if let current = self.details {
-          hadOneofValue = true
-          if case .extension(let m) = current {v = m}
-        }
-        try decoder.decodeSingularMessageField(value: &v)
-        if let v = v {
-          if hadOneofValue {try decoder.handleConflictingOneOf()}
-          self.details = .extension(v)
-        }
-      }()
-      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    try { if let v = self._dataflowGraphID {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    } }()
-    try { if let v = self._flowName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    } }()
-    try { if let v = self._targetDatasetName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    } }()
-    if !self.sqlConf.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.sqlConf, fieldNumber: 4)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._dataflowGraphID {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      } }()
+      try { if let v = _storage._flowName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      } }()
+      try { if let v = _storage._targetDatasetName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      } }()
+      if !_storage._sqlConf.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._sqlConf, fieldNumber: 4)
+      }
+      try { if let v = _storage._clientID {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      } }()
+      try { if let v = _storage._sourceCodeLocation {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      } }()
+      try { if case .relationFlowDetails(let v)? = _storage._details {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      } }()
+      try { if let v = _storage._once {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
+      } }()
+      switch _storage._details {
+      case .autoCdcFlowDetails?: try {
+        guard case .autoCdcFlowDetails(let v)? = _storage._details else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      }()
+      case .extension?: try {
+        guard case .extension(let v)? = _storage._details else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 999)
+      }()
+      default: break
+      }
     }
-    try { if let v = self._clientID {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    } }()
-    try { if let v = self._sourceCodeLocation {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    } }()
-    try { if case .relationFlowDetails(let v)? = self.details {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    } }()
-    try { if let v = self._once {
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
-    } }()
-    try { if case .extension(let v)? = self.details {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 999)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Spark_Connect_PipelineCommand.DefineFlow, rhs: Spark_Connect_PipelineCommand.DefineFlow) -> Bool {
-    if lhs._dataflowGraphID != rhs._dataflowGraphID {return false}
-    if lhs._flowName != rhs._flowName {return false}
-    if lhs._targetDatasetName != rhs._targetDatasetName {return false}
-    if lhs.sqlConf != rhs.sqlConf {return false}
-    if lhs._clientID != rhs._clientID {return false}
-    if lhs._sourceCodeLocation != rhs._sourceCodeLocation {return false}
-    if lhs.details != rhs.details {return false}
-    if lhs._once != rhs._once {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._dataflowGraphID != rhs_storage._dataflowGraphID {return false}
+        if _storage._flowName != rhs_storage._flowName {return false}
+        if _storage._targetDatasetName != rhs_storage._targetDatasetName {return false}
+        if _storage._sqlConf != rhs_storage._sqlConf {return false}
+        if _storage._clientID != rhs_storage._clientID {return false}
+        if _storage._sourceCodeLocation != rhs_storage._sourceCodeLocation {return false}
+        if _storage._details != rhs_storage._details {return false}
+        if _storage._once != rhs_storage._once {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
+}
+
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.SCDType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SCD_TYPE_UNSPECIFIED\0\u{1}SCD_TYPE_1\0")
 }
 
 nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -1814,6 +2008,85 @@ nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlow
 
   static func ==(lhs: Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails, rhs: Spark_Connect_PipelineCommand.DefineFlow.WriteRelationFlowDetails) -> Bool {
     if lhs._relation != rhs._relation {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = Spark_Connect_PipelineCommand.DefineFlow.protoMessageName + ".AutoCdcFlowDetails"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}source\0\u{1}keys\0\u{3}sequence_by\0\u{4}\u{3}apply_as_deletes\0\u{3}apply_as_truncates\0\u{3}column_list\0\u{3}except_column_list\0\u{3}stored_as_scd_type\0\u{4}\u{4}ignore_null_updates_column_list\0\u{3}ignore_null_updates_except_column_list\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._source) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.keys) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._sequenceBy) }()
+      case 6: try { try decoder.decodeSingularMessageField(value: &self._applyAsDeletes) }()
+      case 7: try { try decoder.decodeSingularMessageField(value: &self._applyAsTruncates) }()
+      case 8: try { try decoder.decodeRepeatedMessageField(value: &self.columnList) }()
+      case 9: try { try decoder.decodeRepeatedMessageField(value: &self.exceptColumnList) }()
+      case 10: try { try decoder.decodeSingularEnumField(value: &self.storedAsScdType) }()
+      case 14: try { try decoder.decodeRepeatedMessageField(value: &self.ignoreNullUpdatesColumnList) }()
+      case 15: try { try decoder.decodeRepeatedMessageField(value: &self.ignoreNullUpdatesExceptColumnList) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._source {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    } }()
+    if !self.keys.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.keys, fieldNumber: 2)
+    }
+    try { if let v = self._sequenceBy {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._applyAsDeletes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    } }()
+    try { if let v = self._applyAsTruncates {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    } }()
+    if !self.columnList.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.columnList, fieldNumber: 8)
+    }
+    if !self.exceptColumnList.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.exceptColumnList, fieldNumber: 9)
+    }
+    if self.storedAsScdType != .unspecified {
+      try visitor.visitSingularEnumField(value: self.storedAsScdType, fieldNumber: 10)
+    }
+    if !self.ignoreNullUpdatesColumnList.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.ignoreNullUpdatesColumnList, fieldNumber: 14)
+    }
+    if !self.ignoreNullUpdatesExceptColumnList.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.ignoreNullUpdatesExceptColumnList, fieldNumber: 15)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails, rhs: Spark_Connect_PipelineCommand.DefineFlow.AutoCdcFlowDetails) -> Bool {
+    if lhs._source != rhs._source {return false}
+    if lhs.keys != rhs.keys {return false}
+    if lhs._sequenceBy != rhs._sequenceBy {return false}
+    if lhs._applyAsDeletes != rhs._applyAsDeletes {return false}
+    if lhs._applyAsTruncates != rhs._applyAsTruncates {return false}
+    if lhs.columnList != rhs.columnList {return false}
+    if lhs.exceptColumnList != rhs.exceptColumnList {return false}
+    if lhs.storedAsScdType != rhs.storedAsScdType {return false}
+    if lhs.ignoreNullUpdatesColumnList != rhs.ignoreNullUpdatesColumnList {return false}
+    if lhs.ignoreNullUpdatesExceptColumnList != rhs.ignoreNullUpdatesExceptColumnList {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SparkConnect/relations.pb.swift
+++ b/Sources/SparkConnect/relations.pb.swift
@@ -424,6 +424,14 @@ nonisolated struct Spark_Connect_Relation: @unchecked Sendable {
     set {_uniqueStorage()._relType = .relationChanges(newValue)}
   }
 
+  var nearestByJoin: Spark_Connect_NearestByJoin {
+    get {
+      if case .nearestByJoin(let v)? = _storage._relType {return v}
+      return Spark_Connect_NearestByJoin()
+    }
+    set {_uniqueStorage()._relType = .nearestByJoin(newValue)}
+  }
+
   /// NA functions
   var fillNa: Spark_Connect_NAFill {
     get {
@@ -598,6 +606,7 @@ nonisolated struct Spark_Connect_Relation: @unchecked Sendable {
     case lateralJoin(Spark_Connect_LateralJoin)
     case chunkedCachedLocalRelation(Spark_Connect_ChunkedCachedLocalRelation)
     case relationChanges(Spark_Connect_RelationChanges)
+    case nearestByJoin(Spark_Connect_NearestByJoin)
     /// NA functions
     case fillNa(Spark_Connect_NAFill)
     case dropNa(Spark_Connect_NADrop)
@@ -3789,13 +3798,83 @@ nonisolated struct Spark_Connect_LateralJoin: @unchecked Sendable {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
+/// Relation of type [[NearestByJoin]].
+///
+/// For each row on the left side, returns up to `num_results` rows from the right side ranked
+/// by `ranking_expression`.
+nonisolated struct Spark_Connect_NearestByJoin: @unchecked Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// (Required) Left (query) input relation.
+  var left: Spark_Connect_Relation {
+    get {_storage._left ?? Spark_Connect_Relation()}
+    set {_uniqueStorage()._left = newValue}
+  }
+  /// Returns true if `left` has been explicitly set.
+  var hasLeft: Bool {_storage._left != nil}
+  /// Clears the value of `left`. Subsequent reads from it will return its default value.
+  mutating func clearLeft() {_uniqueStorage()._left = nil}
+
+  /// (Required) Right (base) input relation.
+  var right: Spark_Connect_Relation {
+    get {_storage._right ?? Spark_Connect_Relation()}
+    set {_uniqueStorage()._right = newValue}
+  }
+  /// Returns true if `right` has been explicitly set.
+  var hasRight: Bool {_storage._right != nil}
+  /// Clears the value of `right`. Subsequent reads from it will return its default value.
+  mutating func clearRight() {_uniqueStorage()._right = nil}
+
+  /// (Required) Scalar expression used to rank candidate rows on the right side.
+  var rankingExpression: Spark_Connect_Expression {
+    get {_storage._rankingExpression ?? Spark_Connect_Expression()}
+    set {_uniqueStorage()._rankingExpression = newValue}
+  }
+  /// Returns true if `rankingExpression` has been explicitly set.
+  var hasRankingExpression: Bool {_storage._rankingExpression != nil}
+  /// Clears the value of `rankingExpression`. Subsequent reads from it will return its default value.
+  mutating func clearRankingExpression() {_uniqueStorage()._rankingExpression = nil}
+
+  /// (Required) Maximum number of matches per left row. Must be between 1 and 100000.
+  var numResults: Int32 {
+    get {_storage._numResults}
+    set {_uniqueStorage()._numResults = newValue}
+  }
+
+  /// (Required) The join type. Must be one of: "inner", "leftouter".
+  var joinType: String {
+    get {_storage._joinType}
+    set {_uniqueStorage()._joinType = newValue}
+  }
+
+  /// (Required) Search algorithm contract. Must be one of: "approx", "exact".
+  var mode: String {
+    get {_storage._mode}
+    set {_uniqueStorage()._mode = newValue}
+  }
+
+  /// (Required) Ranking direction. Must be one of: "distance", "similarity".
+  var direction: String {
+    get {_storage._direction}
+    set {_uniqueStorage()._direction = newValue}
+  }
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate nonisolated let _protobuf_package = "spark.connect"
 
 nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Relation"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}common\0\u{1}read\0\u{1}project\0\u{1}filter\0\u{1}join\0\u{3}set_op\0\u{1}sort\0\u{1}limit\0\u{1}aggregate\0\u{1}sql\0\u{3}local_relation\0\u{1}sample\0\u{1}offset\0\u{1}deduplicate\0\u{1}range\0\u{3}subquery_alias\0\u{1}repartition\0\u{3}to_df\0\u{3}with_columns_renamed\0\u{3}show_string\0\u{1}drop\0\u{1}tail\0\u{3}with_columns\0\u{1}hint\0\u{1}unpivot\0\u{3}to_schema\0\u{3}repartition_by_expression\0\u{3}map_partitions\0\u{3}collect_metrics\0\u{1}parse\0\u{3}group_map\0\u{3}co_group_map\0\u{3}with_watermark\0\u{3}apply_in_pandas_with_state\0\u{3}html_string\0\u{3}cached_local_relation\0\u{3}cached_remote_relation\0\u{3}common_inline_user_defined_table_function\0\u{3}as_of_join\0\u{3}common_inline_user_defined_data_source\0\u{3}with_relations\0\u{1}transpose\0\u{3}unresolved_table_valued_function\0\u{3}lateral_join\0\u{3}chunked_cached_local_relation\0\u{3}relation_changes\0\u{4},fill_na\0\u{3}drop_na\0\u{1}replace\0\u{2}\u{8}summary\0\u{1}crosstab\0\u{1}describe\0\u{1}cov\0\u{1}corr\0\u{3}approx_quantile\0\u{3}freq_items\0\u{3}sample_by\0\u{2}]\u{1}catalog\0\u{4}d\u{1}ml_relation\0\u{2}z\u{a}extension\0\u{1}unknown\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}common\0\u{1}read\0\u{1}project\0\u{1}filter\0\u{1}join\0\u{3}set_op\0\u{1}sort\0\u{1}limit\0\u{1}aggregate\0\u{1}sql\0\u{3}local_relation\0\u{1}sample\0\u{1}offset\0\u{1}deduplicate\0\u{1}range\0\u{3}subquery_alias\0\u{1}repartition\0\u{3}to_df\0\u{3}with_columns_renamed\0\u{3}show_string\0\u{1}drop\0\u{1}tail\0\u{3}with_columns\0\u{1}hint\0\u{1}unpivot\0\u{3}to_schema\0\u{3}repartition_by_expression\0\u{3}map_partitions\0\u{3}collect_metrics\0\u{1}parse\0\u{3}group_map\0\u{3}co_group_map\0\u{3}with_watermark\0\u{3}apply_in_pandas_with_state\0\u{3}html_string\0\u{3}cached_local_relation\0\u{3}cached_remote_relation\0\u{3}common_inline_user_defined_table_function\0\u{3}as_of_join\0\u{3}common_inline_user_defined_data_source\0\u{3}with_relations\0\u{1}transpose\0\u{3}unresolved_table_valued_function\0\u{3}lateral_join\0\u{3}chunked_cached_local_relation\0\u{3}relation_changes\0\u{3}nearest_by_join\0\u{4}+fill_na\0\u{3}drop_na\0\u{1}replace\0\u{2}\u{8}summary\0\u{1}crosstab\0\u{1}describe\0\u{1}cov\0\u{1}corr\0\u{3}approx_quantile\0\u{3}freq_items\0\u{3}sample_by\0\u{2}]\u{1}catalog\0\u{4}d\u{1}ml_relation\0\u{2}z\u{a}extension\0\u{1}unknown\0")
 
   fileprivate class _StorageClass {
     var _common: Spark_Connect_RelationCommon? = nil
@@ -4416,6 +4495,19 @@ nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtob
             _storage._relType = .relationChanges(v)
           }
         }()
+        case 47: try {
+          var v: Spark_Connect_NearestByJoin?
+          var hadOneofValue = false
+          if let current = _storage._relType {
+            hadOneofValue = true
+            if case .nearestByJoin(let m) = current {v = m}
+          }
+          try decoder.decodeSingularMessageField(value: &v)
+          if let v = v {
+            if hadOneofValue {try decoder.handleConflictingOneOf()}
+            _storage._relType = .nearestByJoin(v)
+          }
+        }()
         case 90: try {
           var v: Spark_Connect_NAFill?
           var hadOneofValue = false
@@ -4806,6 +4898,10 @@ nonisolated extension Spark_Connect_Relation: SwiftProtobuf.Message, SwiftProtob
       case .relationChanges?: try {
         guard case .relationChanges(let v)? = _storage._relType else { preconditionFailure() }
         try visitor.visitSingularMessageField(value: v, fieldNumber: 46)
+      }()
+      case .nearestByJoin?: try {
+        guard case .nearestByJoin(let v)? = _storage._relType else { preconditionFailure() }
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 47)
       }()
       case .fillNa?: try {
         guard case .fillNa(let v)? = _storage._relType else { preconditionFailure() }
@@ -10303,6 +10399,118 @@ nonisolated extension Spark_Connect_LateralJoin: SwiftProtobuf.Message, SwiftPro
         if _storage._right != rhs_storage._right {return false}
         if _storage._joinCondition != rhs_storage._joinCondition {return false}
         if _storage._joinType != rhs_storage._joinType {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Spark_Connect_NearestByJoin: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".NearestByJoin"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}left\0\u{1}right\0\u{3}ranking_expression\0\u{3}num_results\0\u{3}join_type\0\u{1}mode\0\u{1}direction\0")
+
+  fileprivate class _StorageClass {
+    var _left: Spark_Connect_Relation? = nil
+    var _right: Spark_Connect_Relation? = nil
+    var _rankingExpression: Spark_Connect_Expression? = nil
+    var _numResults: Int32 = 0
+    var _joinType: String = String()
+    var _mode: String = String()
+    var _direction: String = String()
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _left = source._left
+      _right = source._right
+      _rankingExpression = source._rankingExpression
+      _numResults = source._numResults
+      _joinType = source._joinType
+      _mode = source._mode
+      _direction = source._direction
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._left) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._right) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._rankingExpression) }()
+        case 4: try { try decoder.decodeSingularInt32Field(value: &_storage._numResults) }()
+        case 5: try { try decoder.decodeSingularStringField(value: &_storage._joinType) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._mode) }()
+        case 7: try { try decoder.decodeSingularStringField(value: &_storage._direction) }()
+        default: break
+        }
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._left {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      } }()
+      try { if let v = _storage._right {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      } }()
+      try { if let v = _storage._rankingExpression {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      } }()
+      if _storage._numResults != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._numResults, fieldNumber: 4)
+      }
+      if !_storage._joinType.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._joinType, fieldNumber: 5)
+      }
+      if !_storage._mode.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._mode, fieldNumber: 6)
+      }
+      if !_storage._direction.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._direction, fieldNumber: 7)
+      }
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Spark_Connect_NearestByJoin, rhs: Spark_Connect_NearestByJoin) -> Bool {
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._left != rhs_storage._left {return false}
+        if _storage._right != rhs_storage._right {return false}
+        if _storage._rankingExpression != rhs_storage._rankingExpression {return false}
+        if _storage._numResults != rhs_storage._numResults {return false}
+        if _storage._joinType != rhs_storage._joinType {return false}
+        if _storage._mode != rhs_storage._mode {return false}
+        if _storage._direction != rhs_storage._direction {return false}
         return true
       }
       if !storagesAreEqual {return false}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `Spark Connect`-generated Swift source code by regenerating with `4.2.0-rc3`.

- apache/spark#55446
- apache/spark#55589
- apache/spark#55682

### Why are the changes needed?

To keep the generated Swift source code in sync with Apache Spark `4.2.0-rc3` protobuf definitions.

```
$ git clone -b v4.2.0-rc3 https://github.com/apache/spark.git
$ cd spark/sql/connect/common/src/main/protobuf/
$ protoc --swift_out=. spark/connect/*.proto
$ protoc --grpc-swift_out=. spark/connect/*.proto

// Remove empty GRPC files
$ cd spark/connect
$ grep 'This file contained no services' * | awk -F: '{print $1}' | xargs rm
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8