### PR TITLE
[SPARK-58427] Support `randomSplit` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/DataFrame+Transformations.swift
+++ b/Sources/SparkConnect/DataFrame+Transformations.swift
@@ -278,7 +278,7 @@ extension DataFrame {
   public func sample(_ withReplacement: Bool, _ fraction: Double, _ seed: Int64) -> DataFrame {
     return DataFrame(
       spark: self.spark,
-      plan: SparkConnectClient.getSample(self.plan.root, withReplacement, fraction, seed))
+      plan: SparkConnectClient.getSample(self.plan.root, withReplacement, 0.0, fraction, seed))
   }
 
   /// Returns a new ``Dataset`` by sampling a fraction of rows, using a random seed.
@@ -307,6 +307,37 @@ extension DataFrame {
   /// - Returns: A subset of the records.
   public func sample(_ fraction: Double) -> DataFrame {
     return sample(false, fraction)
+  }
+
+  /// Randomly splits this ``DataFrame`` with the provided weights, using a user-supplied seed.
+  /// - Parameters:
+  ///   - weights: Weights for splits. Must be non-empty and positive. They will be normalized
+  ///     if they don't sum up to 1.
+  ///   - seed: Seed for sampling.
+  /// - Returns: An array of ``DataFrame``s whose element count is equal to the weight count.
+  public func randomSplit(_ weights: [Double], _ seed: Int64) throws -> [DataFrame] {
+    guard !weights.isEmpty, weights.allSatisfy({ $0 > 0 }) else {
+      throw SparkConnectError.InvalidArgument
+    }
+    let sum = weights.reduce(0, +)
+    var normalizedCumWeights: [Double] = [0.0]
+    for weight in weights {
+      normalizedCumWeights.append(normalizedCumWeights.last! + weight / sum)
+    }
+    return (0..<weights.count).map { i in
+      DataFrame(
+        spark: self.spark,
+        plan: SparkConnectClient.getSample(
+          self.plan.root, false, normalizedCumWeights[i], normalizedCumWeights[i + 1], seed, true))
+    }
+  }
+
+  /// Randomly splits this ``DataFrame`` with the provided weights, using a random seed.
+  /// - Parameter weights: Weights for splits. Must be non-empty and positive. They will be
+  ///   normalized if they don't sum up to 1.
+  /// - Returns: An array of ``DataFrame``s whose element count is equal to the weight count.
+  public func randomSplit(_ weights: [Double]) throws -> [DataFrame] {
+    return try randomSplit(weights, Int64.random(in: Int64.min...Int64.max))
   }
 
   // MARK: - Join Operations

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -721,14 +721,16 @@ public actor SparkConnectClient {
   }
 
   static func getSample(
-    _ child: Relation, _ withReplacement: Bool, _ fraction: Double, _ seed: Int64
+    _ child: Relation, _ withReplacement: Bool, _ lowerBound: Double, _ upperBound: Double,
+    _ seed: Int64, _ deterministicOrder: Bool = false
   ) -> Plan {
     var sample = Sample()
     sample.input = child
     sample.withReplacement = withReplacement
-    sample.lowerBound = 0.0
-    sample.upperBound = fraction
+    sample.lowerBound = lowerBound
+    sample.upperBound = upperBound
     sample.seed = seed
+    sample.deterministicOrder = deterministicOrder
     return createPlan { $0.sample = sample }
   }
 

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -363,6 +363,27 @@ struct DataFrameTests {
   }
 
   @Test
+  func randomSplit() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1000)
+    let splits = try await df.randomSplit([1.0, 2.0, 3.0], 0)
+    #expect(splits.count == 3)
+    var total: Int64 = 0
+    for split in splits {
+      total += try await split.count()
+    }
+    #expect(total == 1000)
+    for (df1, df2) in zip(splits, try await df.randomSplit([1.0, 2.0, 3.0], 0)) {
+      #expect(try await df1.count() == df2.count())
+    }
+    await #expect(throws: SparkConnectError.InvalidArgument) { try await df.randomSplit([]) }
+    await #expect(throws: SparkConnectError.InvalidArgument) {
+      try await df.randomSplit([1.0, -1.0])
+    }
+    await spark.stop()
+  }
+
+  @Test
   func isEmpty() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(try await spark.range(0).isEmpty())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `DataFrame.randomSplit` API.

- `randomSplit(_ weights: [Double], _ seed: Int64) throws -> [DataFrame]`
- `randomSplit(_ weights: [Double]) throws -> [DataFrame]` (with a random seed)

Like the other Spark Connect clients (PySpark and Scala), it is implemented on the
client side by normalizing the weights into cumulative ranges and creating one
`Sample` relation per weight with the same seed, `deterministic_order = true`, and
`[lowerBound, upperBound)` ranges. `SparkConnectClient.getSample` is extended to
accept `lowerBound` and `deterministicOrder`.

### Why are the changes needed?

To improve the API coverage by providing feature parity with the other Spark clients.

### Does this PR introduce _any_ user-facing change?

No, this is a new API addition.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5