### PR TITLE
[SPARK-58141] Use Apache Spark 4.2.0 for Spark 4.2 integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -165,8 +165,8 @@ jobs:
       run: swift test --filter NOTHING -c release
     - name: Test
       run: |
-        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.2.0-rc5-bin/spark-4.2.0-bin-hadoop3.tgz
-        echo "3b36907aea8f9a4104fec1f99b5478af2472978813a28df37e05b673ee163b880d908ac1396a11c3bb369a36244b0c9f05ed6d8bcbe24070dc25ed43d7ff7c09  spark-4.2.0-bin-hadoop3.tgz" | shasum -a 512 -c
+        curl -LO https://www.apache.org/dyn/closer.lua/spark/spark-4.2.0/spark-4.2.0-bin-hadoop3.tgz?action=download
+        echo "3a6559e8546ff387db8fe7a04b8fe4008853b467b972c2e343df8e14a81450534777719fc5d4998dd96519a86fdf9de140cee753c61e2e94db044d5f9555ddc4  spark-4.2.0-bin-hadoop3.tgz" | shasum -a 512 -c
         tar xvfz spark-4.2.0-bin-hadoop3.tgz && rm spark-4.2.0-bin-hadoop3.tgz
         mv spark-4.2.0-bin-hadoop3/ /tmp/spark
         cd /tmp/spark/sbin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ catalog, ML) over gRPC, exchanging results in Apache Arrow format.
 - **Swift 6.3.2+** with Swift Package Manager (`swift-tools-version: 6.3.2`).
 - **Platforms**: macOS 15+, iOS 18+, watchOS 11+, tvOS 18+, and Linux
   (built and tested on Ubuntu x86_64 & arm64 with the Swift 6.3.2 toolchain).
-- **Server**: Apache Spark 4.x Connect server (tested against 4.0.3 / 4.1.2 / 4.2.0-preview).
+- **Server**: Apache Spark 4.x Connect server (tested against 4.0.3 / 4.1.2 / 4.2.0).
 - **Dependencies** (all pinned with `exact` in [Package.swift](Package.swift)):
   `grpc-swift-2`, `grpc-swift-protobuf`, `grpc-swift-nio-transport`,
   `flatbuffers`, `swift-system`. Keep version bumps as `exact` pins, never


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `integration-test-mac-spark42` CI job to use the official `Apache Spark 4.2.0` release instead of RC5, with the updated SHA-512 checksum.

### Why are the changes needed?

To test against the official `Apache Spark 4.2.0` release.
- https://dlcdn.apache.org/spark/spark-4.2.0/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5