### PR TITLE
[SPARK-59193] Add `firstOrThrow` to avoid trapping on empty server responses

### DIFF
--- a/Sources/SparkConnect/Catalog.swift
+++ b/Sources/SparkConnect/Catalog.swift
@@ -106,7 +106,7 @@ public actor Catalog: Sendable {
       catalog.catType = .currentCatalog(Spark_Connect_CurrentCatalog())
       return catalog
     })
-    return try await df.collect()[0][0] as! String
+    return try await df.collect().firstOrThrow()[0] as! String
   }
 
   /// Sets the current default catalog in this session.
@@ -148,7 +148,7 @@ public actor Catalog: Sendable {
       catalog.catType = .currentDatabase(Spark_Connect_CurrentDatabase())
       return catalog
     })
-    return try await df.collect()[0][0] as! String
+    return try await df.collect().firstOrThrow()[0] as! String
   }
 
   /// Sets the current default database in this session.
@@ -248,7 +248,7 @@ public actor Catalog: Sendable {
       try Database(
         name: $0[0] as! String, catalog: $0[1] as? String, description: $0[2] as? String,
         locationUri: $0[3] as! String)
-    }.first!
+    }.firstOrThrow()
   }
 
   /// Check if the database with the specified name exists.
@@ -262,7 +262,7 @@ public actor Catalog: Sendable {
       catalog.catType = .databaseExists(databaseExists)
       return catalog
     })
-    return try await df.collect().first![0] as! Bool
+    return try await df.collect().firstOrThrow()[0] as! Bool
   }
 
   /// Returns a list of tables in the given database (or the current database).
@@ -411,7 +411,7 @@ public actor Catalog: Sendable {
         description: $0[3] as? String,
         tableType: $0[4] as! String,
         isTemporary: $0[5] as! Bool)
-    }.first!
+    }.firstOrThrow()
   }
 
   /// Get the table properties of the table with the specified name.
@@ -448,7 +448,7 @@ public actor Catalog: Sendable {
       catalog.catType = .getCreateTableString(getCreateTableString)
       return catalog
     })
-    return try await df.collect()[0][0] as! String
+    return try await df.collect().firstOrThrow()[0] as! String
   }
 
   /// Check if the table or view with the specified name exists. This can either be a temporary
@@ -465,7 +465,7 @@ public actor Catalog: Sendable {
       catalog.tableExists = tableExists
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Check if the table or view with the specified name exists. This can either be a temporary
@@ -483,7 +483,7 @@ public actor Catalog: Sendable {
       catalog.tableExists = tableExists
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Returns a list of columns for the given table/view or temporary view.
@@ -540,7 +540,7 @@ public actor Catalog: Sendable {
         description: $0[3] as? String,
         className: $0[4] as! String,
         isTemporary: $0[5] as! Bool)
-    }.first!
+    }.firstOrThrow()
   }
 
   /// Get the function with the specified name in the specified database.
@@ -565,7 +565,7 @@ public actor Catalog: Sendable {
         description: $0[3] as? String,
         className: $0[4] as! String,
         isTemporary: $0[5] as! Bool)
-    }.first!
+    }.firstOrThrow()
   }
 
   /// Check if the function with the specified name exists. This can either be a temporary function
@@ -582,7 +582,7 @@ public actor Catalog: Sendable {
       catalog.functionExists = functionExists
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Check if the function with the specified name exists in the specified database under the Hive
@@ -600,7 +600,7 @@ public actor Catalog: Sendable {
       catalog.functionExists = functionExists
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Caches the specified table in-memory.
@@ -633,7 +633,7 @@ public actor Catalog: Sendable {
       catalog.isCached = isCached
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Invalidates and refreshes all the cached data and metadata of the given table.
@@ -746,7 +746,7 @@ public actor Catalog: Sendable {
       catalog.dropTempView = dropTempView
       return catalog
     })
-    return try await df.collect().first!.getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Drops the global temporary view with the given view name in the catalog. If the view has been
@@ -762,7 +762,7 @@ public actor Catalog: Sendable {
       catalog.dropGlobalTempView = dropGlobalTempView
       return catalog
     })
-    return try await df.collect()[0].getAsBool(0)
+    return try await df.collect().firstOrThrow().getAsBool(0)
   }
 
   /// Drops the table with the given table name in the catalog.

--- a/Sources/SparkConnect/DataFrameStatFunctions.swift
+++ b/Sources/SparkConnect/DataFrameStatFunctions.swift
@@ -96,7 +96,7 @@ public actor DataFrameStatFunctions: Sendable {
     let result = DataFrame(
       spark: await df.spark,
       plan: SparkConnectClient.getStatApproxQuantile(plan.root, cols, probabilities, relativeError))
-    let quantilesPerColumn = try await result.collect()[0].get(0) as! [any Sendable]
+    let quantilesPerColumn = try await result.collect().firstOrThrow().get(0) as! [any Sendable]
     return quantilesPerColumn.map { ($0 as! [any Sendable]).map { $0 as! Double } }
   }
 
@@ -149,7 +149,7 @@ public actor DataFrameStatFunctions: Sendable {
   private func collectDouble(_ f: (Relation) -> Plan) async throws -> Double {
     let plan = await df.getPlan() as! Plan
     let result = DataFrame(spark: await df.spark, plan: f(plan.root))
-    return try await result.collect()[0].get(0) as! Double
+    return try await result.collect().firstOrThrow().get(0) as! Double
   }
 
   /// Builds a new ``DataFrame`` from this ``DataFrame``'s plan using the given plan builder.

--- a/Sources/SparkConnect/DataStreamWriter.swift
+++ b/Sources/SparkConnect/DataStreamWriter.swift
@@ -185,7 +185,7 @@ public actor DataStreamWriter: Sendable {
     command.writeStreamOperationStart = writeStreamOperationStart
 
     let response = try await df.spark.client.execute(df.spark.sessionID, command)
-    let result = response.first!.writeStreamOperationStartResult
+    let result = try response.firstOrThrow().writeStreamOperationStartResult
     // `result.queryStartedEventJson` is intentionally ignored because this client does not
     // support `StreamingQueryListener` yet. Reference clients (PySpark/Scala) parse it and
     // post it to their listener bus, which is a no-op when no listener is registered.

--- a/Sources/SparkConnect/Extension.swift
+++ b/Sources/SparkConnect/Extension.swift
@@ -249,6 +249,24 @@ extension [String: String] {
   }
 }
 
+extension Array {
+  /// Get the first element, or throw ``SparkConnectError/invalidState(_:)`` if this is empty.
+  ///
+  /// The Spark Connect server is expected to return at least one result for the commands whose
+  /// results are consumed by this method. An empty result is a protocol violation, so this throws
+  /// instead of trapping.
+  /// - Parameter function: The caller's name which is used in the error message.
+  /// - Returns: The first element.
+  func firstOrThrow(_ function: String = #function) throws -> Element {
+    guard let first = self.first else {
+      throw SparkConnectError.invalidState(
+        SparkConnectError.Details(
+          message: "The server returned an empty response for \(function)."))
+    }
+    return first
+  }
+}
+
 extension Data {
   /// Get an `Int32` value from unsafe 4 bytes.
   var int32: Int32 { withUnsafeBytes({ $0.load(as: Int32.self) }) }

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -921,7 +921,7 @@ public actor SparkConnectClient {
     var command = Command()
     command.commandType = .executeExternalCommand(executeExternalCommand)
     let response = try await execute(self.sessionID!, command)
-    let relation = response.first!.sqlCommandResult.relation
+    let relation = try response.firstOrThrow().sqlCommandResult.relation
     var plan = Plan()
     plan.opType = .root(relation)
     return plan
@@ -1318,7 +1318,7 @@ public actor SparkConnectClient {
     var command = Spark_Connect_Command()
     command.checkpointCommand = checkpointCommand
     let response = try await execute(self.sessionID!, command)
-    let cachedRemoteRelation = response.first!.checkpointCommandResult.relation
+    let cachedRemoteRelation = try response.firstOrThrow().checkpointCommandResult.relation
     return Self.createPlan { $0.cachedRemoteRelation = cachedRemoteRelation }
   }
 
@@ -1409,7 +1409,7 @@ public actor SparkConnectClient {
       command.commandType = .pipelineCommand(pipelineCommand)
 
       let response = try await execute(self.sessionID!, command)
-      let result = response.first!.pipelineCommandResult.createDataflowGraphResult
+      let result = try response.firstOrThrow().pipelineCommandResult.createDataflowGraphResult
 
       return result.dataflowGraphID
     }

--- a/Sources/SparkConnect/StreamingQuery.swift
+++ b/Sources/SparkConnect/StreamingQuery.swift
@@ -78,7 +78,7 @@ public actor StreamingQuery: Sendable {
   public var isActive: Bool {
     get async throws {
       let response = try await executeCommand(StreamingQueryCommand.OneOf_Command.status(true))
-      return response.first!.streamingQueryCommandResult.status.isActive
+      return try response.firstOrThrow().streamingQueryCommandResult.status.isActive
     }
   }
 
@@ -86,7 +86,7 @@ public actor StreamingQuery: Sendable {
   /// - Returns: A ``StreamingQueryException`` if the query was terminated by an exception, `nil` otherwise.
   public func exception() async throws -> StreamingQueryException? {
     let response = try await executeCommand(StreamingQueryCommand.OneOf_Command.exception(true))
-    let result = response.first!.streamingQueryCommandResult.exception
+    let result = try response.firstOrThrow().streamingQueryCommandResult.exception
     guard result.hasExceptionMessage else {
       return nil
     }
@@ -101,7 +101,7 @@ public actor StreamingQuery: Sendable {
   /// - Returns:
   public func status() async throws -> StreamingQueryStatus {
     let response = try await executeCommand(StreamingQueryCommand.OneOf_Command.status(true))
-    let result = response.first!.streamingQueryCommandResult.status
+    let result = try response.firstOrThrow().streamingQueryCommandResult.status
     return StreamingQueryStatus(
       statusMessage: result.statusMessage,
       isDataAvailable: result.isDataAvailable,
@@ -117,7 +117,7 @@ public actor StreamingQuery: Sendable {
     get async throws {
       let response = try await executeCommand(
         StreamingQueryCommand.OneOf_Command.recentProgress(true))
-      let result = response.first!.streamingQueryCommandResult.recentProgress
+      let result = try response.firstOrThrow().streamingQueryCommandResult.recentProgress
       return try result.recentProgressJson.map { try StreamingQueryProgress.fromJson($0) }
     }
   }
@@ -127,7 +127,7 @@ public actor StreamingQuery: Sendable {
     get async throws {
       let response = try await executeCommand(
         StreamingQueryCommand.OneOf_Command.lastProgress(true))
-      let result = response.first!.streamingQueryCommandResult.recentProgress
+      let result = try response.firstOrThrow().streamingQueryCommandResult.recentProgress
       guard let json = result.recentProgressJson.first else {
         return nil
       }
@@ -150,7 +150,7 @@ public actor StreamingQuery: Sendable {
     }
     let response = try await executeCommand(
       StreamingQueryCommand.OneOf_Command.awaitTermination(command))
-    return response.first!.streamingQueryCommandResult.awaitTermination.terminated
+    return try response.firstOrThrow().streamingQueryCommandResult.awaitTermination.terminated
   }
 
   /// Blocks until all available data in the source has been processed and committed to the sink.
@@ -181,6 +181,6 @@ public actor StreamingQuery: Sendable {
     var command = Spark_Connect_StreamingQueryCommand.ExplainCommand()
     command.extended = extended
     let response = try await executeCommand(StreamingQueryCommand.OneOf_Command.explain(command))
-    print(response.first!.streamingQueryCommandResult.explain.result)
+    print(try response.firstOrThrow().streamingQueryCommandResult.explain.result)
   }
 }

--- a/Sources/SparkConnect/StreamingQueryManager.swift
+++ b/Sources/SparkConnect/StreamingQueryManager.swift
@@ -35,7 +35,8 @@ public actor StreamingQueryManager {
     get async throws {
       let command = StreamingQueryManagerCommand.OneOf_Command.active(true)
       let response = try await self.sparkSession.client.executeStreamingQueryManagerCommand(command)
-      return response.first!.streamingQueryManagerCommandResult.active.activeQueries.map {
+      let result = try response.firstOrThrow().streamingQueryManagerCommandResult
+      return result.active.activeQueries.map {
         StreamingQuery(
           UUID(uuidString: $0.id.id)!,
           UUID(uuidString: $0.id.runID)!,
@@ -59,7 +60,7 @@ public actor StreamingQueryManager {
   public func get(_ id: String) async throws -> StreamingQuery {
     let command = StreamingQueryManagerCommand.OneOf_Command.getQuery(id)
     let response = try await self.sparkSession.client.executeStreamingQueryManagerCommand(command)
-    let query = response.first!.streamingQueryManagerCommandResult.query
+    let query = try response.firstOrThrow().streamingQueryManagerCommandResult.query
     guard query.hasID else {
       throw SparkConnectError.InvalidArgument
     }
@@ -87,7 +88,8 @@ public actor StreamingQueryManager {
     let command = StreamingQueryManagerCommand.OneOf_Command.awaitAnyTermination(
       awaitAnyTerminationCommand)
     let response = try await self.sparkSession.client.executeStreamingQueryManagerCommand(command)
-    return response.first!.streamingQueryManagerCommandResult.awaitAnyTermination.terminated
+    let result = try response.firstOrThrow().streamingQueryManagerCommandResult
+    return result.awaitAnyTermination.terminated
   }
 
   ///  Forget about past terminated queries so that `awaitAnyTermination()` can be used again to

--- a/Tests/SparkConnectTests/ExtensionTests.swift
+++ b/Tests/SparkConnectTests/ExtensionTests.swift
@@ -1,0 +1,41 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `Extension`
+@Suite(.serialized)
+struct ExtensionTests {
+  @Test
+  func firstOrThrowOnNonEmptyArray() throws {
+    #expect(try [1, 2, 3].firstOrThrow() == 1)
+  }
+
+  @Test
+  func firstOrThrowOnEmptyArray() throws {
+    let error = try #require(throws: SparkConnectError.self) {
+      _ = try [Int]().firstOrThrow()
+    }
+    #expect(error == .InvalidState)
+    #expect(
+      error.message == "The server returned an empty response for firstOrThrowOnEmptyArray().")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces force unwraps on server-provided response arrays with an explicit `throw`,
so an empty server response surfaces as a Swift error instead of trapping the process.

A single internal helper, `Array.firstOrThrow()`, is added to `Extension.swift`. It throws
`SparkConnectError.invalidState` on an empty array and uses a `#function` default argument
so the error message names the failing operation without any per-call-site boilerplate.

31 call sites are converted across `Catalog` (15), `StreamingQuery` (7),
`StreamingQueryManager` (3), `SparkConnectClient` (3), `DataFrameStatFunctions` (2), and
`DataStreamWriter` (1). Both spellings of the same trap are covered, because `Catalog` uses
them interchangeably for the same operation: `response.first!` on `[ExecutePlanResponse]`,
and `df.collect()[0]` / `df.collect().first!` on `[Row]`.

### Why are the changes needed?

`.first!` on a server response array traps and kills the process when the Spark Connect
server returns an empty response stream. A misbehaving or incompatible server should not be
able to crash a client application; it should raise a catchable error.

This is the same class of protocol violation that `SparkConnectClient+ReattachableExecute`
already handles by throwing `invalidState` when the server side session ID changes, so this
PR follows that precedent instead of adding a new error case.

Practically every public accessor of `StreamingQuery` was affected, as well as the main SQL
execution path in `SparkConnectClient.getExecuteExternalCommand`.

### Does this PR introduce _any_ user-facing change?

Yes, in the failure path only. Where the client previously trapped on an empty server
response, it now throws `SparkConnectError.invalidState`:

```
The server returned an empty response for getDatabase(_:).
```

There is no behavior change when the server responds normally.

### How was this patch tested?

Pass the CIs with a new `ExtensionTests` suite covering `firstOrThrow()`, which requires no
Spark Connect server. The remaining call sites cannot be unit-tested without a server that
returns an empty response stream, so they are covered by the existing integration tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5