### PR TITLE
[SPARK-59155] Support `TIME(p)` precision in `createDataFrame`

### DIFF
--- a/Sources/SparkConnect/ArrowSchema.swift
+++ b/Sources/SparkConnect/ArrowSchema.swift
@@ -26,11 +26,13 @@ public class ArrowField {
   public let type: ArrowType
   public let name: String
   public let isNullable: Bool
+  public let metadata: [String: String]?
 
-  init(_ name: String, type: ArrowType, isNullable: Bool) {
+  init(_ name: String, type: ArrowType, isNullable: Bool, metadata: [String: String]? = nil) {
     self.name = name
     self.type = type
     self.isNullable = isNullable
+    self.metadata = metadata
   }
 }
 

--- a/Sources/SparkConnect/ArrowWriter.swift
+++ b/Sources/SparkConnect/ArrowWriter.swift
@@ -97,6 +97,20 @@ public class ArrowWriter {  // swiftlint:disable:this type_body_length
       fieldsOffset = fbb.createVector(ofOffsets: offsets)
     }
 
+    var metadataOffset: Offset?
+    if let metadata = field.metadata, !metadata.isEmpty {
+      // Sort by key so that the serialized stream is deterministic for the same input.
+      var offsets = [Offset]()
+      for (key, value) in metadata.sorted(by: { $0.key < $1.key }) {
+        let keyOffset = fbb.create(string: key)
+        let valueOffset = fbb.create(string: value)
+        offsets.append(
+          org_apache_arrow_flatbuf_KeyValue.createKeyValue(
+            &fbb, keyOffset: keyOffset, valueOffset: valueOffset))
+      }
+      metadataOffset = fbb.createVector(ofOffsets: offsets)
+    }
+
     let nameOffset = fbb.create(string: field.name)
     let fieldTypeOffsetResult = toFBType(&fbb, arrowType: field.type)
     let startOffset = org_apache_arrow_flatbuf_Field.startField(&fbb)
@@ -104,6 +118,9 @@ public class ArrowWriter {  // swiftlint:disable:this type_body_length
     org_apache_arrow_flatbuf_Field.add(nullable: field.isNullable, &fbb)
     if let childrenOffset = fieldsOffset {
       org_apache_arrow_flatbuf_Field.addVectorOf(children: childrenOffset, &fbb)
+    }
+    if let metadataOffset {
+      org_apache_arrow_flatbuf_Field.addVectorOf(customMetadata: metadataOffset, &fbb)
     }
 
     switch toFBTypeEnum(field.type) {

--- a/Sources/SparkConnect/ConvertToArrow.swift
+++ b/Sources/SparkConnect/ConvertToArrow.swift
@@ -25,6 +25,10 @@ import Foundation
 
 /// A utility to convert local data into an `Apache Arrow` IPC stream for `LocalRelation`.
 enum ConvertToArrow {
+  /// An `Apache Arrow` field metadata key which `Apache Spark` uses to carry the fractional-second
+  /// precision of a `TIME(p)` column, because the `Apache Arrow` `Time` type has no such field.
+  private static let timePrecisionKey = "SPARK::time::precision"
+
   /// Convert the given rows into an `Apache Arrow` IPC stream according to the Spark schema.
   /// - Parameters:
   ///   - data: An array of rows whose values are ordered like the schema fields.
@@ -39,7 +43,9 @@ enum ConvertToArrow {
       let column = data.map { $0[i] }
       let holder = try toArrowColumn(column, field.dataType)
       batchBuilder.addColumn(
-        ArrowField(field.name, type: holder.type, isNullable: field.nullable), arrowArray: holder)
+        ArrowField(
+          field.name, type: holder.type, isNullable: field.nullable,
+          metadata: metadata(field.dataType)), arrowArray: holder)
     }
     switch batchBuilder.finish() {
     case .success(let batch):
@@ -54,6 +60,14 @@ enum ConvertToArrow {
     case .failure:
       throw SparkConnectError.InvalidArrowData
     }
+  }
+
+  /// Build the `Apache Arrow` field metadata for the given Spark data type, if any.
+  private static func metadata(_ dataType: ProtoDataType) -> [String: String]? {
+    if case .time(let time) = dataType.kind, time.hasPrecision {
+      return [timePrecisionKey: String(time.precision)]
+    }
+    return nil
   }
 
   /// Build an Arrow column from the given values according to the Spark data type.

--- a/Tests/SparkConnectTests/CreateDataFrameTests.swift
+++ b/Tests/SparkConnectTests/CreateDataFrameTests.swift
@@ -82,14 +82,17 @@ struct CreateDataFrameTests {
   @Test
   func timeType() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
-    if await spark.version >= "4.2" {
+    if await spark.version >= "4.3" {
       try await spark.conf.set("spark.sql.timeType.enabled", "true")
       let time = try #require(LocalTime(hour: 12, minute: 34, second: 56, nanosecond: 123_456_000))
       let df = try await spark.createDataFrame([[time], [nil]], "t TIME")
       #expect(try await df.dtypes.map { $0.1 } == ["time(6)"])
       #expect(try await df.collect() == [Row(time), Row(nil)])
-      #expect(
-        try await spark.createDataFrame([[time]], "t TIME(0)").dtypes.map { $0.1 } == ["time(0)"])
+      for precision in 0...6 {
+        #expect(
+          try await spark.createDataFrame([[time]], "t TIME(\(precision))").dtypes.map { $0.1 }
+            == ["time(\(precision))"])
+      }
     }
     await spark.stop()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to send the precision of `TIME(p)` columns as `Apache Arrow` field metadata when `createDataFrame` serializes local data into an `Apache Arrow` IPC stream.

The `Apache Arrow` `Time` type has no fractional-second precision field, so `Apache Spark` carries it in the field metadata under the `SPARK::time::precision` key. See `toPrecisionTaggedArrowField` / `fromArrowField` in [ArrowUtils.scala](https://github.com/apache/spark/blob/v4.3.0-rc1/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala).

- `ArrowField` gains an optional `metadata`, defaulting to `nil`.
- `ArrowWriter.writeField` writes it into the FlatBuffers `Field.custom_metadata` vector, sorted by key so that the same input yields a byte-identical stream.
- `ConvertToArrow` attaches the key to `TIME` columns.

### Why are the changes needed?

Apache Spark 4.3.0 implemented this in the following.
- https://github.com/apache/spark/pull/56778

Without the metadata, an `Apache Spark` 4.3.0 server reads a `time64[ns]` field as the canonical `TIME(6)` and rejects any other declared precision:

```swift
try await spark.createDataFrame([[time]], "t TIME(0)")
```

```
internalError: "[INVALID_COLUMN_OR_FIELD_DATA_TYPE] Column or field `col_0` is of type "TIME(6)" while it's required to be "TIME(0)". SQLSTATE: 42000"
```

### Does this PR introduce _any_ user-facing change?

Yes. `createDataFrame` with a `TIME(p)` schema now works for every precision against `Apache Spark` 4.3.0 and later, where it previously failed for any `p` other than `6`.

### How was this patch tested?

Pass the CIs with the existing tests first. Apache Spark 4.3.0 integration test will be added soon.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5