### PR TITLE
[SPARK-57914] Pin `apache/skywalking-eyes` to `v0.8.0` commit hash

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Check license header
-        uses: apache/skywalking-eyes@main
+        uses: apache/skywalking-eyes@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `apache/skywalking-eyes` GitHub Action to the `v0.8.0` release commit hash instead of the `main` branch.

### Why are the changes needed?

Currently, the `License Check` job tracks the `main` branch of `apache/skywalking-eyes`, so any upstream change is picked up immediately and may break or alter CI behavior unexpectedly. Pinning to the commit hash of the released `v0.8.0` tag (`61275cc`, `Release Apache SkyWalking-Eyes 0.8.0`) makes the CI reproducible and immutable.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs, especially the `License Check` job.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5