### PR TITLE
[SPARK-59157] Upgrade `grpc-swift-2` to 2.4.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
       targets: ["SparkConnect"])
   ],
   dependencies: [
-    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.2"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", exact: "2.4.3"),
     .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", exact: "2.4.1"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", exact: "2.9.2"),
     .package(url: "https://github.com/google/flatbuffers.git", exact: "25.12.19-2026-02-06-03fffb2"),

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For example, a user can develop and ship a lightweight Swift-based SparkPi app.
 
 - [Apache Spark 4.2.0 (July 2026)](https://github.com/apache/spark/releases/tag/v4.2.0)
 - [Swift 6.3.2 (May 2026)](https://swift.org)
-- [gRPC Swift 2.4.2 (June 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.2)
+- [gRPC Swift 2.4.3 (September 2026)](https://github.com/grpc/grpc-swift-2/releases/tag/2.4.3)
 - [gRPC Swift Protobuf 2.4.1 (June 2026)](https://github.com/grpc/grpc-swift-protobuf/releases/tag/2.4.1)
 - [gRPC Swift NIO Transport 2.9.2 (August 2026)](https://github.com/grpc/grpc-swift-nio-transport/releases/tag/2.9.2)
 - [FlatBuffers v25.12.19 (February 2026)](https://github.com/google/flatbuffers/releases/tag/v25.12.19-2026-02-06-03fffb2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `grpc-swift-2` to 2.4.3.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/grpc/grpc-swift-2/releases/tag/2.4.3 (2026-09-01)
  - https://github.com/grpc/grpc-swift-2/pull/52

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5