### PR TITLE
[SPARK-59209] Support `greatest`, `least`, `random` and `try_*` arithmetic functions

### DIFF
--- a/Sources/SparkConnect/MathFunctions.swift
+++ b/Sources/SparkConnect/MathFunctions.swift
@@ -229,6 +229,17 @@ public func floor(_ col: Column, _ scale: Column) -> Column {
   return fn("floor", col, scale)
 }
 
+/// Returns the greatest value of the list of values, skipping null values. This function takes
+/// at least 2 parameters. It will return null iff all parameters are null.
+/// - Parameters:
+///   - col1: A ``Column``.
+///   - col2: A ``Column``.
+///   - cols: Additional ``Column``s.
+/// - Returns: A ``Column``.
+public func greatest(_ col1: Column, _ col2: Column, _ cols: Column...) -> Column {
+  return fn("greatest", [col1, col2] + cols)
+}
+
 /// Computes hex value of the given column.
 /// - Parameter col: A ``Column``.
 /// - Returns: A ``Column``.
@@ -243,6 +254,17 @@ public func hex(_ col: Column) -> Column {
 /// - Returns: A ``Column``.
 public func hypot(_ l: Column, _ r: Column) -> Column {
   return fn("hypot", l, r)
+}
+
+/// Returns the least value of the list of values, skipping null values. This function takes at
+/// least 2 parameters. It will return null iff all parameters are null.
+/// - Parameters:
+///   - col1: A ``Column``.
+///   - col2: A ``Column``.
+///   - cols: Additional ``Column``s.
+/// - Returns: A ``Column``.
+public func least(_ col1: Column, _ col2: Column, _ cols: Column...) -> Column {
+  return fn("least", [col1, col2] + cols)
 }
 
 /// Computes the natural logarithm of the given value.
@@ -343,6 +365,36 @@ public func power(_ l: Column, _ r: Column) -> Column {
 /// - Returns: A ``Column``.
 public func radians(_ col: Column) -> Column {
   return fn("radians", col)
+}
+
+/// Generates a random column with independent and identically distributed (i.i.d.) samples
+/// uniformly distributed in [0.0, 1.0). The function is non-deterministic in general case.
+/// - Returns: A ``Column``.
+public func rand() -> Column {
+  return fn("rand")
+}
+
+/// Generates a random column with independent and identically distributed (i.i.d.) samples
+/// uniformly distributed in [0.0, 1.0), with the chosen random seed.
+/// - Parameter seed: A random seed.
+/// - Returns: A ``Column``.
+public func rand(_ seed: Int64) -> Column {
+  return fn("rand", lit(seed))
+}
+
+/// Generates a column with independent and identically distributed (i.i.d.) samples from the
+/// standard normal distribution. The function is non-deterministic in general case.
+/// - Returns: A ``Column``.
+public func randn() -> Column {
+  return fn("randn")
+}
+
+/// Generates a column with independent and identically distributed (i.i.d.) samples from the
+/// standard normal distribution, with the chosen random seed.
+/// - Parameter seed: A random seed.
+/// - Returns: A ``Column``.
+public func randn(_ seed: Int64) -> Column {
+  return fn("randn", lit(seed))
 }
 
 /// Returns the double value that is closest in value to the argument and is equal to a
@@ -452,12 +504,88 @@ public func tanh(_ col: Column) -> Column {
   return fn("tanh", col)
 }
 
+/// Returns the sum of `left` and `right` and the result is null on overflow. The acceptable
+/// input types are the same with the `+` operator.
+/// - Parameters:
+///   - left: A left operand ``Column``.
+///   - right: A right operand ``Column``.
+/// - Returns: A ``Column``.
+public func try_add(_ left: Column, _ right: Column) -> Column {
+  return fn("try_add", left, right)
+}
+
+/// Returns `left`/`right`. It always performs floating point division. Its result is always null
+/// if `right` is 0.
+/// - Parameters:
+///   - left: A dividend ``Column``.
+///   - right: A divisor ``Column``.
+/// - Returns: A ``Column``.
+public func try_divide(_ left: Column, _ right: Column) -> Column {
+  return fn("try_divide", left, right)
+}
+
+/// Returns the remainder of `left`/`right`. Its result is always null if `right` is 0.
+/// - Parameters:
+///   - left: A dividend ``Column``.
+///   - right: A divisor ``Column``.
+/// - Returns: A ``Column``.
+public func try_mod(_ left: Column, _ right: Column) -> Column {
+  return fn("try_mod", left, right)
+}
+
+/// Returns `left`*`right` and the result is null on overflow. The acceptable input types are the
+/// same with the `*` operator.
+/// - Parameters:
+///   - left: A multiplicand ``Column``.
+///   - right: A multiplier ``Column``.
+/// - Returns: A ``Column``.
+public func try_multiply(_ left: Column, _ right: Column) -> Column {
+  return fn("try_multiply", left, right)
+}
+
+/// Returns `left`-`right` and the result is null on overflow. The acceptable input types are the
+/// same with the `-` operator.
+/// - Parameters:
+///   - left: A left operand ``Column``.
+///   - right: A right operand ``Column``.
+/// - Returns: A ``Column``.
+public func try_subtract(_ left: Column, _ right: Column) -> Column {
+  return fn("try_subtract", left, right)
+}
+
 /// Inverse of ``hex(_:)``. Interprets each pair of characters as a hexadecimal number and
 /// converts to the byte representation of number.
 /// - Parameter col: A ``Column``.
 /// - Returns: A ``Column``.
 public func unhex(_ col: Column) -> Column {
   return fn("unhex", col)
+}
+
+/// Returns a random value with independent and identically distributed (i.i.d.) values with the
+/// specified range of numbers. The provided numbers specifying the minimum and maximum values of
+/// the range must be constant. If both of these numbers are integers, then the result will also
+/// be an integer. Otherwise if one or both of these are floating-point numbers, then the result
+/// will also be a floating-point number.
+/// - Parameters:
+///   - min: A minimum value ``Column`` in the range. Must be a constant.
+///   - max: A maximum value ``Column`` in the range. Must be a constant.
+/// - Returns: A ``Column``.
+public func uniform(_ min: Column, _ max: Column) -> Column {
+  return fn("uniform", min, max)
+}
+
+/// Returns a random value with independent and identically distributed (i.i.d.) values with the
+/// specified range of numbers, with the chosen random seed. The provided numbers specifying the
+/// minimum and maximum values of the range must be constant. If both of these numbers are
+/// integers, then the result will also be an integer. Otherwise if one or both of these are
+/// floating-point numbers, then the result will also be a floating-point number.
+/// - Parameters:
+///   - min: A minimum value ``Column`` in the range. Must be a constant.
+///   - max: A maximum value ``Column`` in the range. Must be a constant.
+///   - seed: A random seed ``Column``. Must be a constant.
+/// - Returns: A ``Column``.
+public func uniform(_ min: Column, _ max: Column, _ seed: Column) -> Column {
+  return fn("uniform", min, max, seed)
 }
 
 /// Returns the bucket number into which the value of this expression would fall after being

--- a/Tests/SparkConnectTests/MathFunctionsTests.swift
+++ b/Tests/SparkConnectTests/MathFunctionsTests.swift
@@ -87,6 +87,14 @@ struct MathFunctionsTests {
       (ceil(col("a"), lit(1)), "ceil"),
       (ceiling(col("a"), lit(1)), "ceiling"),
       (floor(col("a"), lit(1)), "floor"),
+      (greatest(col("a"), col("b")), "greatest"),
+      (least(col("a"), col("b")), "least"),
+      (try_add(col("a"), col("b")), "try_add"),
+      (try_divide(col("a"), col("b")), "try_divide"),
+      (try_mod(col("a"), col("b")), "try_mod"),
+      (try_multiply(col("a"), col("b")), "try_multiply"),
+      (try_subtract(col("a"), col("b")), "try_subtract"),
+      (uniform(lit(0), lit(10)), "uniform"),
     ] {
       let expr = column.expr
       #expect(expr.unresolvedFunction.functionName == name)
@@ -118,6 +126,28 @@ struct MathFunctionsTests {
     #expect(pi().expr.unresolvedFunction.arguments.isEmpty)
     #expect(
       width_bucket(col("a"), lit(0), lit(10), lit(5)).expr.unresolvedFunction.arguments.count == 4)
+
+    #expect(greatest(col("a"), col("b"), col("c")).expr.unresolvedFunction.arguments.count == 3)
+    #expect(least(col("a"), col("b"), col("c")).expr.unresolvedFunction.arguments.count == 3)
+    #expect(uniform(lit(0), lit(10), lit(1)).expr.unresolvedFunction.arguments.count == 3)
+
+    for (column, name) in [
+      (rand(), "rand"),
+      (randn(), "randn"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.isEmpty)
+    }
+
+    for (column, name) in [
+      (rand(42), "rand"),
+      (randn(42), "randn"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[0].literal.long == 42)
+    }
   }
 
   @Test
@@ -197,6 +227,77 @@ struct MathFunctionsTests {
       shiftleft(lit(1), 3), shiftright(lit(8), 2), shiftrightunsigned(lit(8), 2)
     ).collect()
     #expect(rows == [Row("101", "FF", "4", 8, 2, 2)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectComparisonFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let rows = try await df.select(
+      greatest(lit(1), lit(2)), greatest(lit(1), lit(2), lit(3)),
+      least(lit(1), lit(2)), least(lit(1), lit(2), lit(3))
+    ).collect()
+    #expect(rows == [Row(2, 3, 1, 1)])
+
+    // Null values are skipped and the result is null iff all the values are null.
+    let nulls = try await spark.sql(
+      "SELECT CAST(NULL AS INT) AS a, 1 AS b, CAST(NULL AS INT) AS c"
+    ).select(
+      greatest(col("a"), col("b")), least(col("a"), col("b")),
+      greatest(col("a"), col("c")), least(col("a"), col("c"))
+    ).collect()
+    #expect(nulls == [Row(1, 1, nil, nil)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectRandomFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+
+    // The functions are non-deterministic, so only the value range is verified.
+    let rows = try await df.select(rand(), randn()).collect()
+    let random = try rows[0][0] as! Double
+    #expect(random >= 0.0 && random < 1.0)
+    let normal = try rows[0][1]
+    #expect(normal is Double)
+
+    // The same seed always gives the same value.
+    let seeded = try await df.select(rand(42), randn(42)).collect()
+    #expect(try await df.select(rand(42), randn(42)).collect() == seeded)
+
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      let uniforms = try await df.select(uniform(lit(5), lit(105), lit(3))).collect()
+      let value = try uniforms[0][0] as! Int64
+      #expect(value >= 5 && value <= 105)
+      #expect(try await df.select(uniform(lit(5), lit(105), lit(3))).collect() == uniforms)
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func selectTryArithmeticFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let rows = try await df.select(
+      try_add(lit(1), lit(2)), try_subtract(lit(5), lit(2)), try_multiply(lit(2), lit(3)),
+      try_divide(lit(6), lit(3))
+    ).collect()
+    #expect(rows == [Row(3, 3, 6, 2.0)])
+
+    // Null is returned instead of an exception on overflow and division by zero.
+    let overflow = try await df.select(
+      try_add(lit(Int64.max), lit(1)), try_subtract(lit(Int64.min), lit(1)),
+      try_multiply(lit(Int64.max), lit(2)), try_divide(lit(1), lit(0))
+    ).collect()
+    #expect(overflow == [Row(nil, nil, nil, nil)])
+
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      #expect(
+        try await df.select(try_mod(lit(7), lit(3)), try_mod(lit(1), lit(0))).collect()
+          == [Row(1, nil)])
+    }
     await spark.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following 10 functions in `MathFunctions`.

- Comparison: `greatest`, `least`
- Random: `rand`, `randn`, `uniform`
- Try arithmetic: `try_add`, `try_subtract`, `try_multiply`, `try_divide`, `try_mod`

`greatest` and `least` take at least two `Column`s, which is expressed as two
required parameters followed by a variadic one, and `rand`, `randn` and
`uniform` provide an additional overload taking a random seed.

### Why are the changes needed?

To provide the same set of math functions with Apache Spark and PySpark.

- `greatest`, `least`, `rand` and `randn` exist since Apache Spark 1.4.0/1.5.0.
- `try_add`, `try_subtract`, `try_multiply` and `try_divide` exist since Apache Spark 3.5.0.
- `try_mod` and `uniform` exist since Apache Spark 4.0.0.

### Does this PR introduce _any_ user-facing change?

No, this PR adds new functions only.

```swift
let df = try await spark.range(1)
try await df.select(greatest(lit(1), lit(2), lit(3)), least(lit(1), lit(2))).show()
try await df.select(try_divide(lit(1), lit(0)), try_add(lit(Int64.max), lit(1))).show()
try await df.select(rand(42), randn(42), uniform(lit(5), lit(105), lit(3))).show()
```

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5