### PR TITLE
[SPARK-59156] Add `MacOS` integration test with Apache Spark `4.3.0` RC1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -174,6 +174,28 @@ jobs:
         cd -
         swift test --no-parallel -c release
 
+  integration-test-mac-spark43:
+    runs-on: macos-26
+    timeout-minutes: 20
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+    - uses: actions/checkout@v6
+    - name: Select Xcode 26.5
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Build
+      run: swift test --filter NOTHING -c release
+    - name: Test
+      run: |
+        curl -LO https://dist.apache.org/repos/dist/dev/spark/v4.3.0-rc1-bin/spark-4.3.0-bin-hadoop3.tgz
+        echo "18563bb57fa5e5367286a49845d44aa7e808e6c0f4dd151cb32cf71fffd17164734b4a2f54f81b94d69a58b4bdbac807cf05a33241ba9106c7600f491c1b157c  spark-4.3.0-bin-hadoop3.tgz" | shasum -a 512 -c
+        tar xvfz spark-4.3.0-bin-hadoop3.tgz && rm spark-4.3.0-bin-hadoop3.tgz
+        mv spark-4.3.0-bin-hadoop3/ /tmp/spark
+        cd /tmp/spark/sbin
+        ./start-connect-server.sh -c spark.sql.timeType.enabled=true
+        cd -
+        swift test --no-parallel -c release
+
   integration-test-mac:
     runs-on: macos-26
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add an `Apache Spark 4.3.0` RC1 `MacOS` integration test job,
`integration-test-mac-spark43`.

- https://dist.apache.org/repos/dist/dev/spark/v4.3.0-rc1-bin/
- https://github.com/apache/spark/releases/tag/v4.3.0-rc1 (2026-08-31)

The new job mirrors the existing `integration-test-mac-spark42` job, and additionally
verifies the SHA512 checksum of the downloaded binary distribution.

### Why are the changes needed?

To be ready for the `Apache Spark 4.3.0` release.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs, especially the new `integration-test-mac-spark43` job.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5