### PR TITLE
[SPARK-58048] Add `Swift 6.4` build test CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,6 +47,16 @@ jobs:
     - name: Build
       run: swift build -c release
 
+  build-ubuntu-swift64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build
+      run: |
+        docker run swiftlang/swift:nightly-6.4.x-amazonlinux2023 uname -a
+        docker run -v $PWD:/spark -w /spark swiftlang/swift:nightly-6.4.x-amazonlinux2023 swift build
+
   build-ubuntu-latest:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Swift 6.4` build test CI.

### Why are the changes needed?

To be ready for the upcoming Swift 6.4.
- https://forums.swift.org/t/swift-6-4-release-process/85421
  - Branch Cut: 2026-05-04

### Does this PR introduce _any_ user-facing change?

No, this is a test infra change.

### How was this patch tested?

Pass the CIs and check the log.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5