### PR TITLE
[SPARK-59197] Support `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` nanosecond timestamp types in `DataType`

### DIFF
--- a/Sources/SparkConnect/DataType.swift
+++ b/Sources/SparkConnect/DataType.swift
@@ -87,6 +87,8 @@ public indirect enum DataType: Sendable, Equatable {
   case date
   case timestamp
   case timestampNtz
+  case timestampNtzNanos(precision: Int32)
+  case timestampLtzNanos(precision: Int32)
   case time(precision: Int32)
   case calendarInterval
   case yearMonthInterval(startField: YearMonthIntervalField, endField: YearMonthIntervalField)
@@ -136,6 +138,10 @@ public indirect enum DataType: Sendable, Equatable {
       "timestamp"
     case .timestampNtz:
       "timestamp_ntz"
+    case .timestampNtzNanos(let precision):
+      "timestamp_ntz(\(precision))"
+    case .timestampLtzNanos(let precision):
+      "timestamp_ltz(\(precision))"
     case .time(let precision):
       "time(\(precision))"
     case .calendarInterval:
@@ -244,6 +250,14 @@ extension DataType {
       proto.timestamp = ProtoDataType.Timestamp()
     case .timestampNtz:
       proto.timestampNtz = ProtoDataType.TimestampNTZ()
+    case .timestampNtzNanos(let precision):
+      var timestampNtzNanos = ProtoDataType.TimestampNTZNanos()
+      timestampNtzNanos.precision = precision
+      proto.timestampNtzNanos = timestampNtzNanos
+    case .timestampLtzNanos(let precision):
+      var timestampLtzNanos = ProtoDataType.TimestampLTZNanos()
+      timestampLtzNanos.precision = precision
+      proto.timestampLtzNanos = timestampLtzNanos
     case .time(let precision):
       var time = ProtoDataType.Time()
       time.precision = precision
@@ -344,9 +358,10 @@ extension DataType {
       self = .timestamp
     case .timestampNtz:
       self = .timestampNtz
-    case .timestampNtzNanos, .timestampLtzNanos:
-      // Nanosecond-precision timestamps are not supported by this client yet.
-      throw SparkConnectError.InvalidType
+    case .timestampNtzNanos(let nanos):
+      self = .timestampNtzNanos(precision: nanos.hasPrecision ? nanos.precision : 9)
+    case .timestampLtzNanos(let nanos):
+      self = .timestampLtzNanos(precision: nanos.hasPrecision ? nanos.precision : 9)
     case .time(let time):
       self = .time(precision: time.hasPrecision ? time.precision : 6)
     case .calendarInterval:

--- a/Tests/SparkConnectTests/DataTypeTests.swift
+++ b/Tests/SparkConnectTests/DataTypeTests.swift
@@ -17,7 +17,7 @@
 // under the License.
 //
 
-import SparkConnect
+@testable import SparkConnect
 import Testing
 
 /// A test suite for `DataType`, `StructField`, and `StructType`
@@ -41,6 +41,8 @@ struct DataTypeTests {
     #expect(DataType.date.simpleString == "date")
     #expect(DataType.timestamp.simpleString == "timestamp")
     #expect(DataType.timestampNtz.simpleString == "timestamp_ntz")
+    #expect(DataType.timestampNtzNanos(precision: 9).simpleString == "timestamp_ntz(9)")
+    #expect(DataType.timestampLtzNanos(precision: 7).simpleString == "timestamp_ltz(7)")
     #expect(DataType.time(precision: 6).simpleString == "time(6)")
     #expect(DataType.calendarInterval.simpleString == "interval")
     #expect(DataType.variant.simpleString == "variant")
@@ -169,6 +171,47 @@ struct DataTypeTests {
       let schema = try await df.schema
       #expect(schema["t6"]?.dataType == .time(precision: 6))
       #expect(schema["t0"]?.dataType == .time(precision: 0))
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func timestampNanosProtoRoundTrip() throws {
+    for precision: Int32 in 7...9 {
+      let ntz = DataType.timestampNtzNanos(precision: precision)
+      #expect(try DataType(ntz.toProtoDataType) == ntz)
+      let ltz = DataType.timestampLtzNanos(precision: precision)
+      #expect(try DataType(ltz.toProtoDataType) == ltz)
+    }
+    // A missing precision defaults to nanoseconds like Spark's `DEFAULT_PRECISION`.
+    var proto = ProtoDataType()
+    proto.timestampNtzNanos = ProtoDataType.TimestampNTZNanos()
+    #expect(try DataType(proto) == .timestampNtzNanos(precision: 9))
+    proto.timestampLtzNanos = ProtoDataType.TimestampLTZNanos()
+    #expect(try DataType(proto) == .timestampLtzNanos(precision: 9))
+  }
+
+  @Test
+  func schemaTimestampNanosTypes() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      try await spark.conf.set("spark.sql.timestampNanosTypes.enabled", "true")
+      let df = try await spark.sql(
+        """
+        SELECT
+          CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_NTZ(9)) ntz9,
+          CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_NTZ(7)) ntz7,
+          CAST(TIMESTAMP_LTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_LTZ(9)) ltz9,
+          CAST(TIMESTAMP_LTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_LTZ(8)) ltz8
+        """)
+      let schema = try await df.schema
+      #expect(schema["ntz9"]?.dataType == .timestampNtzNanos(precision: 9))
+      #expect(schema["ntz7"]?.dataType == .timestampNtzNanos(precision: 7))
+      #expect(schema["ltz9"]?.dataType == .timestampLtzNanos(precision: 9))
+      #expect(schema["ltz8"]?.dataType == .timestampLtzNanos(precision: 8))
+      #expect(
+        try await df.dtypes.map { $0.1 }
+          == ["timestamp_ntz(9)", "timestamp_ntz(7)", "timestamp_ltz(9)", "timestamp_ltz(8)"])
     }
     await spark.stop()
   }

--- a/Tests/SparkConnectTests/SparkSessionTests.swift
+++ b/Tests/SparkConnectTests/SparkSessionTests.swift
@@ -229,6 +229,15 @@ struct SparkSessionTests {
         try await spark.parseDDL("t TIME(3)")
           == StructType(fields: [StructField(name: "t", dataType: .time(precision: 3))]))
     }
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      try await spark.conf.set("spark.sql.timestampNanosTypes.enabled", "true")
+      #expect(
+        try await spark.parseDDL("a TIMESTAMP_NTZ(9), b TIMESTAMP_LTZ(7)")
+          == StructType(fields: [
+            StructField(name: "a", dataType: .timestampNtzNanos(precision: 9)),
+            StructField(name: "b", dataType: .timestampLtzNanos(precision: 7)),
+          ]))
+    }
     await spark.stop()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the nanosecond timestamp types `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` (`p` in `[7, 9]`, Apache Spark 4.3) in `DataType`.

- Add `DataType.timestampNtzNanos(precision:)` and `DataType.timestampLtzNanos(precision:)`.
- `simpleString` follows Apache Spark's `typeName`: `timestamp_ntz(p)` / `timestamp_ltz(p)`.
- Convert both ways with the `timestamp_ntz_nanos` / `timestamp_ltz_nanos` proto kinds. A missing `precision` defaults to `9`.

### Why are the changes needed?

Since Apache Spark 4.3.0, the server sends these proto types in `AnalyzePlan` and `ExecutePlan` responses.
- https://github.com/apache/spark/pull/57699 ([SPARK-57161] Convert nanosecond-capable timestamp types and literals between proto and Catalyst in Spark Connect)

`DataType.init(_ proto:)` threw `SparkConnectError.InvalidType` for them, so `DataFrame.schema`/`dtypes`/`printSchema`, `parseDDL`, and `collect()` failed on any DataFrame with such a column.

```swift
let df = try await spark.sql("SELECT CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_NTZ(9)) ts")
try await df.schema  // Before: SparkConnectError.invalidType
                     // After : struct<ts:timestamp_ntz(9)>
```

### Does this PR introduce _any_ user-facing change?

Yes, this adds two new `DataType` cases.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1