### PR TITLE
[SPARK-57734] Use 4.2.0 RC4 for Spark 4.2 integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -155,7 +155,7 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.2.0-rc3-bin/spark-4.2.0-bin-hadoop3.tgz
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.2.0-rc4-bin/spark-4.2.0-bin-hadoop3.tgz
         tar xvfz spark-4.2.0-bin-hadoop3.tgz && rm spark-4.2.0-bin-hadoop3.tgz
         mv spark-4.2.0-bin-hadoop3/ /tmp/spark
         cd /tmp/spark/sbin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `integration-test-mac-spark42` CI job to use `Apache Spark 4.2.0` RC4.

### Why are the changes needed?

To test against the latest `Apache Spark 4.2.0` RC4.
- https://dist.apache.org/repos/dist/dev/spark/v4.2.0-rc4-bin/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8