### PR TITLE
[SPARK-59214] Support bitwise functions

### DIFF
--- a/Sources/SparkConnect/BitwiseFunctions.swift
+++ b/Sources/SparkConnect/BitwiseFunctions.swift
@@ -1,0 +1,83 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Bitwise functions
+
+/// Returns the number of bits that are set in the given value as an unsigned 64-bit integer,
+/// or `NULL` if the argument is `NULL`.
+/// - Parameter col: A ``Column`` that evaluates to an integral or boolean.
+/// - Returns: A ``Column``.
+public func bit_count(_ col: Column) -> Column {
+  return fn("bit_count", col)
+}
+
+/// Returns the value of the bit (0 or 1) at the specified position. The positions are numbered
+/// from right to left, starting at zero. The position argument cannot be negative.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an integral.
+///   - pos: A ``Column`` for the bit position, numbered from right to left starting at zero.
+/// - Returns: A ``Column``.
+public func bit_get(_ col: Column, _ pos: Column) -> Column {
+  return fn("bit_get", col, pos)
+}
+
+/// Computes bitwise NOT (`~`) of the given value.
+/// - Parameter col: A ``Column`` that evaluates to an integral.
+/// - Returns: A ``Column`` of the same type as the input.
+public func bitwise_not(_ col: Column) -> Column {
+  return fn("~", col)
+}
+
+/// Returns the value of the bit (0 or 1) at the specified position. The positions are numbered
+/// from right to left, starting at zero. The position argument cannot be negative.
+/// This is an alias of ``bit_get(_:_:)``.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an integral.
+///   - pos: A ``Column`` for the bit position, numbered from right to left starting at zero.
+/// - Returns: A ``Column``.
+public func getbit(_ col: Column, _ pos: Column) -> Column {
+  return fn("getbit", col, pos)
+}
+
+/// Shifts the given value `numBits` left.
+/// - Parameters:
+///   - col: A ``Column``.
+///   - numBits: The number of bits to shift.
+/// - Returns: A ``Column``.
+public func shiftleft(_ col: Column, _ numBits: Int32) -> Column {
+  return fn("shiftleft", col, lit(numBits))
+}
+
+/// (Signed) shifts the given value `numBits` right.
+/// - Parameters:
+///   - col: A ``Column``.
+///   - numBits: The number of bits to shift.
+/// - Returns: A ``Column``.
+public func shiftright(_ col: Column, _ numBits: Int32) -> Column {
+  return fn("shiftright", col, lit(numBits))
+}
+
+/// (Unsigned) shifts the given value `numBits` right.
+/// - Parameters:
+///   - col: A ``Column``.
+///   - numBits: The number of bits to shift.
+/// - Returns: A ``Column``.
+public func shiftrightunsigned(_ col: Column, _ numBits: Int32) -> Column {
+  return fn("shiftrightunsigned", col, lit(numBits))
+}

--- a/Sources/SparkConnect/Column.swift
+++ b/Sources/SparkConnect/Column.swift
@@ -396,6 +396,58 @@ public struct Column: Sendable {
     return try otherwise(value.toLiteralColumn)
   }
 
+  // MARK: - Bitwise methods
+
+  /// Returns an expression computing the bitwise AND (`&`) of this column with another column.
+  ///
+  /// Note that this is a bitwise operation, unlike the logical ``&&(_:_:)`` operator.
+  ///
+  /// ```swift
+  /// df.select(col("a").bitwiseAND(col("b")))
+  /// ```
+  /// - Parameter other: A ``Column`` that evaluates to an integral.
+  /// - Returns: A ``Column``.
+  public func bitwiseAND(_ other: Column) -> Column {
+    return Column.fn("&", self, other)
+  }
+
+  /// Returns an expression computing the bitwise AND (`&`) of this column with a literal value.
+  /// - Parameter other: A literal value.
+  /// - Returns: A ``Column``.
+  public func bitwiseAND(_ other: some SparkLiteral) -> Column {
+    return bitwiseAND(other.toLiteralColumn)
+  }
+
+  /// Returns an expression computing the bitwise OR (`|`) of this column with another column.
+  ///
+  /// Note that this is a bitwise operation, unlike the logical ``||(_:_:)`` operator.
+  /// - Parameter other: A ``Column`` that evaluates to an integral.
+  /// - Returns: A ``Column``.
+  public func bitwiseOR(_ other: Column) -> Column {
+    return Column.fn("|", self, other)
+  }
+
+  /// Returns an expression computing the bitwise OR (`|`) of this column with a literal value.
+  /// - Parameter other: A literal value.
+  /// - Returns: A ``Column``.
+  public func bitwiseOR(_ other: some SparkLiteral) -> Column {
+    return bitwiseOR(other.toLiteralColumn)
+  }
+
+  /// Returns an expression computing the bitwise XOR (`^`) of this column with another column.
+  /// - Parameter other: A ``Column`` that evaluates to an integral.
+  /// - Returns: A ``Column``.
+  public func bitwiseXOR(_ other: Column) -> Column {
+    return Column.fn("^", self, other)
+  }
+
+  /// Returns an expression computing the bitwise XOR (`^`) of this column with a literal value.
+  /// - Parameter other: A literal value.
+  /// - Returns: A ``Column``.
+  public func bitwiseXOR(_ other: some SparkLiteral) -> Column {
+    return bitwiseXOR(other.toLiteralColumn)
+  }
+
   /// Whether this is a `CASE WHEN` expression without an `otherwise` value yet. A `when`
   /// expression holds interleaved (condition, value) argument pairs, so an odd number of
   /// arguments means `otherwise` is already applied.

--- a/Sources/SparkConnect/MathFunctions.swift
+++ b/Sources/SparkConnect/MathFunctions.swift
@@ -428,33 +428,6 @@ public func sec(_ col: Column) -> Column {
   return fn("sec", col)
 }
 
-/// Shifts the given value `numBits` left.
-/// - Parameters:
-///   - col: A ``Column``.
-///   - numBits: The number of bits to shift.
-/// - Returns: A ``Column``.
-public func shiftleft(_ col: Column, _ numBits: Int32) -> Column {
-  return fn("shiftleft", col, lit(numBits))
-}
-
-/// (Signed) shifts the given value `numBits` right.
-/// - Parameters:
-///   - col: A ``Column``.
-///   - numBits: The number of bits to shift.
-/// - Returns: A ``Column``.
-public func shiftright(_ col: Column, _ numBits: Int32) -> Column {
-  return fn("shiftright", col, lit(numBits))
-}
-
-/// (Unsigned) shifts the given value `numBits` right.
-/// - Parameters:
-///   - col: A ``Column``.
-///   - numBits: The number of bits to shift.
-/// - Returns: A ``Column``.
-public func shiftrightunsigned(_ col: Column, _ numBits: Int32) -> Column {
-  return fn("shiftrightunsigned", col, lit(numBits))
-}
-
 /// Computes the signum of the given value.
 /// - Parameter col: A ``Column``.
 /// - Returns: A ``Column``.

--- a/Tests/SparkConnectTests/BitwiseFunctionsTests.swift
+++ b/Tests/SparkConnectTests/BitwiseFunctionsTests.swift
@@ -1,0 +1,128 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `BitwiseFunctions`
+@Suite(.serialized)
+struct BitwiseFunctionsTests {
+
+  @Test
+  func bitwiseFunctions() throws {
+    for (column, name) in [
+      (bit_count(col("a")), "bit_count"),
+      (bitwise_not(col("a")), "~"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  @Test
+  func bitwiseFunctionArguments() throws {
+    for (column, name) in [
+      (bit_get(col("a"), col("b")), "bit_get"),
+      (getbit(col("a"), col("b")), "getbit"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "b")
+    }
+
+    for (column, name, numBits) in [
+      (shiftleft(col("a"), 1), "shiftleft", Int32(1)),
+      (shiftright(col("a"), 1), "shiftright", Int32(1)),
+      (shiftrightunsigned(col("a"), 1), "shiftrightunsigned", Int32(1)),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[1].literal.integer == numBits)
+    }
+  }
+
+  @Test
+  func bitwiseColumnMethods() throws {
+    for (column, name) in [
+      (col("a").bitwiseAND(col("b")), "&"),
+      (col("a").bitwiseOR(col("b")), "|"),
+      (col("a").bitwiseXOR(col("b")), "^"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "b")
+    }
+
+    for (column, name) in [
+      (col("a").bitwiseAND(1), "&"),
+      (col("a").bitwiseOR(1), "|"),
+      (col("a").bitwiseXOR(1), "^"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[1].literal.long == 1)
+    }
+  }
+
+  @Test
+  func selectBitwiseFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let rows = try await df.select(
+      bit_count(lit(7)), bit_count(lit(0)),
+      bit_get(lit(5), lit(0)), bit_get(lit(5), lit(1)),
+      getbit(lit(5), lit(2)), bitwise_not(lit(0))
+    ).collect()
+    #expect(rows == [Row(3, 0, 1, 0, 1, -1)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectShiftFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let rows = try await df.select(
+      shiftleft(lit(1), 3), shiftright(lit(8), 2), shiftrightunsigned(lit(8), 2)
+    ).collect()
+    #expect(rows == [Row(8, 2, 2)])
+    await spark.stop()
+  }
+
+  @Test
+  func selectBitwiseColumnMethods() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let rows = try await df.select(
+      lit(170).bitwiseAND(lit(75)), lit(170).bitwiseOR(lit(75)), lit(170).bitwiseXOR(lit(75))
+    ).collect()
+    #expect(rows == [Row(10, 235, 225)])
+
+    let literals = try await df.select(
+      lit(170).bitwiseAND(75), lit(170).bitwiseOR(75), lit(170).bitwiseXOR(75)
+    ).collect()
+    #expect(literals == [Row(10, 235, 225)])
+    await spark.stop()
+  }
+}

--- a/Tests/SparkConnectTests/MathFunctionsTests.swift
+++ b/Tests/SparkConnectTests/MathFunctionsTests.swift
@@ -104,9 +104,6 @@ struct MathFunctionsTests {
     for (column, name, scale) in [
       (round(col("a"), 2), "round", Int32(2)),
       (bround(col("a"), 2), "bround", Int32(2)),
-      (shiftleft(col("a"), 1), "shiftleft", Int32(1)),
-      (shiftright(col("a"), 1), "shiftright", Int32(1)),
-      (shiftrightunsigned(col("a"), 1), "shiftrightunsigned", Int32(1)),
     ] {
       let expr = column.expr
       #expect(expr.unresolvedFunction.functionName == name)
@@ -223,10 +220,9 @@ struct MathFunctionsTests {
     let spark = try await SparkSession.builder.getOrCreate()
     let df = try await spark.range(1)
     let rows = try await df.select(
-      bin(lit(5)), hex(lit(255)), conv(lit("100"), 2, 10),
-      shiftleft(lit(1), 3), shiftright(lit(8), 2), shiftrightunsigned(lit(8), 2)
+      bin(lit(5)), hex(lit(255)), conv(lit("100"), 2, 10)
     ).collect()
-    #expect(rows == [Row("101", "FF", "4", 8, 2, 2)])
+    #expect(rows == [Row("101", "FF", "4")])
     await spark.stop()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support bitwise functions in the Swift Spark Connect client by
adding a new `BitwiseFunctions.swift` source file:

| Function | Since | Notes |
| --- | --- | --- |
| `bit_count(col)` | 3.5.0 | Number of set bits, as an unsigned 64-bit integer |
| `bit_get(col, pos)` | 3.5.0 | Bit (0 or 1) at `pos`, numbered from right to left |
| `getbit(col, pos)` | 3.5.0 | Alias of `bit_get` |
| `bitwise_not(col)` | 3.2.0 | Bitwise `NOT` of the input |

In addition, `Column` gains the three bitwise methods that PySpark and Spark SQL
expose: `bitwiseAND`, `bitwiseOR`, and `bitwiseXOR`, each with a `Column` and a
literal overload.

The existing `shiftleft`, `shiftright`, and `shiftrightunsigned` functions are
moved from `MathFunctions.swift` into the new file, so that `BitwiseFunctions.swift`
holds exactly the seven functions of the upstream "Bitwise Functions" documentation
group, in the same order. This follows the per-category layout established by
`HashFunctions.swift`, `PredicateFunctions.swift`, `MiscFunctions.swift`, and
`ConditionalFunctions.swift`.

Note that `bitwise_not` sends `~` as the unresolved function name, matching
`FunctionRegistry` (`expression[BitwiseNot]("~")`), `sql/api` `functions.scala`
(`Column.fn("~", e)`), and the Python Spark Connect client
(`_invoke_function_over_columns("~", col)`). The name `bitwise_not` is not
registered on the server side.

The deprecated camelCase alias `bitwiseNOT` is intentionally not added.

### Why are the changes needed?

To improve API coverage and feature parity with PySpark and Spark SQL. These
bitwise functions were entirely missing from the Swift client, as were the
`Column` bitwise methods. Grouping them with the shift functions keeps the whole
upstream bitwise category in a single file.

### Does this PR introduce _any_ user-facing change?

No, this is an additive change that introduces new APIs. The relocated
`shiftleft`, `shiftright`, and `shiftrightunsigned` functions keep their
signatures and remain part of the same `SparkConnect` module, so existing code
is unaffected.

```swift
let df = try await spark.range(1)
try await df.select(bit_count(lit(7)), bit_get(lit(5), lit(0))).show()
try await df.select(lit(170).bitwiseAND(lit(75))).show()
```

`Column` exposes these as named methods rather than overloading Swift's `&`,
`|`, and `^` operators. Both PySpark and Spark SQL use named methods, and in
PySpark `&` and `|` on a `Column` are *logical* operators, so overloading them
as bitwise operators in Swift would give the same syntax the opposite meaning.

### How was this patch tested?

Pass the CIs with the newly added `BitwiseFunctionsTests` suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5
