### PR TITLE
[SPARK-58254] Upgrade `swift-system` to 1.7.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.9.0"),
     .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),
-    .package(url: "https://github.com/apple/swift-system.git", exact: "1.7.4")
+    .package(url: "https://github.com/apple/swift-system.git", exact: "1.7.5")
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [gRPC Swift Protobuf 2.4.1 (June 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.1)
 - [gRPC Swift NIO Transport 2.9.0 (June 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.9.0)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
-- [Swift System 1.7.2 (June 2026)](https://github.com/apple/swift-system/releases/tag/1.7.2)
+- [Swift System 1.7.5 (July 2026)](https://github.com/apple/swift-system/releases/tag/1.7.5)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)
 
 So far, this library project is tracking the upstream changes of [Apache Arrow](https://arrow.apache.org) project's Swift-support.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `swift-system` to 1.7.5.

### Why are the changes needed?

To bring the latest bug fixes.

- https://github.com/apple/swift-system/releases/tag/1.7.5
  - https://github.com/apple/swift-system/pull/355

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5