### PR TITLE
[SPARK-59205] Support `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` in `createDataFrame`

### DIFF
--- a/Sources/SparkConnect/ConvertToArrow.swift
+++ b/Sources/SparkConnect/ConvertToArrow.swift
@@ -29,6 +29,10 @@ enum ConvertToArrow {
   /// precision of a `TIME(p)` column, because the `Apache Arrow` `Time` type has no such field.
   private static let timePrecisionKey = "SPARK::time::precision"
 
+  /// An `Apache Arrow` field metadata key which `Apache Spark` uses to carry the fractional-second
+  /// precision of a `TIMESTAMP_NTZ(p)` or `TIMESTAMP_LTZ(p)` column with nanosecond precision.
+  private static let timestampNanosPrecisionKey = "SPARK::timestampNanos::precision"
+
   /// Convert the given rows into an `Apache Arrow` IPC stream according to the Spark schema.
   /// - Parameters:
   ///   - data: An array of rows whose values are ordered like the schema fields.
@@ -64,10 +68,16 @@ enum ConvertToArrow {
 
   /// Build the `Apache Arrow` field metadata for the given Spark data type, if any.
   private static func metadata(_ dataType: ProtoDataType) -> [String: String]? {
-    if case .time(let time) = dataType.kind, time.hasPrecision {
+    switch dataType.kind {
+    case .time(let time) where time.hasPrecision:
       return [timePrecisionKey: String(time.precision)]
+    case .timestampNtzNanos(let timestamp) where timestamp.hasPrecision:
+      return [timestampNanosPrecisionKey: String(timestamp.precision)]
+    case .timestampLtzNanos(let timestamp) where timestamp.hasPrecision:
+      return [timestampNanosPrecisionKey: String(timestamp.precision)]
+    default:
+      return nil
     }
-    return nil
   }
 
   /// Build an Arrow column from the given values according to the Spark data type.
@@ -105,6 +115,14 @@ enum ConvertToArrow {
       return try fill(
         ArrowArrayBuilders.loadTimestampArrayBuilder(.microseconds, timezone: "UTC"), column
       ) { ($0 as? Date).map { Int64(($0.timeIntervalSince1970 * 1_000_000).rounded()) } }
+    case .timestampNtzNanos:
+      return try fill(ArrowArrayBuilders.loadTimestampArrayBuilder(.nanoseconds), column) {
+        ($0 as? TimestampNanos).flatMap(toEpochNanos)
+      }
+    case .timestampLtzNanos:
+      return try fill(
+        ArrowArrayBuilders.loadTimestampArrayBuilder(.nanoseconds, timezone: "UTC"), column
+      ) { ($0 as? TimestampNanos).flatMap(toEpochNanos) }
     case .time:
       return try fill(ArrowArrayBuilders.loadTime64ArrayBuilder(.nanoseconds), column) {
         ($0 as? LocalTime)?.nanoOfDay
@@ -132,6 +150,14 @@ enum ConvertToArrow {
       }
     }
     return try builder.toHolder()
+  }
+
+  /// Returns the nanoseconds since the Unix epoch, or `nil` if it overflows `Int64`.
+  private static func toEpochNanos(_ value: TimestampNanos) -> Int64? {
+    let (micros, overflow) = value.epochMicros.multipliedReportingOverflow(by: 1_000)
+    guard !overflow else { return nil }
+    let (nanos, overflow2) = micros.addingReportingOverflow(Int64(value.nanosWithinMicro))
+    return overflow2 ? nil : nanos
   }
 
   private static func toInt64(_ value: Sendable) -> Int64? {

--- a/Sources/SparkConnect/SparkSession.swift
+++ b/Sources/SparkConnect/SparkSession.swift
@@ -147,8 +147,9 @@ public actor SparkSession {
   ///
   /// The data is serialized into an `Apache Arrow` IPC stream and embedded into the plan as a
   /// `LocalRelation`. The supported schema types are `BOOLEAN`, `TINYINT`, `SMALLINT`, `INT`,
-  /// `BIGINT`, `FLOAT`, `DOUBLE`, `STRING`, `BINARY`, `DATE`, `TIMESTAMP`, and `TIME`.
-  /// `nil` values are mapped to `NULL`. When the serialized data is equal to or larger than
+  /// `BIGINT`, `FLOAT`, `DOUBLE`, `STRING`, `BINARY`, `DATE`, `TIMESTAMP`, `TIMESTAMP_NTZ(p)`,
+  /// `TIMESTAMP_LTZ(p)` (`p` in `7...9`, with ``TimestampNanos`` values), and `TIME`. `nil`
+  /// values are mapped to `NULL`. When the serialized data is equal to or larger than
   /// `spark.sql.session.localRelationCacheThreshold` (1MiB by default), it is uploaded to the
   /// server as a `cache/` artifact and referenced by a `CachedLocalRelation` plan instead, so
   /// it is not limited by the gRPC message size limit.

--- a/Tests/SparkConnectTests/CreateDataFrameTests.swift
+++ b/Tests/SparkConnectTests/CreateDataFrameTests.swift
@@ -98,6 +98,35 @@ struct CreateDataFrameTests {
   }
 
   @Test
+  func timestampNanosTypes() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      try await spark.conf.set("spark.sql.timestampNanosTypes.enabled", "true")
+      let timestamp = try #require(
+        TimestampNanos(epochMicros: 1_706_000_000_123_456, nanosWithinMicro: 789))
+      let beforeEpoch = TimestampNanos(epochNanos: -1)  // 1969-12-31 23:59:59.999999999
+      for type in ["TIMESTAMP_NTZ", "TIMESTAMP_LTZ"] {
+        let df = try await spark.createDataFrame(
+          [[timestamp], [beforeEpoch], [nil]], "t \(type)(9)")
+        #expect(try await df.dtypes.map { $0.1 } == ["\(type.lowercased())(9)"])
+        #expect(try await df.collect() == [Row(timestamp), Row(beforeEpoch), Row(nil)])
+        for (precision, nanos) in [(7, Int16(700)), (8, 780), (9, 789)] {
+          let value = TimestampNanos(epochMicros: 1_706_000_000_123_456, nanosWithinMicro: nanos)
+          let df = try await spark.createDataFrame([[value]], "t \(type)(\(precision))")
+          #expect(try await df.dtypes.map { $0.1 } == ["\(type.lowercased())(\(precision))"])
+          #expect(try await df.collect() == [Row(value)])
+        }
+        // Out of the Arrow nanosecond range (about 1677 ~ 2262).
+        await #expect(throws: SparkConnectError.InvalidType) {
+          try await spark.createDataFrame(
+            [[TimestampNanos(epochMicros: Int64.max)]], "t \(type)(9)")
+        }
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
   func binaryType() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let df = try await spark.createDataFrame([[Data([1, 2, 3])], [nil]], "a BINARY")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` (`p` in `7...9`) columns in `SparkSession.createDataFrame` with `TimestampNanos` values.

```swift
let ts = TimestampNanos(epochMicros: 1_706_000_000_123_456, nanosWithinMicro: 789)!
let df = try await spark.createDataFrame([[ts], [nil]], "t TIMESTAMP_NTZ(9)")
try await df.dtypes    // [("t", "timestamp_ntz(9)")]
try await df.collect() // [Row(2024-01-23 08:53:20.123456789), Row(nil)]
```

- `ConvertToArrow` maps both types to an `Apache Arrow` `Timestamp(NANOSECOND)` column (no timezone for `TIMESTAMP_NTZ(p)`, `UTC` for `TIMESTAMP_LTZ(p)`), writing `TimestampNanos` as `Int64` epoch nanoseconds, symmetrically with the `collect()` decoding path added by SPARK-59198. A value outside the `Int64` nanosecond range throws `SparkConnectError.InvalidType` instead of overflowing silently.
- The precision is sent as the `SPARK::timestampNanos::precision` field metadata key, which `ArrowUtils.fromArrowField` reads on the server, like `SPARK::time::precision` for `TIME(p)` (SPARK-59155).

### Why are the changes needed?

This is the last missing piece of nanosecond timestamp support after `DataType` (SPARK-59197), `collect()` (SPARK-59198), and `lit`/SQL parameters (SPARK-59203). `createDataFrame` rejected these schemas with `SparkConnectError.InvalidType`.

### Does this PR introduce _any_ user-facing change?

No behavior change. Only `createDataFrame` now accepts `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` columns with `TimestampNanos` values against Apache Spark 4.3.0 and later.

### How was this patch tested?

Pass the CIs with a newly added test case, `CreateDataFrameTests.timestampNanosTypes`, which verifies `dtypes` and a `createDataFrame` → `collect` round trip for both types and precision 7 to 9, including sub-microsecond digits, a pre-1970 value, `nil`, and the out-of-range error.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1