### PR TITLE
[SPARK-59191] Support `grpc_max_message_size` in connection string

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -310,7 +310,8 @@ public actor DataFrame: Sendable {
       try await withGRPCClient(
         transport: .http2NIOPosix(
           target: .dns(host: spark.client.host, port: spark.client.port),
-          transportSecurity: spark.client.transportSecurity
+          transportSecurity: spark.client.transportSecurity,
+          serviceConfig: spark.client.serviceConfig
         ),
         interceptors: spark.client.getIntercepters()
       ) { client in

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -34,6 +34,8 @@ public actor SparkConnectClient {
   let token: String?
   var useTLS: Bool = false
   let transportSecurity: HTTP2ClientTransport.Posix.TransportSecurity
+  let maxMessageSize: Int?
+  let serviceConfig: ServiceConfig
   var intercepters: [ClientInterceptor] = []
   let userContext: UserContext
   var sessionID: String? = nil
@@ -43,7 +45,7 @@ public actor SparkConnectClient {
   /// - Parameters:
   ///   - remote: A string to connect `Spark Connect` server.
   /// - Throws: `SparkConnectError.InvalidArgument` if `remote` is not a valid `sc://` connection
-  /// string or a parameter has no value.
+  /// string, a parameter has no value, or `grpc_max_message_size` is not a positive integer.
   init(remote: String) throws {
     guard let url = URL(string: remote), url.scheme == "sc" else {
       throw SparkConnectError.InvalidArgument
@@ -52,6 +54,7 @@ public actor SparkConnectClient {
     self.host = url.host() ?? "localhost"
     self.port = self.url.port ?? 15002
     var token: String? = nil
+    var maxMessageSize: Int? = nil
     let processInfo = ProcessInfo.processInfo
     #if os(macOS) || os(Linux)
       var userName = processInfo.environment["SPARK_USER"] ?? processInfo.userName
@@ -64,6 +67,11 @@ public actor SparkConnectClient {
         throw SparkConnectError.InvalidArgument
       }
       switch String(kv[0]).lowercased() {
+      case URIParams.PARAM_GRPC_MAX_MESSAGE_SIZE:
+        guard let size = Int(String(kv[1])), size > 0 else {
+          throw SparkConnectError.InvalidArgument
+        }
+        maxMessageSize = size
       case URIParams.PARAM_SESSION_ID:
         // SparkSession handles this.
         break
@@ -91,6 +99,18 @@ public actor SparkConnectClient {
       self.transportSecurity = .tls
     } else {
       self.transportSecurity = .plaintext
+    }
+    self.maxMessageSize = maxMessageSize
+    if let maxMessageSize {
+      // An empty service name is the default configuration for all services and methods.
+      self.serviceConfig = ServiceConfig(methodConfig: [
+        MethodConfig(
+          names: [MethodConfig.Name(service: "")],
+          maxRequestMessageBytes: maxMessageSize,
+          maxResponseMessageBytes: maxMessageSize)
+      ])
+    } else {
+      self.serviceConfig = ServiceConfig()
     }
     self.userContext = userName.toUserContext
   }
@@ -140,7 +160,8 @@ public actor SparkConnectClient {
       try await withGRPCClient(
         transport: .http2NIOPosix(
           target: .dns(host: self.host, port: self.port),
-          transportSecurity: self.transportSecurity
+          transportSecurity: self.transportSecurity,
+          serviceConfig: self.serviceConfig
         ),
         interceptors: self.intercepters
       ) { client in

--- a/Tests/SparkConnectTests/SparkConnectClientTests.swift
+++ b/Tests/SparkConnectTests/SparkConnectClientTests.swift
@@ -57,6 +57,37 @@ struct SparkConnectClientTests {
   }
 
   @Test
+  func parameterWithGrpcMaxMessageSize() async throws {
+    let client = try SparkConnectClient(remote: "sc://host1:123/;grpc_max_message_size=268435456")
+    #expect(await client.maxMessageSize == 268_435_456)
+    let methodConfig = try #require(await client.serviceConfig.methodConfig.first)
+    // An empty service name is the default configuration for all services and methods.
+    #expect(methodConfig.names.count == 1)
+    #expect(methodConfig.names.first?.service == "")
+    #expect(methodConfig.names.first?.method == "")
+    #expect(methodConfig.maxRequestMessageBytes == 268_435_456)
+    #expect(methodConfig.maxResponseMessageBytes == 268_435_456)
+    await client.stop()
+  }
+
+  @Test
+  func parameterWithoutGrpcMaxMessageSize() async throws {
+    let client = try SparkConnectClient(remote: "sc://host1:123")
+    #expect(await client.maxMessageSize == nil)
+    #expect(await client.serviceConfig.methodConfig.isEmpty)
+    await client.stop()
+  }
+
+  @Test
+  func parameterWithInvalidGrpcMaxMessageSize() async throws {
+    for value in ["abc", "0", "-1", "1.5"] {
+      #expect(throws: SparkConnectError.InvalidArgument) {
+        try SparkConnectClient(remote: "sc://host1:123/;grpc_max_message_size=\(value)")
+      }
+    }
+  }
+
+  @Test
   func invalidRemote() async throws {
     #expect(throws: SparkConnectError.InvalidArgument) {
       try SparkConnectClient(remote: "http://host1:123")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support the `grpc_max_message_size` parameter in the Spark
Connect connection string.

- `SparkConnectClient.init(remote:)` parses it now. Previously it fell through to
  the `default` branch and only printed `Unknown parameter: ...`, leaving the
  existing `URIParams.PARAM_GRPC_MAX_MESSAGE_SIZE` constant unused.
- A non-positive or non-integer value throws `SparkConnectError.InvalidArgument`,
  like the other invalid inputs in the same initializer.
- The value is applied to the gRPC transport through a default `MethodConfig`
  (an empty service name applies to all services and methods) in a `ServiceConfig`,
  at both places creating the transport: `SparkConnectClient.withGPRC` and
  `DataFrame.withGPRC`. Both `maxRequestMessageBytes` and `maxResponseMessageBytes`
  are set, matching PySpark which sets both `grpc.max_send_message_length` and
  `grpc.max_receive_message_length`.

When the parameter is absent, an empty `ServiceConfig` is used and the behavior is
unchanged (gRPC's 4MiB default).

### Why are the changes needed?

`grpc_max_message_size` is supported by the PySpark and Scala clients and is used to
avoid hitting the default gRPC message size limit when collecting large results.
The Swift client silently dropped it, so users had no way to raise the limit.

### Does this PR introduce _any_ user-facing change?

Yes. `sc://localhost:15002/;grpc_max_message_size=268435456` is now honored instead
of ignored, and an invalid value such as `grpc_max_message_size=abc` now throws
`SparkConnectError.InvalidArgument` instead of being ignored.

### How was this patch tested?

Pass the CIs with the newly added test cases in `SparkConnectClientTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5