### PR TITLE
[SPARK-59178] Use `Xcode 26.6` in CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,8 +42,8 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift build -c release
 
@@ -138,8 +138,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -159,8 +159,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -181,8 +181,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -203,8 +203,8 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -225,8 +225,8 @@ jobs:
       SPARK_CONNECT_AUTHENTICATE_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Build
       run: swift test --filter NOTHING -c release
     - name: Test
@@ -247,8 +247,8 @@ jobs:
       SPARK_ICEBERG_TEST_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Install Java
       uses: actions/setup-java@v5
       with:
@@ -280,8 +280,8 @@ jobs:
       SPARK_ICEBERG_TEST_ENABLED: "true"
     steps:
     - uses: actions/checkout@v6
-    - name: Select Xcode 26.5
-      run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+    - name: Select Xcode 26.6
+      run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
     - name: Install Java
       uses: actions/setup-java@v5
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Xcode to `26.6` in GitHub Actions.

### Why are the changes needed?

To validate Apache Spark Connect Swift with the latest Xcode toolchain on CI.

- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5