### PR TITLE
[SPARK-58568] Support `TIME` type in `DataType.simpleString`

### DIFF
--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -329,6 +329,12 @@ extension DataType {
         "timestamp"
       case .timestampNtz:
         "timestamp_ntz"
+      case .time:
+        if self.time.hasPrecision {
+          "time(\(self.time.precision))"
+        } else {
+          "time(6)"
+        }
       case .calendarInterval:
         "interval"
       case .yearMonthInterval:

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -155,6 +155,23 @@ struct DataFrameTests {
   }
 
   @Test
+  func dtypesTime() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      try await spark.conf.set("spark.sql.timeType.enabled", "true")
+      let expected = [
+        ("TIME'12:34:56'", "time(6)"),
+        ("CAST(TIME'12:34:56' AS TIME(0))", "time(0)"),
+        ("CAST(TIME'12:34:56.123' AS TIME(3))", "time(3)"),
+      ]
+      for pair in expected {
+        #expect(try await spark.sql("SELECT \(pair.0)").dtypes[0].1 == pair.1)
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
   func array() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(try await spark.sql("SELECT array('a')").collect() == [Row(Array(["a"]))])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `TIME` type (added in Apache Spark 4.1) in `DataType.simpleString`
so that `DataFrame.schema`/`dtypes`/`printSchema` work on `TIME` columns.

Following Apache Spark's `TimeType.typeName` convention, the mapping uses `time(<precision>)`.
When the proto `precision` field is absent, it falls back to `time(6)` like Apache Spark's
`TimeType.DEFAULT_PRECISION` (`MICROS_PRECISION`).

### Why are the changes needed?

`Spark_Connect_DataType`'s `time` kind fell through to the `default:` branch of
`DataType.simpleString` and threw `SparkConnectError.InvalidType`. As a result,
`DataFrame.dtypes` failed entirely on any DataFrame containing a `TIME` column.

```swift
let df = try await spark.sql("SELECT TIME'12:34:56'")
try await df.dtypes  // Before: throws SparkConnectError.InvalidType
                     // After: [("TIME '12:34:56'", "time(6)")]
```

### Does this PR introduce _any_ user-facing change?

Yes, `DataFrame.dtypes` no longer throws on `TIME` columns and returns Spark-style type
strings instead. This is a bug fix from the unreleased perspective.

### How was this patch tested?

Pass the CIs with a newly added test case. The new test enables `spark.sql.timeType.enabled`
at the session level and is guarded to run on Apache Spark 4.2+ only.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5