### PR TITLE
[SPARK-59198] Support nanosecond timestamp values in `DataFrame.collect`

### DIFF
--- a/Sources/SparkConnect/DataFrame+Actions.swift
+++ b/Sources/SparkConnect/DataFrame+Actions.swift
@@ -156,18 +156,18 @@ extension DataFrame {
                 throw SparkConnectError.invalidArrowData(
                   SparkConnectError.Details(message: "Invalid Arrow `timestamp` column."))
               }
-              let timeInterval =
-                switch timestampType.unit {
-                case .seconds:
-                  TimeInterval(timestamp)
-                case .milliseconds:
-                  TimeInterval(timestamp) / 1_000
-                case .microseconds:
-                  TimeInterval(timestamp) / 1_000_000
-                case .nanoseconds:
-                  TimeInterval(timestamp) / 1_000_000_000
-                }
-              values.append(Date(timeIntervalSince1970: timeInterval))
+              switch timestampType.unit {
+              case .seconds:
+                values.append(Date(timeIntervalSince1970: TimeInterval(timestamp)))
+              case .milliseconds:
+                values.append(Date(timeIntervalSince1970: TimeInterval(timestamp) / 1_000))
+              case .microseconds:
+                values.append(Date(timeIntervalSince1970: TimeInterval(timestamp) / 1_000_000))
+              case .nanoseconds:
+                // Spark serializes `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` columns as Arrow
+                // nanosecond timestamps, which `Date` cannot hold without losing digits.
+                values.append(TimestampNanos(epochNanos: timestamp))
+              }
             case ArrowType.ArrowBinary:
               guard let binaryArray = array as? AsString else {
                 throw SparkConnectError.invalidArrowData(

--- a/Sources/SparkConnect/Documentation.docc/SparkConnect.md
+++ b/Sources/SparkConnect/Documentation.docc/SparkConnect.md
@@ -31,6 +31,7 @@ SparkConnect is a modern Swift library that provides a native interface to Apach
 - ``GroupedData``
 - ``Row``
 - ``LocalTime``
+- ``TimestampNanos``
 - ``StorageLevel``
 
 ### Data Types

--- a/Sources/SparkConnect/Row.swift
+++ b/Sources/SparkConnect/Row.swift
@@ -147,6 +147,8 @@ public struct Row: Sendable, Equatable {
         return a == b
       } else if let a = x as? LocalTime, let b = y as? LocalTime {
         return a == b
+      } else if let a = x as? TimestampNanos, let b = y as? TimestampNanos {
+        return a == b
       } else if let a = x as? String, let b = y as? String {
         return a == b
       } else if let a = x as? [Bool], let b = y as? [Bool] {

--- a/Sources/SparkConnect/TimestampNanos.swift
+++ b/Sources/SparkConnect/TimestampNanos.swift
@@ -1,0 +1,98 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// A timestamp with nanosecond precision, like `TimestampNanosVal` of Apache Spark.
+/// Values of Spark's `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` types (`p` in `7...9`) are
+/// represented as `TimestampNanos` in ``Row``s because `Date` cannot keep sub-microsecond digits.
+/// Like `Date` for the microsecond timestamp types, a value is the elapsed time since the Unix
+/// epoch: `TIMESTAMP_LTZ(p)` values are instants and `TIMESTAMP_NTZ(p)` values are local
+/// date-times interpreted as UTC.
+public struct TimestampNanos: Sendable, Equatable, Hashable, CustomStringConvertible {
+  /// The number of microseconds since `1970-01-01 00:00:00` UTC, rounded toward negative infinity.
+  public let epochMicros: Int64
+
+  /// The nanosecond within the microsecond, in the range `0...999`.
+  public let nanosWithinMicro: Int16
+
+  /// Creates a `TimestampNanos` from the microseconds since the Unix epoch and the nanoseconds
+  /// within that microsecond.
+  /// - Parameters:
+  ///   - epochMicros: The number of microseconds since `1970-01-01 00:00:00` UTC.
+  ///   - nanosWithinMicro: A nanosecond within the microsecond in the range `0...999`.
+  /// - Returns: `nil` if `nanosWithinMicro` is out of range.
+  public init?(epochMicros: Int64, nanosWithinMicro: Int16 = 0) {
+    guard (0...999).contains(nanosWithinMicro) else {
+      return nil
+    }
+    self.epochMicros = epochMicros
+    self.nanosWithinMicro = nanosWithinMicro
+  }
+
+  /// Creates a `TimestampNanos` from the number of nanoseconds since the Unix epoch.
+  /// - Parameter epochNanos: The number of nanoseconds since `1970-01-01 00:00:00` UTC.
+  public init(epochNanos: Int64) {
+    let (micros, nanos) = Self.floorDivMod(epochNanos, 1_000)
+    self.epochMicros = micros
+    self.nanosWithinMicro = Int16(nanos)
+  }
+
+  /// The same point in time as a `Date`, rounded to the resolution of `Date`'s `Double` seconds.
+  public var date: Date {
+    Date(
+      timeIntervalSince1970: TimeInterval(epochMicros) / 1_000_000
+        + TimeInterval(nanosWithinMicro) / 1_000_000_000)
+  }
+
+  /// A UTC string like `2026-01-01 00:00:00`, `2026-01-01 00:00:00.123`,
+  /// `2026-01-01 00:00:00.123456`, or `2026-01-01 00:00:00.123456789` depending on the
+  /// smallest non-zero fractional unit.
+  public var description: String {
+    let (seconds, micros) = Self.floorDivMod(epochMicros, 1_000_000)
+    let (days, secondOfDay) = Self.floorDivMod(seconds, 86_400)
+    let nanoOfDay =
+      secondOfDay * LocalTime.nanosPerSecond + micros * 1_000 + Int64(nanosWithinMicro)
+    let (year, month, day) = Self.civilDate(daysSinceEpoch: days)
+    return String(format: "%04d-%02d-%02d ", year, month, day)
+      + LocalTime(nanoOfDay: nanoOfDay)!.description
+  }
+
+  private static func floorDivMod(_ x: Int64, _ y: Int64) -> (Int64, Int64) {
+    let (quotient, remainder) = x.quotientAndRemainder(dividingBy: y)
+    return remainder < 0 ? (quotient - 1, remainder + y) : (quotient, remainder)
+  }
+
+  /// Converts days since `1970-01-01` to a proleptic Gregorian date.
+  /// See https://howardhinnant.github.io/date_algorithms.html#civil_from_days
+  private static func civilDate(daysSinceEpoch: Int64) -> (Int, Int, Int) {
+    let z = daysSinceEpoch + 719_468
+    let (era, dayOfEra) = floorDivMod(z, 146_097)
+    let yearOfEra = (dayOfEra - dayOfEra / 1_460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
+    let dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+    let shiftedMonth = (5 * dayOfYear + 2) / 153
+    let day = dayOfYear - (153 * shiftedMonth + 2) / 5 + 1
+    let month = shiftedMonth < 10 ? shiftedMonth + 3 : shiftedMonth - 9
+    let year = yearOfEra + era * 400 + (month <= 2 ? 1 : 0)
+    return (Int(year), Int(month), Int(day))
+  }
+}

--- a/Tests/SparkConnectTests/DataFrameTests.swift
+++ b/Tests/SparkConnectTests/DataFrameTests.swift
@@ -197,6 +197,43 @@ struct DataFrameTests {
   }
 
   @Test
+  func collectTimestampNanos() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      try await spark.conf.set("spark.sql.timestampNanosTypes.enabled", "true")
+      try await spark.conf.set("spark.sql.session.timeZone", "UTC")
+      let expected = [
+        (
+          "CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_NTZ(9))",
+          TimestampNanos(epochNanos: 1_767_225_600_123_456_789)
+        ),
+        (
+          "CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.1234567' AS TIMESTAMP_NTZ(7))",
+          TimestampNanos(epochNanos: 1_767_225_600_123_456_700)
+        ),
+        (
+          "CAST(TIMESTAMP_LTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_LTZ(9))",
+          TimestampNanos(epochNanos: 1_767_225_600_123_456_789)
+        ),
+        (
+          "CAST(TIMESTAMP_NTZ'1970-01-01 00:00:00' AS TIMESTAMP_NTZ(9))",
+          TimestampNanos(epochNanos: 0)
+        ),
+        (
+          "CAST(TIMESTAMP_NTZ'1969-12-31 23:59:59.999999999' AS TIMESTAMP_NTZ(9))",
+          TimestampNanos(epochNanos: -1)
+        ),
+      ]
+      for pair in expected {
+        #expect(try await spark.sql("SELECT \(pair.0)").collect() == [Row(pair.1)])
+      }
+      #expect(try await spark.sql("SELECT CAST(NULL AS TIMESTAMP_NTZ(9))").collect() == [Row(nil)])
+      #expect(try await spark.sql("SELECT CAST(NULL AS TIMESTAMP_LTZ(9))").collect() == [Row(nil)])
+    }
+    await spark.stop()
+  }
+
+  @Test
   func selectTimeLiteral() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     if await isSparkVersionAtLeast(spark.version, "4.2") {

--- a/Tests/SparkConnectTests/TimestampNanosTests.swift
+++ b/Tests/SparkConnectTests/TimestampNanosTests.swift
@@ -1,0 +1,95 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SparkConnect
+import Testing
+
+/// A test suite for ``TimestampNanos``.
+struct TimestampNanosTests {
+  @Test
+  func components() async throws {
+    let timestamp = try #require(
+      TimestampNanos(epochMicros: 1_767_225_600_123_456, nanosWithinMicro: 789))
+    #expect(timestamp.epochMicros == 1_767_225_600_123_456)
+    #expect(timestamp.nanosWithinMicro == 789)
+    #expect(TimestampNanos(epochMicros: 1)?.nanosWithinMicro == 0)
+  }
+
+  @Test
+  func componentBounds() async throws {
+    #expect(TimestampNanos(epochMicros: 0, nanosWithinMicro: 0) != nil)
+    #expect(TimestampNanos(epochMicros: 0, nanosWithinMicro: 999) != nil)
+    #expect(TimestampNanos(epochMicros: Int64.min) != nil)
+    #expect(TimestampNanos(epochMicros: Int64.max) != nil)
+    #expect(TimestampNanos(epochMicros: 0, nanosWithinMicro: -1) == nil)
+    #expect(TimestampNanos(epochMicros: 0, nanosWithinMicro: 1_000) == nil)
+  }
+
+  @Test
+  func epochNanos() async throws {
+    #expect(TimestampNanos(epochNanos: 0) == TimestampNanos(epochMicros: 0))
+    #expect(
+      TimestampNanos(epochNanos: 1_767_225_600_123_456_789)
+        == TimestampNanos(epochMicros: 1_767_225_600_123_456, nanosWithinMicro: 789))
+    // Timestamps before 1970 keep `nanosWithinMicro` in `0...999`.
+    #expect(
+      TimestampNanos(epochNanos: -1) == TimestampNanos(epochMicros: -1, nanosWithinMicro: 999))
+    #expect(TimestampNanos(epochNanos: -1_000) == TimestampNanos(epochMicros: -1))
+    #expect(
+      TimestampNanos(epochNanos: -1_001) == TimestampNanos(epochMicros: -2, nanosWithinMicro: 999))
+  }
+
+  @Test
+  func date() async throws {
+    #expect(TimestampNanos(epochNanos: 0).date == Date(timeIntervalSince1970: 0))
+    #expect(TimestampNanos(epochNanos: 1_500_000_000).date == Date(timeIntervalSince1970: 1.5))
+    #expect(TimestampNanos(epochNanos: -1_500_000_000).date == Date(timeIntervalSince1970: -1.5))
+    let date = TimestampNanos(epochNanos: 1_767_225_600_123_456_789).date
+    #expect(abs(date.timeIntervalSince1970 - 1_767_225_600.123456789) < 1e-6)
+  }
+
+  @Test
+  func description() async throws {
+    #expect(TimestampNanos(epochNanos: 0).description == "1970-01-01 00:00:00")
+    #expect(TimestampNanos(epochNanos: -1).description == "1969-12-31 23:59:59.999999999")
+    #expect(
+      TimestampNanos(epochNanos: 1_767_225_600_123_000_000).description
+        == "2026-01-01 00:00:00.123")
+    #expect(
+      TimestampNanos(epochNanos: 1_767_225_600_123_456_000).description
+        == "2026-01-01 00:00:00.123456")
+    #expect(
+      TimestampNanos(epochNanos: 1_767_225_600_123_456_789).description
+        == "2026-01-01 00:00:00.123456789")
+    #expect(
+      TimestampNanos(epochNanos: 951_782_400_000_000_000).description == "2000-02-29 00:00:00")
+    // Beyond the range of Arrow's 64-bit nanosecond timestamps (1677 ~ 2262).
+    #expect(
+      TimestampNanos(epochMicros: 32_503_680_000_000_000)?.description == "3000-01-01 00:00:00")
+    #expect(
+      TimestampNanos(epochMicros: -11_676_096_000_000_000)?.description == "1600-01-01 00:00:00")
+    #expect(
+      TimestampNanos(epochMicros: -62_135_596_800_000_000)?.description == "0001-01-01 00:00:00")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support nanosecond timestamp values in `DataFrame.collect` by introducing a new `TimestampNanos` struct.

- A new public struct `TimestampNanos` represents a timestamp with nanosecond precision. Like `TimestampNanosVal` of Apache Spark, it stores `epochMicros: Int64` and `nanosWithinMicro: Int16`, so it is not limited to the `1677 ~ 2262` range of Arrow's 64-bit nanosecond timestamps. It provides `init(epochNanos:)`, a lossy `date` conversion, and a UTC `description`.
- `DataFrame.collect` now decodes Arrow `timestamp(NANOSECOND)` columns into `TimestampNanos` values. Apache Spark serializes both `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` (`p` in `[7, 9]`) columns this way. Microsecond timestamp columns still return `Date`.
- `Row.==` supports `TimestampNanos` value comparison.

`lit`, SQL parameter binding, and `createDataFrame` for this type will be handled separately.

### Why are the changes needed?

`Date` stores `Double` seconds, so `DataFrame.collect` lost sub-microsecond digits of the nanosecond timestamp types added in Apache Spark 4.3.0.

```swift
try await spark.conf.set("spark.sql.timestampNanosTypes.enabled", "true")
let df = try await spark.sql("SELECT CAST(TIMESTAMP_NTZ'2026-01-01 00:00:00.123456789' AS TIMESTAMP_NTZ(9))")
try await df.collect()  // Before: [Row(2026-01-01 00:00:00.123456717)] as `Date`
                        // After:  [Row(2026-01-01 00:00:00.123456789)] as `TimestampNanos`
```

### Does this PR introduce _any_ user-facing change?

Yes, `DataFrame.collect` returns `TimestampNanos` values instead of lossy `Date` values for `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` columns, and a new public type `TimestampNanos` is added. Existing `TIMESTAMP` and `TIMESTAMP_NTZ` columns still return `Date`.

### How was this patch tested?

Pass the CIs with the newly added test cases. Manually verified the full test suite against Apache Spark 4.3.0 RC1 and 4.2.0.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1