### PR TITLE
[SPARK-59207] Support predicate functions

### DIFF
--- a/Sources/SparkConnect/PredicateFunctions.swift
+++ b/Sources/SparkConnect/PredicateFunctions.swift
@@ -1,0 +1,122 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Predicate functions
+
+/// Returns true if `col1` is equal to `col2`, treating two nulls as equal.
+/// Unlike the `==` operator, this never returns null.
+/// - Parameters:
+///   - col1: A ``Column`` to compare.
+///   - col2: A ``Column`` to compare with.
+/// - Returns: A ``Column``.
+public func equal_null(_ col1: Column, _ col2: Column) -> Column {
+  return fn("equal_null", col1, col2)
+}
+
+/// Returns true if `str` matches `pattern` case-insensitively, null if any argument is null,
+/// false otherwise. The default escape character is `\`.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - pattern: A SQL `LIKE` pattern ``Column``.
+/// - Returns: A ``Column``.
+public func ilike(_ str: Column, _ pattern: Column) -> Column {
+  return fn("ilike", str, pattern)
+}
+
+/// Returns true if `str` matches `pattern` with `escapeChar` case-insensitively, null if any
+/// argument is null, false otherwise.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - pattern: A SQL `LIKE` pattern ``Column``.
+///   - escapeChar: An escape character ``Column``. Must be a constant.
+/// - Returns: A ``Column``.
+public func ilike(_ str: Column, _ pattern: Column, _ escapeChar: Column) -> Column {
+  return fn("ilike", str, pattern, escapeChar)
+}
+
+/// Returns true if `col` is NaN.
+/// - Parameter col: A ``Column`` to check.
+/// - Returns: A ``Column``.
+public func isnan(_ col: Column) -> Column {
+  return fn("isnan", col)
+}
+
+/// Returns true if `col` is not null.
+/// - Parameter col: A ``Column`` to check.
+/// - Returns: A ``Column``.
+public func isnotnull(_ col: Column) -> Column {
+  return fn("isnotnull", col)
+}
+
+/// Returns true if `col` is null.
+/// - Parameter col: A ``Column`` to check.
+/// - Returns: A ``Column``.
+public func isnull(_ col: Column) -> Column {
+  return fn("isnull", col)
+}
+
+/// Returns true if `str` matches `pattern`, null if any argument is null, false otherwise.
+/// The default escape character is `\`.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - pattern: A SQL `LIKE` pattern ``Column``.
+/// - Returns: A ``Column``.
+public func like(_ str: Column, _ pattern: Column) -> Column {
+  return fn("like", str, pattern)
+}
+
+/// Returns true if `str` matches `pattern` with `escapeChar`, null if any argument is null,
+/// false otherwise.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - pattern: A SQL `LIKE` pattern ``Column``.
+///   - escapeChar: An escape character ``Column``. Must be a constant.
+/// - Returns: A ``Column``.
+public func like(_ str: Column, _ pattern: Column, _ escapeChar: Column) -> Column {
+  return fn("like", str, pattern, escapeChar)
+}
+
+/// Returns true if `str` matches `regexp`, or false otherwise.
+/// This is an alias of ``rlike(_:_:)``.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - regexp: A regular expression ``Column``.
+/// - Returns: A ``Column``.
+public func regexp(_ str: Column, _ regexp: Column) -> Column {
+  return fn("regexp", str, regexp)
+}
+
+/// Returns true if `str` matches `regexp`, or false otherwise.
+/// This is an alias of ``rlike(_:_:)``.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - regexp: A regular expression ``Column``.
+/// - Returns: A ``Column``.
+public func regexp_like(_ str: Column, _ regexp: Column) -> Column {
+  return fn("regexp_like", str, regexp)
+}
+
+/// Returns true if `str` matches `regexp`, or false otherwise.
+/// - Parameters:
+///   - str: A ``Column`` to match.
+///   - regexp: A regular expression ``Column``.
+/// - Returns: A ``Column``.
+public func rlike(_ str: Column, _ regexp: Column) -> Column {
+  return fn("rlike", str, regexp)
+}

--- a/Tests/SparkConnectTests/PredicateFunctionsTests.swift
+++ b/Tests/SparkConnectTests/PredicateFunctionsTests.swift
@@ -1,0 +1,116 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `PredicateFunctions`
+@Suite(.serialized)
+struct PredicateFunctionsTests {
+
+  @Test
+  func predicateFunctions() throws {
+    for (column, name) in [
+      (isnan(col("a")), "isnan"),
+      (isnotnull(col("a")), "isnotnull"),
+      (isnull(col("a")), "isnull"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 1)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  @Test
+  func predicateFunctionArguments() throws {
+    for (column, name) in [
+      (equal_null(col("a"), col("b")), "equal_null"),
+      (ilike(col("a"), col("b")), "ilike"),
+      (like(col("a"), col("b")), "like"),
+      (regexp(col("a"), col("b")), "regexp"),
+      (regexp_like(col("a"), col("b")), "regexp_like"),
+      (rlike(col("a"), col("b")), "rlike"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "b")
+    }
+  }
+
+  @Test
+  func predicateFunctionEscapeChar() throws {
+    for (column, name) in [
+      (ilike(col("a"), col("b"), lit("/")), "ilike"),
+      (like(col("a"), col("b"), lit("/")), "like"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 3)
+      #expect(expr.unresolvedFunction.arguments[2].literal.string == "/")
+    }
+  }
+
+  @Test
+  func filterWithNullPredicates() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql(
+      "SELECT * FROM VALUES ('Alice', 20), ('Bob', NULL), (NULL, 30) T(name, age)")
+    #expect(try await df.filter(isnull(col("age"))).count() == 1)
+    #expect(try await df.filter(isnotnull(col("age"))).count() == 2)
+    #expect(try await df.filter(isnull(col("name"))).count() == 1)
+
+    let pairs = try await spark.sql(
+      "SELECT * FROM VALUES ('a', 'a'), (NULL, NULL), ('a', NULL) T(x, y)")
+    #expect(try await pairs.filter(equal_null(col("x"), col("y"))).count() == 2)
+    #expect(try await pairs.select(equal_null(col("x"), col("y"))).collect()
+      == [Row(true), Row(true), Row(false)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectIsnan() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT CAST('NaN' AS DOUBLE) AS a, 1.0D AS b")
+    #expect(try await df.select(isnan(col("a")), isnan(col("b"))).collect() == [Row(true, false)])
+    await spark.stop()
+  }
+
+  @Test
+  func filterWithPatternPredicates() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql(
+      "SELECT * FROM VALUES ('Alice'), ('Bob'), ('Charlie') T(name)")
+    #expect(try await df.filter(like(col("name"), lit("Al%"))).count() == 1)
+    #expect(try await df.filter(ilike(col("name"), lit("al%"))).count() == 1)
+    #expect(try await df.filter(rlike(col("name"), lit("^.o.$"))).count() == 1)
+    #expect(try await df.filter(regexp(col("name"), lit("^.o.$"))).count() == 1)
+    #expect(try await df.filter(regexp_like(col("name"), lit("^.o.$"))).count() == 1)
+
+    // `_` matches any single character unless it is preceded by the escape character.
+    let escaped = try await spark.sql("SELECT * FROM VALUES ('a_b'), ('axb') T(s)")
+    #expect(try await escaped.filter(like(col("s"), lit("a_b"))).count() == 2)
+    #expect(try await escaped.filter(like(col("s"), lit("a/_b"), lit("/"))).count() == 1)
+    #expect(try await escaped.filter(ilike(col("s"), lit("A/_B"), lit("/"))).count() == 1)
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the 9 missing predicate functions to the Swift Spark Connect client, in a new
`PredicateFunctions.swift`:

- `equal_null`, `isnan`, `isnotnull`, `isnull`, `like`, `ilike`, `regexp`, `regexp_like`, `rlike`

`like` and `ilike` are provided as two overloads each, with and without the optional `escapeChar`
argument, mirroring the Scala API.

The grouping follows upstream: these are exactly the members of the `Predicate Functions` section
in PySpark's `functions.rst`, and of the `@group predicate_funcs` annotation in Scala's
`functions.scala` (whose only other member, `not`, is already covered here by the `!` prefix
operator on `Column`). The new file also matches the existing per-category layout of
`MathFunctions.swift`, `StringFunctions.swift` and `CollectionFunctions.swift`.

Following the existing convention in this repository, all new functions accept `Column` only;
no `String` overloads are added.

### Why are the changes needed?

These are among the most frequently used functions in the PySpark API and have no Swift
equivalent today. `Column` already exposes `isNull()`, `isNotNull()`, `like()`, `rlike()` and
`ilike()` as methods, but PySpark and the Scala API additionally provide them as free functions,
which is what this PR fills in.

### Does this PR introduce _any_ user-facing change?

No because there are new public APIs. For example:

```swift
let df = try await spark.sql("SELECT * FROM VALUES ('Alice', 20), ('Bob', NULL) T(name, age)")
try await df.filter(isnotnull(col("age"))).show()
try await df.filter(like(col("name"), lit("Al%"))).show()
```

### How was this patch tested?

Pass the CIs with the newly added `PredicateFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5