### PR TITLE
[SPARK-57731] Upgrade `gRPC Swift Protobuf` to 2.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.8.0"),
     .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.7.2")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Apache Spark 4.1.2 (May 2026)](https://github.com/apache/spark/releases/tag/v4.1.2)
 - [Swift 6.3.2 (May 2026)](https://swift.org)
 - [gRPC Swift 2.4 (April 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.0)
-- [gRPC Swift Protobuf 2.4.0 (May 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.0)
+- [gRPC Swift Protobuf 2.4.1 (June 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.1)
 - [gRPC Swift NIO Transport 2.8.0 (June 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.8.0)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
 - [Swift System 1.7.2 (June 2026)](https://github.com/apple/swift-system/releases/tag/1.7.2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `grpc-swift-protobuf` to 2.4.1.

### Why are the changes needed?

To bring the latest bug fixes and improvements.
- https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.1
  - https://github.com/grpc/grpc-swift-protobuf/pull/102

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8