### PR TITLE
[SPARK-59179] Add `Xcode 27` (Swift 6.4) GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,6 +47,14 @@ jobs:
     - name: Build
       run: swift build -c release
 
+  build-macos-26-swift64:
+    runs-on: xcode-27
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build
+      run: swift build -c release
+
   build-ubuntu-swift64:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new `build-macos-26-swift64` GitHub Action job which uses the `xcode-27` runner image.

### Why are the changes needed?

To validate Apache Spark Connect Swift with the next Swift toolchain on Apple platforms.

Currently, all macOS jobs are pinned to `Xcode 26.5` (Swift 6.3), while the next toolchain is only validated on Linux via the existing `build-ubuntu-swift64` job (`swiftlang/swift:nightly-6.4.x`). The [`xcode-27` runner image](https://github.com/actions/runner-images/blob/main/images/macos/xcode-27-arm64-Readme.md) ([public preview](https://github.blog/changelog/2026-07-16-xcode-27-runner-image-now-in-public-preview/) since 2026-07-16) provides `Xcode 27.0 beta` with `Swift 6.4` and the macOS/iOS 27 SDKs, which makes the toolchain coverage symmetric across Linux and Apple platforms.

Note that `Xcode 27` is the only installed and default Xcode in that image, so no `xcode-select` step is required.

### Does this PR introduce _any_ user-facing change?

No, this is a CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5