### PR TITLE
[SPARK-57967] Upgrade Swift Docker image to 6.3.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,8 +54,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.2 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3.2 swift build -c release
+        docker run swift:6.3.3 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.3 swift build -c release
 
   build-ubuntu-arm:
     runs-on: ubuntu-24.04-arm
@@ -64,8 +64,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.2 uname -a
-        docker run -v $PWD:/spark -w /spark swift:6.3.2 swift build -c release
+        docker run swift:6.3.3 uname -a
+        docker run -v $PWD:/spark -w /spark swift:6.3.3 swift build -c release
 
   integration-test-ubuntu:
     runs-on: ubuntu-latest
@@ -83,8 +83,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.2 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
+        docker run swift:6.3.3 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.3 swift test --no-parallel -c release
 
   integration-test-ubuntu-spark41:
     runs-on: ubuntu-latest
@@ -102,8 +102,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build
       run: |
-        docker run swift:6.3.2 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
+        docker run swift:6.3.3 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.3 swift test --no-parallel -c release
 
   integration-test-ubuntu-spark42:
     runs-on: ubuntu-latest
@@ -118,8 +118,8 @@ jobs:
           -c spark.sql.timeType.enabled=true
     - name: Test
       run: |
-        docker run swift:6.3.2 uname -a
-        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.2 swift test --no-parallel -c release
+        docker run swift:6.3.3 uname -a
+        docker run --add-host=host.docker.internal:host-gateway -v $PWD:/spark -w /spark -e SPARK_REMOTE='sc://host.docker.internal:15003' swift:6.3.3 swift test --no-parallel -c release
 
   integration-test-mac-spark41:
     runs-on: macos-26

--- a/Examples/app/Dockerfile
+++ b/Examples/app/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.2 AS builder
+FROM swift:6.3.3 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.3-release/static-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/pi/Dockerfile
+++ b/Examples/pi/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.2 AS builder
+FROM swift:6.3.3 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.3-release/static-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/spark-sql/Dockerfile
+++ b/Examples/spark-sql/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.2 AS builder
+FROM swift:6.3.3 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.3-release/static-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 

--- a/Examples/stream/Dockerfile
+++ b/Examples/stream/Dockerfile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM swift:6.3.2 AS builder
+FROM swift:6.3.3 AS builder
 
 WORKDIR /app
 
-ADD https://download.swift.org/swift-6.3.2-release/static-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
+ADD https://download.swift.org/swift-6.3.3-release/static-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz /tmp/swift-static-sdk.tar.gz
 RUN swift sdk install /tmp/swift-static-sdk.tar.gz && \
     rm /tmp/swift-static-sdk.tar.gz
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the Swift Docker image to 6.3.3.

- `docker run swift:6.3.3` in the CI build and integration test jobs (`build_and_test.yml`)
- `FROM swift:6.3.3` and the `swift-6.3.3-RELEASE` static Linux SDK URL in the four example Dockerfiles (`app`, `pi`, `spark-sql`, `stream`)

### Why are the changes needed?

To use the latest Swift 6.3.3 release for building and testing.
- https://github.com/swiftlang/swift/releases/tag/swift-6.3.3-RELEASE (2026-06-30)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5