### PR TITLE
[SPARK-58345] Handle Arrow message load failures in `DataFrame.execute`

### DIFF
--- a/Sources/SparkConnect/ArrowReader.swift
+++ b/Sources/SparkConnect/ArrowReader.swift
@@ -462,9 +462,12 @@ public class ArrowReader {  // swiftlint:disable:this type_body_length
         return .failure(error)
       }
     case .recordbatch:
+      guard let messageSchema = result.messageSchema, let arrowSchema = result.schema else {
+        return .failure(.invalid("Record batch received before schema"))
+      }
       let rbMessage = message.header(type: org_apache_arrow_flatbuf_RecordBatch.self)!
       let recordBatchResult = try loadRecordBatch(
-        rbMessage, schema: result.messageSchema!, arrowSchema: result.schema!,
+        rbMessage, schema: messageSchema, arrowSchema: arrowSchema,
         data: dataBody, messageEndOffset: 0
       )
       switch recordBatchResult {

--- a/Sources/SparkConnect/DataFrame+Actions.swift
+++ b/Sources/SparkConnect/DataFrame+Actions.swift
@@ -87,8 +87,16 @@ extension DataFrame {
             // Read ArrowBatches
             let reader = ArrowReader()
             let arrowResult = ArrowReader.makeArrowReaderResult()
-            _ = reader.fromMessage(schema, dataBody: Data(), result: arrowResult)
-            _ = reader.fromMessage(dataHeader, dataBody: dataBody, result: arrowResult)
+            if case .failure(let error) = reader.fromMessage(
+              schema, dataBody: Data(), result: arrowResult)
+            {
+              throw error
+            }
+            if case .failure(let error) = reader.fromMessage(
+              dataHeader, dataBody: dataBody, result: arrowResult)
+            {
+              throw error
+            }
             await self.addBatches(arrowResult.batches)
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `DataFrame.execute()` to throw an error when `ArrowReader.fromMessage` fails, instead of ignoring the returned `Result`. In addition, `ArrowReader.fromMessage` now returns `.failure` instead of force-unwrapping `result.messageSchema!` when a record batch arrives before the schema.

### Why are the changes needed?

Previously, a schema load failure (e.g., an unsupported Arrow type) crashed the process on the force-unwrap, and a record-batch load failure silently dropped data from `collect()` results.

### Does this PR introduce _any_ user-facing change?

No. Failures which previously crashed or silently dropped data now throw an error.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5