### PR TITLE
[SPARK-59190] Make `Row.getAsBool` throw instead of trapping on type mismatch

### DIFF
--- a/Sources/SparkConnect/Row.swift
+++ b/Sources/SparkConnect/Row.swift
@@ -114,8 +114,16 @@ public struct Row: Sendable, Equatable {
     return dict
   }
 
+  /// Returns the value at the given index as a `Bool`.
+  /// - Parameter i: A 0-based column index.
+  /// - Returns: A `Bool` value of the field.
+  /// - Throws: `SparkConnectError.InvalidArgument` if the index is out of range, or
+  /// `SparkConnectError.InvalidType` if the value is `nil` or not a `Bool`.
   public func getAsBool(_ i: Int) throws -> Bool {
-    return try get(i) as! Bool
+    guard let value = try get(i) as? Bool else {
+      throw SparkConnectError.InvalidType
+    }
+    return value
   }
 
   public static func == (lhs: Row, rhs: Row) -> Bool {

--- a/Tests/SparkConnectTests/RowTests.swift
+++ b/Tests/SparkConnectTests/RowTests.swift
@@ -67,6 +67,31 @@ struct RowTests {
   }
 
   @Test
+  func getAsBool() throws {
+    #expect(try Row(true).getAsBool(0) == true)
+    #expect(try Row(false).getAsBool(0) == false)
+    #expect(try Row(valueArray: [true], schema: RowSchema(["flag"])).getAsBool(0) == true)
+
+    // A type mismatch throws instead of trapping.
+    #expect(throws: SparkConnectError.InvalidType) {
+      try Row(1).getAsBool(0)
+    }
+    #expect(throws: SparkConnectError.InvalidType) {
+      try Row("true").getAsBool(0)
+    }
+    #expect(throws: SparkConnectError.InvalidType) {
+      try Row(nil).getAsBool(0)
+    }
+
+    #expect(throws: SparkConnectError.InvalidArgument) {
+      try Row(true).getAsBool(1)
+    }
+    #expect(throws: SparkConnectError.InvalidArgument) {
+      try Row(true).getAsBool(-1)
+    }
+  }
+
+  @Test
   func fieldIndex() throws {
     let row = Row(valueArray: [1, "a"], schema: RowSchema(["id", "name"]))
     #expect(try row.fieldIndex("id") == 0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `Row.getAsBool(_:)` throw `SparkConnectError.InvalidType` instead of
trapping when the value is not a `Bool`, and adds a doc comment describing its
throwing behavior.

### Why are the changes needed?

`getAsBool(_:)` is a public API declared as `throws`, but a forced cast traps
(crashes the process) rather than throwing when the value is not a `Bool`.
Library users cannot catch a trap.

This is reachable from server-controlled data: `Catalog` calls `getAsBool(0)` on
the first column of a collected query result in `databaseExists`, `tableExists`,
`functionExists`, `dropTempView`, `dropGlobalTempView`, `isCached`, and
`clearCache`. If a server returns an unexpected column type, the client crashes
instead of surfacing a catchable error.

`SparkConnectError.InvalidType` already exists and is used for the same kind of
type mismatch elsewhere (`DataType.swift`, `ConvertToArrow.swift`,
`SparkSession.parseDDL`), so no new error case is introduced.

### Does this PR introduce _any_ user-facing change?

Yes, this is a behavior change.

`Row.getAsBool(_:)` previously crashed (trapped) on a type mismatch; it now
throws `SparkConnectError.InvalidType`. Code that relied on the process
terminating will now observe a thrown error instead. Since the function is
already declared `throws`, no source-level signature change is required for
callers. The success path is unchanged.

### How was this patch tested?

Pass the CIs with a newly added test case in `RowTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5