### PR TITLE
[SPARK-52746] Test `isLocal` behavior explicitly for Spark 4.0 and 4.1+ servers

### DIFF
--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -539,10 +539,11 @@ struct DataFrameTests {
   func isLocal() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let version = await spark.version
-    if !(version.starts(with: "4.1") || version.starts(with: "4.2")) { // TODO(SPARK-52746)
-      #expect(try await spark.sql("SHOW DATABASES").isLocal())
-      #expect(try await spark.sql("SHOW TABLES").isLocal())
-    }
+    // Since Spark 4.1, `AnalyzePlan` no longer executes commands eagerly (SPARK-51818),
+    // so command plans are not local anymore.
+    let expected = version < "4.1"
+    #expect(try await spark.sql("SHOW DATABASES").isLocal() == expected)
+    #expect(try await spark.sql("SHOW TABLES").isLocal() == expected)
     #expect(try await spark.range(1).isLocal() == false)
     await spark.stop()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `isLocal` test in `DataFrameTests` to verify the version-specific expected behavior explicitly, replacing the previous `TODO(SPARK-52746)` guard that simply skipped the checks on Spark 4.1/4.2 servers.

- Spark 4.0.x servers: `SHOW DATABASES`/`SHOW TABLES` plans are expected to be local (`isLocal() == true`).
- Spark 4.1+ servers: they are expected to be non-local (`isLocal() == false`), which is now asserted instead of skipped.
- The version branch uses `version < "4.1"` (following the existing string-comparison pattern in this file) instead of enumerating `"4.1"`/`"4.2"` prefixes, so it keeps working for Spark 4.3+.

### Why are the changes needed?

The behavior difference is not a server bug awaiting a fix, but an intentional change in Spark 4.1 by [SPARK-51818](https://issues.apache.org/jira/browse/SPARK-51818) ("Move QueryExecution creation to AnalyzeHandler and don't Execute for AnalyzePlanRequests"). Up to 4.0, `AnalyzePlan` executed commands eagerly, so the analyzed plan became a `CommandResult` and `Dataset.isLocal` returned `true`. Since 4.1, commands are no longer executed during analysis (`CommandExecutionMode.SKIP`), so the plan stays an unexecuted command and `isLocal` returns `false`. Therefore `isLocal() == false` on 4.1+ is the expected behavior going forward and should be asserted, not skipped.
- https://github.com/apache/spark/pull/50605

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5