### PR TITLE
[SPARK-59210] Support misc metadata functions

### DIFF
--- a/Sources/SparkConnect/MiscFunctions.swift
+++ b/Sources/SparkConnect/MiscFunctions.swift
@@ -1,0 +1,135 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Misc functions
+
+/// Returns the current catalog.
+/// - Returns: A ``Column``.
+public func current_catalog() -> Column {
+  return fn("current_catalog")
+}
+
+/// Returns the current database.
+/// - Returns: A ``Column``.
+public func current_database() -> Column {
+  return fn("current_database")
+}
+
+/// Returns the current SQL path as a comma-separated list of qualified schema names.
+/// This requires a Spark 4.2.0+ server.
+/// - Returns: A ``Column``.
+public func current_path() -> Column {
+  return fn("current_path")
+}
+
+/// Returns the current schema.
+/// - Returns: A ``Column``.
+public func current_schema() -> Column {
+  return fn("current_schema")
+}
+
+/// Returns the user name of the current execution context.
+/// - Returns: A ``Column``.
+public func current_user() -> Column {
+  return fn("current_user")
+}
+
+/// Returns the length of the block being read, or -1 if not available.
+/// - Returns: A ``Column``.
+public func input_file_block_length() -> Column {
+  return fn("input_file_block_length")
+}
+
+/// Returns the start offset of the block being read, or -1 if not available.
+/// - Returns: A ``Column``.
+public func input_file_block_start() -> Column {
+  return fn("input_file_block_start")
+}
+
+/// Returns the file name of the current Spark task, or an empty string if not available.
+/// - Returns: A ``Column``.
+public func input_file_name() -> Column {
+  return fn("input_file_name")
+}
+
+/// Returns monotonically increasing 64-bit integers. The generated ID is guaranteed to be
+/// monotonically increasing and unique, but not consecutive.
+/// - Returns: A ``Column``.
+public func monotonically_increasing_id() -> Column {
+  return fn("monotonically_increasing_id")
+}
+
+/// Returns the user name of the current execution context.
+/// This requires a Spark 4.0.0+ server.
+/// - Returns: A ``Column``.
+public func session_user() -> Column {
+  return fn("session_user")
+}
+
+/// Returns the partition ID. This is non-deterministic because it depends on data partitioning
+/// and task scheduling.
+/// - Returns: A ``Column``.
+public func spark_partition_id() -> Column {
+  return fn("spark_partition_id")
+}
+
+/// Returns the DDL-formatted type string for the data type of the input.
+/// - Parameter col: A ``Column``.
+/// - Returns: A ``Column``.
+public func typeof(_ col: Column) -> Column {
+  return fn("typeof", col)
+}
+
+/// Returns the user name of the current execution context.
+/// - Returns: A ``Column``.
+public func user() -> Column {
+  return fn("user")
+}
+
+/// Returns a universally unique identifier (UUID) string. The value is returned as a canonical
+/// UUID 36-character string.
+/// - Returns: A ``Column``.
+public func uuid() -> Column {
+  return fn("uuid")
+}
+
+/// Returns a universally unique identifier (UUID) string. The value is returned as a canonical
+/// UUID 36-character string. This requires a Spark 4.1.0+ server.
+/// - Parameter seed: A random number seed ``Column``. Must be a constant.
+/// - Returns: A ``Column``.
+public func uuid(_ seed: Column) -> Column {
+  return fn("uuid", seed)
+}
+
+/// Returns a universally unique identifier (UUID) string. The value is returned as a canonical
+/// UUID 36-character string. This requires a Spark 4.1.0+ server.
+/// - Parameter seed: A literal random number seed.
+/// - Returns: A ``Column``.
+public func uuid(_ seed: some SparkLiteral) -> Column {
+  return uuid(seed.toLiteralColumn)
+}
+
+/// Returns the Spark version of the server as a ``Column`` expression. The string contains two
+/// fields, the first being a release version and the second being a git revision. Unlike
+/// ``SparkSession/version``, which is a `String` already fetched from the server, this builds a
+/// SQL expression evaluated by the server.
+/// - Returns: A ``Column``.
+public func version() -> Column {
+  return fn("version")
+}

--- a/Tests/SparkConnectTests/MiscFunctionsTests.swift
+++ b/Tests/SparkConnectTests/MiscFunctionsTests.swift
@@ -1,0 +1,159 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `MiscFunctions`
+@Suite(.serialized)
+struct MiscFunctionsTests {
+
+  @Test
+  func miscFunctions() throws {
+    for (column, name) in [
+      (current_catalog(), "current_catalog"),
+      (current_database(), "current_database"),
+      (current_path(), "current_path"),
+      (current_schema(), "current_schema"),
+      (current_user(), "current_user"),
+      (input_file_block_length(), "input_file_block_length"),
+      (input_file_block_start(), "input_file_block_start"),
+      (input_file_name(), "input_file_name"),
+      (monotonically_increasing_id(), "monotonically_increasing_id"),
+      (session_user(), "session_user"),
+      (spark_partition_id(), "spark_partition_id"),
+      (user(), "user"),
+      (uuid(), "uuid"),
+      (version(), "version"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.isEmpty)
+    }
+  }
+
+  @Test
+  func miscFunctionArguments() throws {
+    let typeOfColumn = typeof(col("a")).expr
+    #expect(typeOfColumn.unresolvedFunction.functionName == "typeof")
+    #expect(typeOfColumn.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+
+    let seededByColumn = uuid(col("a")).expr
+    #expect(seededByColumn.unresolvedFunction.functionName == "uuid")
+    #expect(seededByColumn.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+
+    let seededByLiteral = uuid(123).expr
+    #expect(seededByLiteral.unresolvedFunction.functionName == "uuid")
+    #expect(seededByLiteral.unresolvedFunction.arguments[0].literal.long == 123)
+  }
+
+  @Test
+  func sessionFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let rows = try await spark.range(1).select(
+      current_catalog(), current_database(), current_schema(), current_user(), user(), version()
+    ).collect()
+    #expect(try rows[0].get(0) as! String == "spark_catalog")
+    #expect(try rows[0].get(1) as! String == "default")
+    #expect(try rows[0].get(2) as! String == "default")
+    let currentUser = try rows[0].get(3) as! String
+    #expect(!currentUser.isEmpty)
+    #expect(try rows[0].get(4) as! String == currentUser)
+    // `version()` is a server-side SQL expression, `spark.version` is the already fetched string.
+    #expect(try (rows[0].get(5) as! String).hasPrefix(await spark.version))
+    await spark.stop()
+  }
+
+  @Test
+  func sessionUser() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      let rows = try await spark.range(1).select(session_user(), current_user()).collect()
+      #expect(try rows[0].get(0) as! String == (try rows[0].get(1) as! String))
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func currentPath() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.2.0") {
+      let rows = try await spark.range(1).select(current_path()).collect()
+      #expect(!(try rows[0].get(0) as! String).isEmpty)
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func typeOf() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let rows = try await spark.range(1).select(
+      typeof(lit(1)), typeof(lit(1.0)), typeof(lit("a"))
+    ).collect()
+    #expect(rows == [Row("bigint", "double", "string")])
+    await spark.stop()
+  }
+
+  @Test
+  func nondeterministicFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let rows = try await spark.range(3).select(
+      monotonically_increasing_id(), spark_partition_id(), uuid()
+    ).collect()
+    #expect(rows.count == 3)
+    for row in rows {
+      #expect((try row.get(0) as? Int64) != nil)
+      #expect((try row.get(1) as? Int32) != nil)
+      #expect((try row.get(2) as! String).count == 36)
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func uuidWithSeed() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1.0") {
+      let rows = try await spark.range(3).select(uuid(lit(123)), uuid(456)).collect()
+      #expect(rows.count == 3)
+      for row in rows {
+        #expect((try row.get(0) as! String).count == 36)
+        #expect((try row.get(1) as! String).count == 36)
+      }
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func fileMetadataFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.read.orc("../examples/src/main/resources/users.orc")
+    let rows = try await df.select(
+      input_file_name(), input_file_block_start(), input_file_block_length()
+    ).collect()
+    #expect(rows.count == 2)
+    for row in rows {
+      let name = try row.get(0) as! String
+      #expect(name.isEmpty || name.hasSuffix("users.orc"))
+      #expect((try row.get(1) as! Int64) >= -1)
+      #expect((try row.get(2) as! Int64) >= -1)
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following 15 misc metadata functions by adding a new
`MiscFunctions.swift` file.

| Function | Since (Apache Spark) |
| -------- | -------------------- |
| `monotonically_increasing_id()`, `spark_partition_id()`, `input_file_name()` | 1.6.0 |
| `input_file_block_start()`, `input_file_block_length()` | 3.5.0 |
| `current_catalog()`, `current_database()`, `current_schema()` | 3.5.0 |
| `current_user()`, `user()`, `version()`, `typeof(col)`, `uuid()` | 3.5.0 |
| `session_user()` | 4.0.0 |
| `uuid(seed)` | 4.1.0 |
| `current_path()` | 4.2.0 |

Note that `uuid()` is sent without any argument like PySpark's
`sf.uuid()` does, so that it keeps working against Apache Spark 4.0 servers.

### Why are the changes needed?

To improve the API coverage. These functions expose session, partition, and file
metadata, and none of them was available in this client before.

### Does this PR introduce _any_ user-facing change?

No, this is a new addition to the public API.

```swift
let df = try await spark.range(1)
try await df.select(current_catalog(), current_database(), version()).show()
```

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5