### PR TITLE
[SPARK-59206] Support hash functions

### DIFF
--- a/Sources/SparkConnect/HashFunctions.swift
+++ b/Sources/SparkConnect/HashFunctions.swift
@@ -1,0 +1,76 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Hash functions
+
+/// Calculates the MD5 digest of a binary column and returns the value as a 32 character hex
+/// string.
+/// - Parameter col: A ``Column`` to compute on.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func md5(_ col: Column) -> Column {
+  return fn("md5", col)
+}
+
+/// Calculates the SHA-1 digest of a binary column and returns the value as a 40 character hex
+/// string.
+/// - Parameter col: A ``Column`` to compute on.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func sha1(_ col: Column) -> Column {
+  return fn("sha1", col)
+}
+
+/// Returns a sha1 hash value as a hex string of the `col`. This is an alias of ``sha1(_:)``.
+/// - Parameter col: A ``Column`` to compute on.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func sha(_ col: Column) -> Column {
+  return fn("sha", col)
+}
+
+/// Calculates the SHA-2 family of hash functions of a binary column and returns the value as a
+/// hex string.
+/// - Parameters:
+///   - col: A ``Column`` to compute on.
+///   - numBits: One of 224, 256, 384, 512, or 0 which is equivalent to 256.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func sha2(_ col: Column, _ numBits: Int32) -> Column {
+  return fn("sha2", col, lit(numBits))
+}
+
+/// Calculates the cyclic redundancy check value (CRC32) of a binary column and returns the value
+/// as a bigint.
+/// - Parameter col: A ``Column`` to compute on.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func crc32(_ col: Column) -> Column {
+  return fn("crc32", col)
+}
+
+/// Calculates the hash code of given columns, and returns the result as an int column.
+/// - Parameter cols: One or more ``Column``s to compute on.
+/// - Returns: A ``Column`` that evaluates to an integer.
+public func hash(_ cols: Column...) -> Column {
+  return fn("hash", cols)
+}
+
+/// Calculates the hash code of given columns using the 64-bit variant of the xxHash algorithm,
+/// and returns the result as a long column. The hash computation uses an initial seed of 42.
+/// - Parameter cols: One or more ``Column``s to compute on.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func xxhash64(_ cols: Column...) -> Column {
+  return fn("xxhash64", cols)
+}

--- a/Tests/SparkConnectTests/HashFunctionsTests.swift
+++ b/Tests/SparkConnectTests/HashFunctionsTests.swift
@@ -1,0 +1,103 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `HashFunctions`
+@Suite(.serialized)
+struct HashFunctionsTests {
+
+  @Test
+  func hashFunctions() throws {
+    for (column, name) in [
+      (md5(col("a")), "md5"),
+      (sha1(col("a")), "sha1"),
+      (sha(col("a")), "sha"),
+      (crc32(col("a")), "crc32"),
+      (hash(col("a")), "hash"),
+      (xxhash64(col("a")), "xxhash64"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  @Test
+  func hashFunctionArguments() throws {
+    let digest = sha2(col("a"), 256).expr
+    #expect(digest.unresolvedFunction.functionName == "sha2")
+    #expect(digest.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    #expect(digest.unresolvedFunction.arguments[1].literal.integer == 256)
+
+    for (column, name) in [
+      (hash(col("a"), col("b"), col("c")), "hash"),
+      (xxhash64(col("a"), col("b"), col("c")), "xxhash64"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 3)
+    }
+  }
+
+  @Test
+  func selectDigestFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT 'Spark' AS a")
+    let rows = try await df.select(md5(col("a")), sha1(col("a")), sha(col("a")), crc32(col("a")))
+      .collect()
+    #expect(
+      rows == [
+        Row(
+          "8cde774d6f7333752ed72cacddb05126",
+          "85f5955f4b27a9a4c2aab6ffe5d7189fc298b92c",
+          "85f5955f4b27a9a4c2aab6ffe5d7189fc298b92c",
+          1_557_323_817
+        )
+      ])
+
+    let sha2Rows = try await df.select(
+      sha2(col("a"), 224), sha2(col("a"), 256), sha2(col("a"), 0)
+    ).collect()
+    #expect(
+      sha2Rows == [
+        Row(
+          "dbeab94971678d36af2195851c0f7485775a2a7c60073d62fc04549c",
+          "529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b",
+          "529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b"
+        )
+      ])
+    await spark.stop()
+  }
+
+  @Test
+  func selectHashCodeFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT 'Spark' AS a, 1 AS b")
+    let rows = try await df.select(hash(col("a")), xxhash64(col("a"))).collect()
+    #expect(rows == [Row(228_093_765, -4_294_468_057_691_064_905)])
+
+    let multiple = try await df.select(hash(col("b"), col("a")), xxhash64(col("b"), col("a")))
+      .collect()
+    #expect(multiple == [Row(1_622_978_250, 8_223_983_067_343_925_414)])
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following 7 hash functions in a new
`HashFunctions.swift` file.

| Function | Signature | Since |
| -------- | --------- | ----- |
| `md5` | `(Column) -> Column` | 1.5.0 |
| `sha1` | `(Column) -> Column` | 1.5.0 |
| `sha` | `(Column) -> Column` | 3.5.0 |
| `sha2` | `(Column, Int32) -> Column` | 1.5.0 |
| `crc32` | `(Column) -> Column` | 1.5.0 |
| `hash` | `(Column...) -> Column` | 2.0.0 |
| `xxhash64` | `(Column...) -> Column` | 3.0.0 |

Note that the existing `CRC32` and `SHA256` structs are internal utilities used
by `SparkConnectClient+Artifact.swift` to compute client-side checksums during
artifact upload. They are unrelated to these SQL functions and are untouched.

### Why are the changes needed?

For feature parity with Apache Spark's `functions.scala` and PySpark's
`pyspark.sql.functions`. The `hash_funcs` group was previously not covered by
this Swift client at all.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature addition to the public API. There is no behavior
change in the existing APIs.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5