### PR TITLE
[SPARK-58574] Support `TIME` type literals in `lit` and SQL parameter binding

### DIFF
--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -197,6 +197,9 @@ extension ExpressionLiteral {
       // `Date` is an absolute point in time, so it maps to Spark's `TIMESTAMP`
       // (microseconds since the UNIX epoch), not `DATE`.
       self.timestamp = Int64(value.timeIntervalSince1970 * 1_000_000)
+    case let value as LocalTime:
+      self.time.nano = value.nanoOfDay
+      self.time.precision = 6
     default:
       if case Optional<Any>.none = value as Any {
         var dataType = DataType()

--- a/Sources/SparkConnect/Functions.swift
+++ b/Sources/SparkConnect/Functions.swift
@@ -112,6 +112,16 @@ public func lit(_ value: String) -> Column {
   return litColumn(literal)
 }
 
+/// Creates a ``Column`` of literal value.
+/// - Parameter value: A literal value.
+/// - Returns: A ``Column``.
+public func lit(_ value: LocalTime) -> Column {
+  var literal = ExpressionLiteral()
+  literal.time.nano = value.nanoOfDay
+  literal.time.precision = 6
+  return litColumn(literal)
+}
+
 /// A type that can be used as a literal operand of ``Column`` operators.
 ///
 /// This allows Swift literals to be mixed with ``Column`` expressions directly
@@ -158,6 +168,10 @@ extension Double: SparkLiteral {
 }
 
 extension String: SparkLiteral {
+  public var toLiteralColumn: Column { lit(self) }
+}
+
+extension LocalTime: SparkLiteral {
   public var toLiteralColumn: Column { lit(self) }
 }
 

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -198,6 +198,19 @@ struct DataFrameTests {
   }
 
   @Test
+  func selectTimeLiteral() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      try await spark.conf.set("spark.sql.timeType.enabled", "true")
+      let time = try #require(LocalTime(hour: 12, minute: 34, second: 56, nanosecond: 123_456_000))
+      let df = try await spark.range(1).select(lit(time))
+      #expect(try await df.dtypes[0].1 == "time(6)")
+      #expect(try await df.collect() == [Row(time)])
+    }
+    await spark.stop()
+  }
+
+  @Test
   func array() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     #expect(try await spark.sql("SELECT array('a')").collect() == [Row(Array(["a"]))])

--- a/Tests/SparkConnectTests/FunctionsTests.swift
+++ b/Tests/SparkConnectTests/FunctionsTests.swift
@@ -57,6 +57,9 @@ struct FunctionsTests {
     #expect(lit(Float(1.0)).expr.literal.float == 1.0)
     #expect(lit(1.0).expr.literal.double == 1.0)
     #expect(lit("a").expr.literal.string == "a")
+    let time = try #require(LocalTime(hour: 12, minute: 34, second: 56))
+    #expect(lit(time).expr.literal.time.nano == 45_296_000_000_000)
+    #expect(lit(time).expr.literal.time.precision == 6)
   }
 
   @Test
@@ -253,6 +256,10 @@ struct FunctionsTests {
     #expect((col("a") == Float(1.0)).expr.unresolvedFunction.arguments[1].literal.float == 1.0)
     #expect((col("a") == 1.0).expr.unresolvedFunction.arguments[1].literal.double == 1.0)
     #expect((col("a") == "x").expr.unresolvedFunction.arguments[1].literal.string == "x")
+    let time = try #require(LocalTime(hour: 12, minute: 34, second: 56))
+    #expect(
+      (col("a") == time).expr.unresolvedFunction.arguments[1].literal.time.nano
+        == 45_296_000_000_000)
   }
 
   @Test

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -172,6 +172,20 @@ struct SparkSessionTests {
   }
 
   @Test
+  func sqlWithTimeParameter() async throws {
+    await SparkSession.builder.clear()
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await spark.version >= "4.2" {
+      try await spark.conf.set("spark.sql.timeType.enabled", "true")
+      let time = try #require(LocalTime(hour: 12, minute: 34, second: 56, nanosecond: 123_456_000))
+      #expect(try await spark.sql("SELECT typeof(?)", time).collect() == [Row("time(6)")])
+      #expect(try await spark.sql("SELECT ?", time).collect() == [Row(time)])
+      #expect(try await spark.sql("SELECT :t", args: ["t": time]).collect() == [Row(time)])
+    }
+    await spark.stop()
+  }
+
+  @Test
   func sqlWithUnsupportedParameterType() async throws {
     await SparkSession.builder.clear()
     let spark = try await SparkSession.builder.getOrCreate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `TIME` type literals in `lit` and SQL parameter binding.

- Add `lit(_ value: LocalTime)` which builds `Expression.Literal.Time` with `nano = nanoOfDay` and `precision = 6`, matching the Scala client (`TimeTypeConnectOps`) which always uses `DEFAULT_PRECISION`.
- Conform `LocalTime` to `SparkLiteral` so it can be used directly as an operand of `Column` operators, e.g. `col("t") == LocalTime(hour: 12, minute: 34, second: 56)!`.
- Handle `LocalTime` in `ExpressionLiteral.init(_:)` so it can be bound as a positional (`?`) or named (`:name`) parameter of `spark.sql`.

```swift
let time = LocalTime(hour: 12, minute: 34, second: 56)!
spark.range(1).select(lit(time))
try await spark.sql("SELECT ?", time)
try await spark.sql("SELECT :t", args: ["t": time])
```

### Why are the changes needed?

SPARK-58571 covered only the read path (`DataFrame.collect`). This completes the write path for expressions so that Swift users can send `TIME` values to the server via `lit`, `Column` operators, and parameterized SQL, on par with the Scala client.

### Does this PR introduce _any_ user-facing change?

Yes, `LocalTime` is newly accepted by `lit`, `Column` operators, and `spark.sql` parameters. There is no behavior change for existing code.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5