### PR TITLE
[SPARK-58957] Upgrade `gRPC Swift NIO Transport` to 2.9.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.2"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.1"),
-    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.9.1"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.9.2"),
     .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.8.0")
   ],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 - [Swift 6.3.2 (May 2026)](https://swift.org)
 - [gRPC Swift 2.4.2 (June 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.2)
 - [gRPC Swift Protobuf 2.4.1 (June 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.1)
-- [gRPC Swift NIO Transport 2.9.1 (August 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.9.1)
+- [gRPC Swift NIO Transport 2.9.2 (August 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.9.2)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)
 - [Swift System 1.8.0 (August 2026)](https://github.com/apple/swift-system/releases/tag/1.8.0)
 - [Apache Arrow Swift](https://github.com/apache/arrow-swift)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `grpc-swift-nio-transport` dependency to `2.9.2`.

### Why are the changes needed?

To adopt the latest `grpc-swift-nio-transport` release (`2.9.2`, 2026-08-20).
- https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.9.2
  - https://github.com/grpc/grpc-swift-nio-transport/pull/191

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5