### PR TITLE
[SPARK-59213] Support null ordering in sort functions and `Column`

### DIFF
--- a/Sources/SparkConnect/Column.swift
+++ b/Sources/SparkConnect/Column.swift
@@ -68,9 +68,37 @@ public struct Column: Sendable {
     return sortOrder(.ascending, .sortNullsFirst)
   }
 
+  /// Returns a sort expression based on the ascending order of this column, with null values
+  /// appearing before non-null values. This is an alias of ``asc()``.
+  /// - Returns: A ``Column`` with ascending sort order.
+  public func ascNullsFirst() -> Column {
+    return sortOrder(.ascending, .sortNullsFirst)
+  }
+
+  /// Returns a sort expression based on the ascending order of this column, with null values
+  /// appearing after non-null values.
+  /// - Returns: A ``Column`` with ascending sort order.
+  public func ascNullsLast() -> Column {
+    return sortOrder(.ascending, .sortNullsLast)
+  }
+
   /// Returns a sort expression based on the descending order of this column.
   /// - Returns: A ``Column`` with descending sort order.
   public func desc() -> Column {
+    return sortOrder(.descending, .sortNullsLast)
+  }
+
+  /// Returns a sort expression based on the descending order of this column, with null values
+  /// appearing before non-null values.
+  /// - Returns: A ``Column`` with descending sort order.
+  public func descNullsFirst() -> Column {
+    return sortOrder(.descending, .sortNullsFirst)
+  }
+
+  /// Returns a sort expression based on the descending order of this column, with null values
+  /// appearing after non-null values. This is an alias of ``desc()``.
+  /// - Returns: A ``Column`` with descending sort order.
+  public func descNullsLast() -> Column {
     return sortOrder(.descending, .sortNullsLast)
   }
 

--- a/Sources/SparkConnect/Functions.swift
+++ b/Sources/SparkConnect/Functions.swift
@@ -197,11 +197,43 @@ public func asc(_ name: String) -> Column {
   return Column(name).asc()
 }
 
+/// Returns a sort expression based on the ascending order of the given column name, with null
+/// values appearing before non-null values. This is an alias of ``asc(_:)``.
+/// - Parameter name: A column name.
+/// - Returns: A ``Column`` with ascending sort order.
+public func asc_nulls_first(_ name: String) -> Column {
+  return Column(name).ascNullsFirst()
+}
+
+/// Returns a sort expression based on the ascending order of the given column name, with null
+/// values appearing after non-null values.
+/// - Parameter name: A column name.
+/// - Returns: A ``Column`` with ascending sort order.
+public func asc_nulls_last(_ name: String) -> Column {
+  return Column(name).ascNullsLast()
+}
+
 /// Returns a sort expression based on the descending order of the given column name.
 /// - Parameter name: A column name.
 /// - Returns: A ``Column`` with descending sort order.
 public func desc(_ name: String) -> Column {
   return Column(name).desc()
+}
+
+/// Returns a sort expression based on the descending order of the given column name, with null
+/// values appearing before non-null values.
+/// - Parameter name: A column name.
+/// - Returns: A ``Column`` with descending sort order.
+public func desc_nulls_first(_ name: String) -> Column {
+  return Column(name).descNullsFirst()
+}
+
+/// Returns a sort expression based on the descending order of the given column name, with null
+/// values appearing after non-null values. This is an alias of ``desc(_:)``.
+/// - Parameter name: A column name.
+/// - Returns: A ``Column`` with descending sort order.
+public func desc_nulls_last(_ name: String) -> Column {
+  return Column(name).descNullsLast()
 }
 
 /// Parses the expression string into the column that it represents.

--- a/Tests/SparkConnectTests/FunctionsTests.swift
+++ b/Tests/SparkConnectTests/FunctionsTests.swift
@@ -95,6 +95,34 @@ struct FunctionsTests {
   }
 
   @Test
+  func nullOrderingFunctions() throws {
+    let cases:
+      [(
+        Column, Spark_Connect_Expression.SortOrder.SortDirection,
+        Spark_Connect_Expression.SortOrder.NullOrdering
+      )] = [
+        (asc_nulls_first("id"), .ascending, .sortNullsFirst),
+        (asc_nulls_last("id"), .ascending, .sortNullsLast),
+        (desc_nulls_first("id"), .descending, .sortNullsFirst),
+        (desc_nulls_last("id"), .descending, .sortNullsLast),
+        (col("id").ascNullsFirst(), .ascending, .sortNullsFirst),
+        (col("id").ascNullsLast(), .ascending, .sortNullsLast),
+        (col("id").descNullsFirst(), .descending, .sortNullsFirst),
+        (col("id").descNullsLast(), .descending, .sortNullsLast),
+      ]
+    for (column, direction, nullOrdering) in cases {
+      let expr = column.expr
+      #expect(expr.sortOrder.child.unresolvedAttribute.unparsedIdentifier == "id")
+      #expect(expr.sortOrder.direction == direction)
+      #expect(expr.sortOrder.nullOrdering == nullOrdering)
+    }
+
+    // `asc` is an alias of `asc_nulls_first` and `desc` is an alias of `desc_nulls_last`.
+    #expect(asc("id").expr == asc_nulls_first("id").expr)
+    #expect(desc("id").expr == desc_nulls_last("id").expr)
+  }
+
+  @Test
   func cast() throws {
     let expr = col("id").cast("string").expr
     #expect(expr.cast.expr.unresolvedAttribute.unparsedIdentifier == "id")
@@ -441,6 +469,19 @@ struct FunctionsTests {
     let rows = try await df.select(
       col("arr").getItem(0), col("m").getItem("k"), col("s").getField("a")).collect()
     #expect(rows == [Row(1, 10, 7)])
+    await spark.stop()
+  }
+
+  @Test
+  func sortWithNullOrdering() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT * FROM VALUES (1), (null), (2) AS T(v)")
+    #expect(try await df.orderBy(asc_nulls_first("v")).collect() == [Row(nil), Row(1), Row(2)])
+    #expect(try await df.orderBy(asc_nulls_last("v")).collect() == [Row(1), Row(2), Row(nil)])
+    #expect(try await df.orderBy(desc_nulls_first("v")).collect() == [Row(nil), Row(2), Row(1)])
+    #expect(try await df.orderBy(desc_nulls_last("v")).collect() == [Row(2), Row(1), Row(nil)])
+    #expect(try await df.sort(col("v").ascNullsLast()).collect() == [Row(1), Row(2), Row(nil)])
+    #expect(try await df.sort(col("v").descNullsFirst()).collect() == [Row(nil), Row(2), Row(1)])
     await spark.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds null-ordering sort APIs.

- `Functions.swift`: `asc_nulls_first`, `asc_nulls_last`, `desc_nulls_first`, `desc_nulls_last`
- `Column`: `ascNullsFirst()`, `ascNullsLast()`, `descNullsFirst()`, `descNullsLast()`

Free functions use `snake_case` to mirror Spark/PySpark (like the existing `any_value`,
`count_if`), while `Column` methods use `camelCase` (like the existing `isNull`,
`eqNullSafe`). The free functions delegate to the new `Column` methods, which reuse the
existing private `sortOrder(_:_:)` helper.

### Why are the changes needed?

Apache Spark has provided these in both `functions` and `Column` since 2.1.0. This client
only had `asc` and `desc`, so null placement could not be controlled without a raw SQL
string like `expr("v ASC NULLS LAST")`.

The existing `asc()`/`desc()` already match the upstream defaults (`asc == asc_nulls_first`,
`desc == desc_nulls_last`) and are unchanged.

### Does this PR introduce _any_ user-facing change?

No existing behavior changes because this is new public APIs. 

```swift
let df = try await spark.sql("SELECT * FROM VALUES (1), (null), (2) AS T(v)")
try await df.orderBy(asc_nulls_last("v")).show()   // 1, 2, NULL
try await df.sort(col("v").descNullsFirst()).show()  // NULL, 2, 1
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5