### PR TITLE
[SPARK-58644] Document intentional ignore of `queryStartedEventJson` in `DataStreamWriter`

### DIFF
--- a/Sources/SparkConnect/DataStreamWriter.swift
+++ b/Sources/SparkConnect/DataStreamWriter.swift
@@ -186,9 +186,9 @@ public actor DataStreamWriter: Sendable {
 
     let response = try await df.spark.client.execute(df.spark.sessionID, command)
     let result = response.first!.writeStreamOperationStartResult
-    if result.hasQueryStartedEventJson {
-      // TODO: post
-    }
+    // `result.queryStartedEventJson` is intentionally ignored because this client does not
+    // support `StreamingQueryListener` yet. Reference clients (PySpark/Scala) parse it and
+    // post it to their listener bus, which is a no-op when no listener is registered.
 
     let query = try await StreamingQuery(
       UUID(uuidString: result.queryID.id)!,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the dead `// TODO: post` block in `DataStreamWriter.start()` with a comment
documenting that `WriteStreamOperationStartResult.queryStartedEventJson` is intentionally
ignored because this client does not support `StreamingQueryListener` yet.

### Why are the changes needed?

The previous code checked `result.hasQueryStartedEventJson` and did nothing, leaving a
misleading `TODO` that suggested an unfinished code path. Reference clients (PySpark and
Scala Connect) parse this JSON into a `QueryStartedEvent` and post it to their
`StreamingQueryListener` bus, which is a no-op when no listener is registered. Since this
client has no listener subsystem, dropping the event is semantically equivalent; the comment
now records that decision and marks the posting point for future listener support.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. This is a comment-only change with no behavior difference.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5