### PR TITLE
[SPARK-58491] Support `expr` in `Functions`

### DIFF
--- a/Sources/SparkConnect/Functions.swift
+++ b/Sources/SparkConnect/Functions.swift
@@ -175,6 +175,18 @@ public func desc(_ name: String) -> Column {
   return Column(name).desc()
 }
 
+/// Parses the expression string into the column that it represents.
+///
+/// ```swift
+/// df.select(expr("id + 1"))
+/// ```
+///
+/// - Parameter sqlExpr: A SQL expression string.
+/// - Returns: A ``Column``.
+public func expr(_ sqlExpr: String) -> Column {
+  return Column(sqlExpr.toExpression)
+}
+
 /// Returns the number of items in a group.
 /// - Parameter col: A ``Column`` to count.
 /// - Returns: A ``Column``.

--- a/Tests/SparkConnectTests/FunctionsTests.swift
+++ b/Tests/SparkConnectTests/FunctionsTests.swift
@@ -60,6 +60,11 @@ struct FunctionsTests {
   }
 
   @Test
+  func exprFunction() throws {
+    #expect(expr("id + 1").expr.expressionString.expression == "id + 1")
+  }
+
+  @Test
   func alias() throws {
     let expr = col("id").alias("x").expr
     #expect(expr.alias.name == ["x"])
@@ -356,6 +361,17 @@ struct FunctionsTests {
       .agg(count(col("*")).alias("cnt"), sum(col("id")), avg(col("id")))
       .orderBy("id").collect()
     #expect(rows == [Row(0, 1, 0, 0.0), Row(1, 1, 1, 1.0), Row(2, 1, 2, 2.0)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectWithExpr() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(3)
+    #expect(
+      try await df.select(expr("id + 1").alias("plus")).orderBy("plus").collect()
+        == [Row(1), Row(2), Row(3)])
+    #expect(try await df.filter(expr("id > 1")).count() == 1)
     await spark.stop()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `expr` function in `Functions`.

```swift
public func expr(_ sqlExpr: String) -> Column
```

### Why are the changes needed?

To improve the API compatibility with the Scala client's `functions.expr`, allowing users to build a `Column` from a SQL expression string.

```swift
df.select(expr("id + 1"))
df.filter(expr("id > 1"))
```

### Does this PR introduce _any_ user-facing change?

No, this is a new API addition.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5