### PR TITLE
[SPARK-59195] Create a gRPC channel per session instead of per RPC

### DIFF
--- a/Sources/SparkConnect/DataFrame.swift
+++ b/Sources/SparkConnect/DataFrame.swift
@@ -306,22 +306,14 @@ public actor DataFrame: Sendable {
   func withGPRC<Result: Sendable>(
     _ f: (GRPCClient<GRPCNIOTransportHTTP2.HTTP2ClientTransport.Posix>) async throws -> Result
   ) async throws -> Result {
-    try await withRetry {
-      try await withGRPCClient(
-        transport: .http2NIOPosix(
-          target: .dns(host: spark.client.host, port: spark.client.port),
-          transportSecurity: spark.client.transportSecurity,
-          serviceConfig: spark.client.serviceConfig
-        ),
-        interceptors: spark.client.getIntercepters()
-      ) { client in
-        do {
-          return try await f(client)
-        } catch let error as RPCError where error.code == .internalError {
-          throw await GrpcErrorConverter.convert(
-            error, fetchingDetailsWith: client, sessionID: spark.client.sessionID,
-            userContext: spark.client.userContext, clientType: spark.client.clientType) ?? error
-        }
+    let client = try await spark.client.getGRPCClient()
+    return try await withRetry {
+      do {
+        return try await f(client)
+      } catch let error as RPCError where error.code == .internalError {
+        throw await GrpcErrorConverter.convert(
+          error, fetchingDetailsWith: client, sessionID: spark.client.sessionID,
+          userContext: spark.client.userContext, clientType: spark.client.clientType) ?? error
       }
     }
   }

--- a/Sources/SparkConnect/SparkConnectClient.swift
+++ b/Sources/SparkConnect/SparkConnectClient.swift
@@ -41,6 +41,13 @@ public actor SparkConnectClient {
   var sessionID: String? = nil
   var tags = Set<String>()
 
+  /// A ``GRPCClient`` shared by every RPC of this client. It is created lazily on the first RPC
+  /// and reused until ``stop()`` shuts it down.
+  private var grpcClient: GRPCClient<GRPCNIOTransportHTTP2.HTTP2ClientTransport.Posix>? = nil
+
+  /// A task running the connections of ``grpcClient``.
+  private var runTask: Task<Void, Never>? = nil
+
   /// Create a client to use GRPCClient.
   /// - Parameters:
   ///   - remote: A string to connect `Spark Connect` server.
@@ -115,16 +122,24 @@ public actor SparkConnectClient {
     self.userContext = userName.toUserContext
   }
 
-  /// Stop the connection.
+  /// Stop the connection by releasing the server-side session and shutting down the shared
+  /// gRPC channel. A subsequent RPC re-creates the channel.
   func stop() async {
-    guard self.sessionID != nil else { return }
-    try? await withGPRC { client in
-      let service = SparkConnectService.Client(wrapping: client)
-      var request = Spark_Connect_ReleaseSessionRequest()
-      request.sessionID = self.sessionID!
-      request.userContext = self.userContext
-      request.clientType = self.clientType
-      _ = try await service.releaseSession(request)
+    if self.sessionID != nil {
+      try? await withGPRC { client in
+        let service = SparkConnectService.Client(wrapping: client)
+        var request = Spark_Connect_ReleaseSessionRequest()
+        request.sessionID = self.sessionID!
+        request.userContext = self.userContext
+        request.clientType = self.clientType
+        _ = try await service.releaseSession(request)
+      }
+    }
+    if let grpcClient = self.grpcClient {
+      grpcClient.beginGracefulShutdown()
+      await self.runTask?.value
+      self.grpcClient = nil
+      self.runTask = nil
     }
   }
 
@@ -152,26 +167,40 @@ public actor SparkConnectClient {
     }
   }
 
+  /// Return the ``GRPCClient`` shared by every RPC of this client. On the first call, a gRPC
+  /// channel is created and started in a detached task which runs until ``stop()`` begins its
+  /// graceful shutdown. The channel re-resolves the target and reconnects on its own when a
+  /// connection is lost or closed after being idle.
+  /// - Returns: A running ``GRPCClient`` instance.
+  func getGRPCClient() throws -> GRPCClient<GRPCNIOTransportHTTP2.HTTP2ClientTransport.Posix> {
+    if let grpcClient = self.grpcClient {
+      return grpcClient
+    }
+    let grpcClient = GRPCClient(
+      transport: try HTTP2ClientTransport.Posix(
+        target: .dns(host: self.host, port: self.port),
+        transportSecurity: self.transportSecurity,
+        serviceConfig: self.serviceConfig
+      ),
+      interceptors: self.intercepters
+    )
+    self.runTask = Task.detached { try? await grpcClient.runConnections() }
+    self.grpcClient = grpcClient
+    return grpcClient
+  }
+
   func withGPRC<Result: Sendable>(
     retryable: Bool = true,
     _ f: (GRPCClient<GRPCNIOTransportHTTP2.HTTP2ClientTransport.Posix>) async throws -> Result
   ) async throws -> Result {
-    try await withRetry(shouldRetry: { retryable && RetryPolicy.canRetry($0) }) {
-      try await withGRPCClient(
-        transport: .http2NIOPosix(
-          target: .dns(host: self.host, port: self.port),
-          transportSecurity: self.transportSecurity,
-          serviceConfig: self.serviceConfig
-        ),
-        interceptors: self.intercepters
-      ) { client in
-        do {
-          return try await f(client)
-        } catch let error as RPCError where error.code == .internalError {
-          throw await GrpcErrorConverter.convert(
-            error, fetchingDetailsWith: client, sessionID: self.sessionID,
-            userContext: self.userContext, clientType: self.clientType) ?? error
-        }
+    let client = try getGRPCClient()
+    return try await withRetry(shouldRetry: { retryable && RetryPolicy.canRetry($0) }) {
+      do {
+        return try await f(client)
+      } catch let error as RPCError where error.code == .internalError {
+        throw await GrpcErrorConverter.convert(
+          error, fetchingDetailsWith: client, sessionID: self.sessionID,
+          userContext: self.userContext, clientType: self.clientType) ?? error
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `SparkConnectClient` create its gRPC channel once and reuse it for
every RPC of a session, instead of creating and tearing down a `GRPCClient` per RPC.

- A new `getGRPCClient()` lazily creates a `GRPCClient` and runs its connections in
  a detached task. `stop()` shuts it down with `beginGracefulShutdown()`.
- `DataFrame.withGPRC` no longer builds its own transport; it uses the shared client.
  This removes a duplicated transport configuration that had to be kept in sync in
  two places.

Keepalive, compression, proxy support, and custom TLS are left as follow-ups.

### Why are the changes needed?

Every RPC paid for a full connection setup: DNS resolution, TCP handshake, TLS
handshake, and the HTTP/2 preface, and retries paid it again on every attempt.
Reusing the channel removes that cost and matches how the Scala and Python Spark
Connect clients work.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

Reconnection was checked by killing the server container while a session was idle
and starting a new one on the same port; the next query on the same `SparkSession`
succeeded, so the shared channel reconnects on its own.

Performance, timed on loopback with plaintext transport over three runs each on two
freshly started servers. `spark.conf.get(...)` is a single unary RPC per iteration,
so it isolates the connection cost:

| benchmark | before | after |
| --- | --- | --- |
| `spark.conf.get(...)` x 100 | 2.58-4.00 ms/RPC | 0.95-1.52 ms/RPC |
| `spark.catalog.currentDatabase()` x 50 | 9.18-12.88 ms | 6.74-9.57 ms |
| `spark.range(1).count()` x 50 | 16.34-31.19 ms | 12.85-22.34 ms |

That is roughly 1.5-2.5 ms saved per RPC. Loopback with plaintext is the most
favorable case for the old code; against a remote server over TLS, each RPC
previously paid about three extra round trips that are now paid once per session.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5