### PR TITLE
[SPARK-58430] Support `alias` for `DataFrame`

### DIFF
--- a/Sources/SparkConnect/DataFrame+Transformations.swift
+++ b/Sources/SparkConnect/DataFrame+Transformations.swift
@@ -288,6 +288,22 @@ extension DataFrame {
     return DataFrame(spark: self.spark, plan: SparkConnectClient.getOffset(self.plan.root, n))
   }
 
+  /// Returns a new ``DataFrame`` with an alias set. This is useful to disambiguate columns
+  /// with the same name in self-joins.
+  ///
+  /// ```swift
+  /// let df1 = df.alias("l")
+  /// let df2 = df.alias("r")
+  /// let joined = await df1.join(df2, joinExprs: "l.id = r.id")
+  /// ```
+  ///
+  /// - Parameter alias: The alias name.
+  /// - Returns: An aliased ``DataFrame``.
+  public func alias(_ alias: String) -> DataFrame {
+    return DataFrame(
+      spark: self.spark, plan: SparkConnectClient.getSubqueryAlias(self.plan.root, alias))
+  }
+
   /// Returns a new ``Dataset`` by sampling a fraction of rows, using a user-supplied seed.
   /// - Parameters:
   ///   - withReplacement: Sample with replacement or not.

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -730,6 +730,13 @@ public actor SparkConnectClient {
     return createPlan { $0.offset = offset }
   }
 
+  static func getSubqueryAlias(_ child: Relation, _ alias: String) -> Plan {
+    var subqueryAlias = Spark_Connect_SubqueryAlias()
+    subqueryAlias.input = child
+    subqueryAlias.alias = alias
+    return createPlan { $0.subqueryAlias = subqueryAlias }
+  }
+
   static func getSample(
     _ child: Relation, _ withReplacement: Bool, _ lowerBound: Double, _ upperBound: Double,
     _ seed: Int64, _ deterministicOrder: Bool = false

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -648,6 +648,17 @@ struct DataFrameTests {
   }
 
   @Test
+  func alias() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(3)
+    #expect(try await df.alias("a").select("a.id").collect() == [Row(0), Row(1), Row(2)])
+
+    let joined = try await df.alias("l").join(df.alias("r"), joinExprs: "l.id = r.id")
+    #expect(try await joined.orderBy("l.id").collect() == [Row(0, 0), Row(1, 1), Row(2, 2)])
+    await spark.stop()
+  }
+
+  @Test
   func lateralJoin() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     if await spark.version.starts(with: "4.") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `DataFrame.alias` API to support qualified column access and self-joins, like PySpark's `df.alias("a")`.

- `DataFrame.alias(_ alias: String) -> DataFrame` builds a `SubqueryAlias` relation on top of the current plan.
- `SparkConnectClient.getSubqueryAlias` is added following the existing `get*` relation helper pattern.

```swift
let df1 = df.alias("l")
let df2 = df.alias("r")
let joined = await df1.join(df2, joinExprs: "l.id = r.id")
```

### Why are the changes needed?

Without `alias`, it is difficult to disambiguate columns with the same name when self-joining a `DataFrame`. The `Spark_Connect_SubqueryAlias` relation already exists in the generated protobuf code but was unused.

### Does this PR introduce _any_ user-facing change?

Yes, this adds a new `DataFrame.alias` API.

### How was this patch tested?

Pass the CIs with a newly added test case covering qualified column access (`df.alias("a").select("a.id")`) and a self-join with two aliases, verified against a local Apache Spark 4.2.0 Connect server.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5