### PR TITLE
[SPARK-59217] Support interval and timestamp constructor functions

### DIFF
--- a/Sources/SparkConnect/DateTimeFunctions.swift
+++ b/Sources/SparkConnect/DateTimeFunctions.swift
@@ -316,6 +316,38 @@ public func make_date(_ year: Column, _ month: Column, _ day: Column) -> Column 
   return fn("make_date", year, month, day)
 }
 
+/// Creates a `DayTimeIntervalType` duration from `days`, `hours`, `mins` and `secs` fields. Each
+/// field is optional and defaults to zero.
+/// - Parameters:
+///   - days: The number of days, positive or negative.
+///   - hours: The number of hours, positive or negative.
+///   - mins: The number of minutes, positive or negative.
+///   - secs: The number of seconds with the fractional part in microsecond precision.
+/// - Returns: A ``Column``.
+public func make_dt_interval(
+  days: Column = lit(0), hours: Column = lit(0), mins: Column = lit(0), secs: Column = lit(0)
+) -> Column {
+  return fn("make_dt_interval", days, hours, mins, secs)
+}
+
+/// Creates an interval from `years`, `months`, `weeks`, `days`, `hours`, `mins` and `secs`
+/// fields. Each field is optional and defaults to zero.
+/// - Parameters:
+///   - years: The number of years, positive or negative.
+///   - months: The number of months, positive or negative.
+///   - weeks: The number of weeks, positive or negative.
+///   - days: The number of days, positive or negative.
+///   - hours: The number of hours, positive or negative.
+///   - mins: The number of minutes, positive or negative.
+///   - secs: The number of seconds with the fractional part in microsecond precision.
+/// - Returns: A ``Column``.
+public func make_interval(
+  years: Column = lit(0), months: Column = lit(0), weeks: Column = lit(0),
+  days: Column = lit(0), hours: Column = lit(0), mins: Column = lit(0), secs: Column = lit(0)
+) -> Column {
+  return fn("make_interval", years, months, weeks, days, hours, mins, secs)
+}
+
 /// Creates a time from `hour`, `minute` and `second` fields.
 /// - Parameters:
 ///   - hour: An hour ``Column``, from 0 to 23.
@@ -324,6 +356,104 @@ public func make_date(_ year: Column, _ month: Column, _ day: Column) -> Column 
 /// - Returns: A ``Column``.
 public func make_time(_ hour: Column, _ minute: Column, _ second: Column) -> Column {
   return fn("make_time", hour, minute, second)
+}
+
+/// Creates a timestamp from `years`, `months`, `days`, `hours`, `mins` and `secs` fields. The
+/// result data type is consistent with the value of the `spark.sql.timestampType` configuration.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func make_timestamp(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("make_timestamp", years, months, days, hours, mins, secs)
+}
+
+/// Creates a timestamp from `years`, `months`, `days`, `hours`, `mins`, `secs` and `timezone`
+/// fields. The result data type is consistent with the value of the `spark.sql.timestampType`
+/// configuration.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+///   - timezone: A time zone identifier ``Column``.
+/// - Returns: A ``Column``.
+public func make_timestamp(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column, _ timezone: Column
+) -> Column {
+  return fn("make_timestamp", years, months, days, hours, mins, secs, timezone)
+}
+
+/// Creates a timestamp with local time zone from `years`, `months`, `days`, `hours`, `mins` and
+/// `secs` fields.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func make_timestamp_ltz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("make_timestamp_ltz", years, months, days, hours, mins, secs)
+}
+
+/// Creates a timestamp with local time zone from `years`, `months`, `days`, `hours`, `mins`,
+/// `secs` and `timezone` fields.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+///   - timezone: A time zone identifier ``Column``.
+/// - Returns: A ``Column``.
+public func make_timestamp_ltz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column, _ timezone: Column
+) -> Column {
+  return fn("make_timestamp_ltz", years, months, days, hours, mins, secs, timezone)
+}
+
+/// Creates a timestamp without time zone from `years`, `months`, `days`, `hours`, `mins` and
+/// `secs` fields.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func make_timestamp_ntz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("make_timestamp_ntz", years, months, days, hours, mins, secs)
+}
+
+/// Creates a `YearMonthIntervalType` duration from `years` and `months` fields. Each field is
+/// optional and defaults to zero.
+/// - Parameters:
+///   - years: The number of years, positive or negative.
+///   - months: The number of months, positive or negative.
+/// - Returns: A ``Column``.
+public func make_ym_interval(years: Column = lit(0), months: Column = lit(0)) -> Column {
+  return fn("make_ym_interval", years, months)
 }
 
 /// Extracts the minutes as an integer from a given date/timestamp/string.
@@ -680,6 +810,112 @@ public func to_utc_timestamp(_ ts: Column, _ tz: Column) -> Column {
 /// - Returns: A ``Column``.
 public func trunc(_ date: Column, _ format: String) -> Column {
   return fn("trunc", date, lit(format))
+}
+
+/// This is a special version of ``make_interval(years:months:weeks:days:hours:mins:secs:)`` that
+/// returns `NULL` instead of raising an error if the interval cannot be created. Each field is
+/// optional and defaults to zero.
+/// - Parameters:
+///   - years: The number of years, positive or negative.
+///   - months: The number of months, positive or negative.
+///   - weeks: The number of weeks, positive or negative.
+///   - days: The number of days, positive or negative.
+///   - hours: The number of hours, positive or negative.
+///   - mins: The number of minutes, positive or negative.
+///   - secs: The number of seconds with the fractional part in microsecond precision.
+/// - Returns: A ``Column``.
+public func try_make_interval(
+  years: Column = lit(0), months: Column = lit(0), weeks: Column = lit(0),
+  days: Column = lit(0), hours: Column = lit(0), mins: Column = lit(0), secs: Column = lit(0)
+) -> Column {
+  return fn("try_make_interval", years, months, weeks, days, hours, mins, secs)
+}
+
+/// Creates a timestamp from `years`, `months`, `days`, `hours`, `mins` and `secs` fields, and
+/// returns `NULL` on invalid inputs.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func try_make_timestamp(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("try_make_timestamp", years, months, days, hours, mins, secs)
+}
+
+/// Creates a timestamp from `years`, `months`, `days`, `hours`, `mins`, `secs` and `timezone`
+/// fields, and returns `NULL` on invalid inputs.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+///   - timezone: A time zone identifier ``Column``.
+/// - Returns: A ``Column``.
+public func try_make_timestamp(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column, _ timezone: Column
+) -> Column {
+  return fn("try_make_timestamp", years, months, days, hours, mins, secs, timezone)
+}
+
+/// Creates a timestamp with local time zone from `years`, `months`, `days`, `hours`, `mins` and
+/// `secs` fields, and returns `NULL` on invalid inputs.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func try_make_timestamp_ltz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("try_make_timestamp_ltz", years, months, days, hours, mins, secs)
+}
+
+/// Creates a timestamp with local time zone from `years`, `months`, `days`, `hours`, `mins`,
+/// `secs` and `timezone` fields, and returns `NULL` on invalid inputs.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+///   - timezone: A time zone identifier ``Column``.
+/// - Returns: A ``Column``.
+public func try_make_timestamp_ltz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column, _ timezone: Column
+) -> Column {
+  return fn("try_make_timestamp_ltz", years, months, days, hours, mins, secs, timezone)
+}
+
+/// Creates a timestamp without time zone from `years`, `months`, `days`, `hours`, `mins` and
+/// `secs` fields, and returns `NULL` on invalid inputs.
+/// - Parameters:
+///   - years: A year ``Column``, from 1 to 9999.
+///   - months: A month-of-year ``Column``, from 1 to 12.
+///   - days: A day-of-month ``Column``, from 1 to 31.
+///   - hours: An hour-of-day ``Column``, from 0 to 23.
+///   - mins: A minute-of-hour ``Column``, from 0 to 59.
+///   - secs: A second-of-minute ``Column``, from 0 to 60, with microsecond precision.
+/// - Returns: A ``Column``.
+public func try_make_timestamp_ntz(
+  _ years: Column, _ months: Column, _ days: Column, _ hours: Column, _ mins: Column,
+  _ secs: Column
+) -> Column {
+  return fn("try_make_timestamp_ntz", years, months, days, hours, mins, secs)
 }
 
 /// Converts the column into `DateType` by casting rules to `DateType`. Returns null with invalid

--- a/Tests/SparkConnectTests/DateTimeFunctionsTests.swift
+++ b/Tests/SparkConnectTests/DateTimeFunctionsTests.swift
@@ -190,6 +190,60 @@ struct DateTimeFunctionsTests {
   }
 
   @Test
+  func intervalAndTimestampConstructorArguments() throws {
+    for (column, name, count) in [
+      (make_interval(), "make_interval", 7),
+      (make_interval(years: col("a")), "make_interval", 7),
+      (try_make_interval(), "try_make_interval", 7),
+      (make_dt_interval(), "make_dt_interval", 4),
+      (make_dt_interval(days: col("a")), "make_dt_interval", 4),
+      (make_ym_interval(), "make_ym_interval", 2),
+      (make_ym_interval(years: col("a")), "make_ym_interval", 2),
+      (make_timestamp(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "make_timestamp", 6),
+      (make_timestamp(col("a"), col("b"), col("c"), col("d"), col("e"), col("f"), col("g")),
+        "make_timestamp", 7),
+      (make_timestamp_ltz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "make_timestamp_ltz", 6),
+      (make_timestamp_ltz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f"), col("g")),
+        "make_timestamp_ltz", 7),
+      (make_timestamp_ntz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "make_timestamp_ntz", 6),
+      (try_make_timestamp(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "try_make_timestamp", 6),
+      (try_make_timestamp(col("a"), col("b"), col("c"), col("d"), col("e"), col("f"), col("g")),
+        "try_make_timestamp", 7),
+      (try_make_timestamp_ltz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "try_make_timestamp_ltz", 6),
+      (try_make_timestamp_ltz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f"), col("g")),
+        "try_make_timestamp_ltz", 7),
+      (try_make_timestamp_ntz(col("a"), col("b"), col("c"), col("d"), col("e"), col("f")),
+        "try_make_timestamp_ntz", 6),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+    }
+
+    // The omitted optional fields are filled with a zero literal, so the full argument list is
+    // always sent to the server.
+    let interval = make_interval(hours: col("a")).expr
+    #expect(interval.unresolvedFunction.arguments[4].unresolvedAttribute.unparsedIdentifier == "a")
+    for i in [0, 1, 2, 3, 5, 6] {
+      #expect(interval.unresolvedFunction.arguments[i].literal.long == 0)
+    }
+
+    let dtInterval = make_dt_interval(mins: col("a")).expr
+    #expect(dtInterval.unresolvedFunction.arguments[2].unresolvedAttribute.unparsedIdentifier == "a")
+    for i in [0, 1, 3] {
+      #expect(dtInterval.unresolvedFunction.arguments[i].literal.long == 0)
+    }
+
+    let ymInterval = make_ym_interval(months: col("a")).expr
+    #expect(ymInterval.unresolvedFunction.arguments[0].literal.long == 0)
+    #expect(ymInterval.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "a")
+  }
+  @Test
   func selectCurrentDateTimeFunctions() async throws {
     let spark = try await SparkSession.builder.getOrCreate()
     let rows = try await spark.range(1).select(
@@ -361,6 +415,81 @@ struct DateTimeFunctionsTests {
         ])
     }
     try await spark.conf.unset("spark.sql.timeType.enabled")
+    await spark.stop()
+  }
+
+  @Test
+  func selectIntervalConstructorFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    // Interval values are cast to `string` because the Arrow decoder does not support them.
+    let intervals = try await spark.range(1).select(
+      make_interval().cast("string"),
+      make_interval(
+        years: lit(1), months: lit(2), weeks: lit(3), days: lit(4), hours: lit(5), mins: lit(6),
+        secs: lit(7)
+      ).cast("string"),
+      make_dt_interval().cast("string"),
+      make_dt_interval(days: lit(1), hours: lit(2), mins: lit(3), secs: lit(4)).cast("string"),
+      make_ym_interval().cast("string"),
+      make_ym_interval(years: lit(1), months: lit(2)).cast("string")
+    ).collect()
+    #expect(
+      intervals == [
+        Row(
+          "0 seconds", "1 years 2 months 25 days 5 hours 6 minutes 7 seconds",
+          "INTERVAL '0 00:00:00' DAY TO SECOND", "INTERVAL '1 02:03:04' DAY TO SECOND",
+          "INTERVAL '0-0' YEAR TO MONTH", "INTERVAL '1-2' YEAR TO MONTH")
+      ])
+
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let tryIntervals = try await spark.range(1).select(
+        try_make_interval(years: lit(1), months: lit(2)).cast("string"),
+        try_make_interval(years: lit(2147483647)).cast("string")
+      ).collect()
+      #expect(tryIntervals == [Row("1 years 2 months", nil)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func selectTimestampConstructorFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    try await spark.conf.set("spark.sql.session.timeZone", "UTC")
+    let timestamps = try await spark.range(1).select(
+      make_timestamp(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string"),
+      make_timestamp(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0), lit("Asia/Seoul"))
+        .cast("string"),
+      make_timestamp_ltz(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string"),
+      make_timestamp_ltz(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0), lit("Asia/Seoul"))
+        .cast("string"),
+      make_timestamp_ntz(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string")
+    ).collect()
+    #expect(
+      timestamps == [
+        Row(
+          "2026-09-03 12:00:00", "2026-09-03 03:00:00", "2026-09-03 12:00:00",
+          "2026-09-03 03:00:00", "2026-09-03 12:00:00")
+      ])
+
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let tryTimestamps = try await spark.range(1).select(
+        try_make_timestamp(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string"),
+        try_make_timestamp_ltz(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string"),
+        try_make_timestamp_ntz(lit(2026), lit(9), lit(3), lit(12), lit(0), lit(0)).cast("string"),
+        try_make_timestamp(lit(2026), lit(13), lit(3), lit(12), lit(0), lit(0)),
+        try_make_timestamp(lit(2026), lit(13), lit(3), lit(12), lit(0), lit(0), lit("UTC")),
+        try_make_timestamp_ltz(lit(2026), lit(13), lit(3), lit(12), lit(0), lit(0)),
+        try_make_timestamp_ltz(lit(2026), lit(13), lit(3), lit(12), lit(0), lit(0), lit("UTC")),
+        try_make_timestamp_ntz(lit(2026), lit(13), lit(3), lit(12), lit(0), lit(0))
+      ).collect()
+      #expect(
+        tryTimestamps == [
+          Row(
+            "2026-09-03 12:00:00", "2026-09-03 12:00:00", "2026-09-03 12:00:00", nil, nil, nil,
+            nil, nil)
+        ])
+    }
+    try await spark.conf.unset("spark.sql.session.timeZone")
     await spark.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 10 interval and timestamp constructor functions in `DateTimeFunctions`.

| Function | Swift signature | Since |
| --- | --- | --- |
| `make_interval` | `make_interval(years:months:weeks:days:hours:mins:secs:)` | 3.5.0 |
| `make_dt_interval` | `make_dt_interval(days:hours:mins:secs:)` | 3.5.0 |
| `make_ym_interval` | `make_ym_interval(years:months:)` | 3.5.0 |
| `make_timestamp` | `make_timestamp(_:_:_:_:_:_:)` | 3.5.0 |
| `make_timestamp` | `make_timestamp(_:_:_:_:_:_:_:)` (with `timezone`) | 3.5.0 |
| `make_timestamp_ltz` | `make_timestamp_ltz(_:_:_:_:_:_:)` | 3.5.0 |
| `make_timestamp_ltz` | `make_timestamp_ltz(_:_:_:_:_:_:_:)` (with `timezone`) | 3.5.0 |
| `make_timestamp_ntz` | `make_timestamp_ntz(_:_:_:_:_:_:)` | 3.5.0 |
| `try_make_interval` | `try_make_interval(years:months:weeks:days:hours:mins:secs:)` | 4.0.0 |
| `try_make_timestamp` | `try_make_timestamp(_:_:_:_:_:_:)` | 4.0.0 |
| `try_make_timestamp` | `try_make_timestamp(_:_:_:_:_:_:_:)` (with `timezone`) | 4.0.0 |
| `try_make_timestamp_ltz` | `try_make_timestamp_ltz(_:_:_:_:_:_:)` | 4.0.0 |
| `try_make_timestamp_ltz` | `try_make_timestamp_ltz(_:_:_:_:_:_:_:)` (with `timezone`) | 4.0.0 |
| `try_make_timestamp_ntz` | `try_make_timestamp_ntz(_:_:_:_:_:_:)` | 4.0.0 |

The `try_*` variants return `NULL` instead of raising an error when the value
cannot be created.

**On optional arguments.** The interval constructors have *only* optional fields
(7 for `make_interval`, 4 for `make_dt_interval`, 2 for `make_ym_interval`), so
they are declared with Swift default argument values instead of arity overloads:

```swift
public func make_interval(
  years: Column = lit(0), months: Column = lit(0), weeks: Column = lit(0),
  days: Column = lit(0), hours: Column = lit(0), mins: Column = lit(0), secs: Column = lit(0)
) -> Column
```

Modeling these as Scala-style prefix overloads would need 8 declarations for
`make_interval` alone (16 with `try_make_interval`) and still could not express a
call that sets only `hours`. For that reason, and unlike the rest of this
codebase, the interval constructors keep their argument labels: without labels,
default values could only be dropped from the tail, which defeats the purpose.
The labels also match how these functions are called in PySpark
(`make_interval(hours=...)`).

Following the PySpark implementation, omitted fields are filled with a zero
literal, so the full argument list is always sent to the server, e.g.
`make_interval(hours: col("h"))` sends `make_interval(0, 0, 0, 0, h, 0, 0)`.
PySpark uses `lit(decimal.Decimal(0))` for `secs`; a `long` zero is implicitly
coerced to `DECIMAL(18,6)` by the server, so no new `lit` overload is required.

The timestamp constructors take six required fields, so they follow the existing
convention of unlabeled arguments used by `make_date` and `make_time`. Their
optional `timezone` field is expressed as an overload pair, matching the existing
`to_timestamp_ltz`/`to_timestamp_ntz` precedent.

### Why are the changes needed?

For feature parity with Apache Spark's Scala and Python clients. These are the
only remaining `make_*` datetime constructors missing from this client;
`make_date` and `make_time` are already supported.

### Does this PR introduce _any_ user-facing change?

No, this only adds new functions.

### How was this patch tested?

Pass the CIs with newly added test cases in `DateTimeFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5
