### PR TITLE
[SPARK-58337] Fix `StreamingQuery.exception()` to return `nil` when no exception exists

### DIFF
--- a/Sources/SparkConnect/StreamingQuery.swift
+++ b/Sources/SparkConnect/StreamingQuery.swift
@@ -83,10 +83,13 @@ public actor StreamingQuery: Sendable {
   }
 
   /// Returns the ``StreamingQueryException`` if the query was terminated by an exception.
-  /// - Returns: A ``StreamingQueryException``.
+  /// - Returns: A ``StreamingQueryException`` if the query was terminated by an exception, `nil` otherwise.
   public func exception() async throws -> StreamingQueryException? {
     let response = try await executeCommand(StreamingQueryCommand.OneOf_Command.exception(true))
     let result = response.first!.streamingQueryCommandResult.exception
+    guard result.hasExceptionMessage else {
+      return nil
+    }
     return StreamingQueryException(
       exceptionMessage: result.exceptionMessage,
       errorClass: result.errorClass,

--- a/Tests/SparkConnectTests/StreamingQueryTests.swift
+++ b/Tests/SparkConnectTests/StreamingQueryTests.swift
@@ -58,4 +58,38 @@ struct StreamingQueryTests {
     }
     await spark.stop()
   }
+
+  @Test
+  func exception() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+
+    // Prepare directories
+    let input = "/tmp/input-" + UUID().uuidString
+    let checkpoint = "/tmp/checkpoint-" + UUID().uuidString
+    let output = "/tmp/output-" + UUID().uuidString
+    try await spark.range(2025).write.orc(input)
+
+    // Start a streaming query
+    let query =
+      try await spark
+      .readStream
+      .schema("id LONG")
+      .orc(input)
+      .writeStream
+      .option("checkpointLocation", checkpoint)
+      .outputMode("append")
+      .format("orc")
+      .trigger(Trigger.ProcessingTime(1000))
+      .start(output)
+    #expect(try await query.isActive)
+
+    // A query without any exception returns nil.
+    #expect(try await query.exception() == nil)
+
+    try await query.stop()
+    #expect(try await query.isActive == false)
+    #expect(try await query.exception() == nil)
+
+    await spark.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `StreamingQuery.exception()` to return `nil` when the query has no exception, by checking the `hasExceptionMessage` accessor of the optional proto field like the PySpark client.

### Why are the changes needed?

Previously, `exception()` always returned a `StreamingQueryException` filled with empty strings even when there was no exception, although its return type is optional. PySpark and Scala clients return `None`/`null` in that case.

### Does this PR introduce _any_ user-facing change?

Yes, `StreamingQuery.exception()` now returns `nil` instead of an empty `StreamingQueryException` when the query has no exception.

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5