### PR TITLE
[SPARK-59222] Support XML functions

### DIFF
--- a/Sources/SparkConnect/XmlFunctions.swift
+++ b/Sources/SparkConnect/XmlFunctions.swift
@@ -1,0 +1,187 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - XML functions
+
+/// Parses a column containing an XML string into a struct with the given schema.
+/// Returns `NULL`, in the case of an unparseable string.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an XML string.
+///   - schema: A DDL schema string, e.g. `a INT, b STRING`.
+///   - options: Options to control how the XML is parsed. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` of the type given by the schema.
+public func from_xml(
+  _ col: Column, _ schema: String, _ options: [String: String] = [:]
+) -> Column {
+  return fn("from_xml", options: options, col, lit(schema))
+}
+
+/// Parses a column containing an XML string into a struct with the given schema.
+/// Returns `NULL`, in the case of an unparseable string.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an XML string.
+///   - schema: A ``StructType`` schema.
+///   - options: Options to control how the XML is parsed. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` of the type given by the schema.
+public func from_xml(
+  _ col: Column, _ schema: StructType, _ options: [String: String] = [:]
+) -> Column {
+  return from_xml(col, schema.toDDL, options)
+}
+
+/// Parses a column containing an XML string into a struct with the given schema.
+/// Returns `NULL`, in the case of an unparseable string.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an XML string.
+///   - schema: A ``Column`` that evaluates to a constant schema string,
+///     e.g. a `schema_of_xml` result.
+///   - options: Options to control how the XML is parsed. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` of the type given by the schema.
+public func from_xml(
+  _ col: Column, _ schema: Column, _ options: [String: String] = [:]
+) -> Column {
+  return fn("from_xml", options: options, col, schema)
+}
+
+/// Parses an XML string and infers its schema in DDL format.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - xml: An XML string.
+///   - options: Options to control how the XML is parsed. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` that evaluates to a schema string in DDL format.
+public func schema_of_xml(_ xml: String, _ options: [String: String] = [:]) -> Column {
+  return schema_of_xml(lit(xml), options)
+}
+
+/// Parses an XML string and infers its schema in DDL format.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to a constant XML string.
+///   - options: Options to control how the XML is parsed. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` that evaluates to a schema string in DDL format.
+public func schema_of_xml(_ xml: Column, _ options: [String: String] = [:]) -> Column {
+  return fn("schema_of_xml", options: options, xml)
+}
+
+/// Converts a column containing a struct into an XML string.
+/// Throws an exception, in the case of an unsupported type.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a struct.
+///   - options: Options to control how the column is converted. It accepts the same options as
+///     the XML data source.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func to_xml(_ col: Column, _ options: [String: String] = [:]) -> Column {
+  return fn("to_xml", options: options, col)
+}
+
+/// Returns a string array of values within the nodes of `xml` that match the XPath expression.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to an array of strings.
+public func xpath(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath", xml, path)
+}
+
+/// Returns `true` if the XPath expression evaluates to `true`, or if a matching node is found.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a boolean.
+public func xpath_boolean(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_boolean", xml, path)
+}
+
+/// Returns a double value, the value zero if no match is found, or `NaN` if a match is found
+/// but the value is non-numeric.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func xpath_double(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_double", xml, path)
+}
+
+/// Returns a float value, the value zero if no match is found, or `NaN` if a match is found
+/// but the value is non-numeric.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func xpath_float(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_float", xml, path)
+}
+
+/// Returns an integer value, the value zero if no match is found, or a match is found but the
+/// value is non-numeric.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to an integer.
+public func xpath_int(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_int", xml, path)
+}
+
+/// Returns a long integer value, the value zero if no match is found, or a match is found but
+/// the value is non-numeric.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func xpath_long(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_long", xml, path)
+}
+
+/// Returns a double value, the value zero if no match is found, or `NaN` if a match is found
+/// but the value is non-numeric. This is an alias of ``xpath_double(_:_:)``.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func xpath_number(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_number", xml, path)
+}
+
+/// Returns a short integer value, the value zero if no match is found, or a match is found but
+/// the value is non-numeric.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a short.
+public func xpath_short(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_short", xml, path)
+}
+
+/// Returns the text contents of the first XML node that matches the XPath expression.
+/// - Parameters:
+///   - xml: A ``Column`` that evaluates to an XML string.
+///   - path: A ``Column`` that evaluates to a constant XPath expression.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func xpath_string(_ xml: Column, _ path: Column) -> Column {
+  return fn("xpath_string", xml, path)
+}

--- a/Tests/SparkConnectTests/XmlFunctionsTests.swift
+++ b/Tests/SparkConnectTests/XmlFunctionsTests.swift
@@ -1,0 +1,170 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `XmlFunctions`
+@Suite(.serialized)
+struct XmlFunctionsTests {
+
+  @Test
+  func xmlFunctions() throws {
+    for (column, name) in [
+      (to_xml(col("a")), "to_xml"),
+      (schema_of_xml(col("a")), "schema_of_xml"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 1)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+
+    let schemaOfXml = schema_of_xml("<p><a>1</a></p>").expr
+    #expect(schemaOfXml.unresolvedFunction.functionName == "schema_of_xml")
+    #expect(schemaOfXml.unresolvedFunction.arguments[0].literal.string == "<p><a>1</a></p>")
+  }
+
+  @Test
+  func xpathFunctions() throws {
+    for (column, name) in [
+      (xpath(col("a"), col("b")), "xpath"),
+      (xpath_boolean(col("a"), col("b")), "xpath_boolean"),
+      (xpath_double(col("a"), col("b")), "xpath_double"),
+      (xpath_float(col("a"), col("b")), "xpath_float"),
+      (xpath_int(col("a"), col("b")), "xpath_int"),
+      (xpath_long(col("a"), col("b")), "xpath_long"),
+      (xpath_number(col("a"), col("b")), "xpath_number"),
+      (xpath_short(col("a"), col("b")), "xpath_short"),
+      (xpath_string(col("a"), col("b")), "xpath_string"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "b")
+    }
+  }
+
+  @Test
+  func fromXmlSchema() throws {
+    let ddl = from_xml(col("a"), "b INT").expr
+    #expect(ddl.unresolvedFunction.functionName == "from_xml")
+    #expect(ddl.unresolvedFunction.arguments.count == 2)
+    #expect(ddl.unresolvedFunction.arguments[1].literal.string == "b INT")
+
+    let schema = StructType(fields: [StructField(name: "b", dataType: .integer)])
+    #expect(from_xml(col("a"), schema).expr == ddl)
+
+    let column = from_xml(col("a"), schema_of_xml("<p><b>1</b></p>")).expr
+    #expect(column.unresolvedFunction.functionName == "from_xml")
+    let inferred = column.unresolvedFunction.arguments[1].unresolvedFunction
+    #expect(inferred.functionName == "schema_of_xml")
+  }
+
+  /// Options are appended as a single `map` argument like Spark SQL's `Column.fnWithOptions`.
+  @Test
+  func options() throws {
+    #expect(to_xml(col("a"), [:]).expr == to_xml(col("a")).expr)
+
+    let expr = from_xml(col("a"), "b INT", ["rowTag": "item", "mode": "FAILFAST"]).expr
+    #expect(expr.unresolvedFunction.functionName == "from_xml")
+    #expect(expr.unresolvedFunction.arguments.count == 3)
+    let options = expr.unresolvedFunction.arguments[2].unresolvedFunction
+    #expect(options.functionName == "map")
+    #expect(options.arguments.map { $0.literal.string } == ["mode", "FAILFAST", "rowTag", "item"])
+  }
+
+  @Test
+  func roundTrip() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      let df = try await spark.sql("SELECT 1 AS id, 'a' AS name")
+      let schema = "id INT, name STRING"
+      let parsed = from_xml(to_xml(`struct`(col("id"), col("name"))), schema).alias("parsed")
+      let rows = try await df.select(parsed).selectExpr("parsed.id", "parsed.name").collect()
+      #expect(rows == [Row(Int32(1), "a")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func schemaOfXml() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      let rows = try await spark.range(1).select(
+        schema_of_xml("<p><a>1</a><b>x</b></p>"),
+        schema_of_xml(lit("<p><a>1</a></p>"), ["rowTag": "p"])
+      ).collect()
+      #expect(rows == [Row("STRUCT<a: BIGINT, b: STRING>", "STRUCT<a: BIGINT>")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func xmlWithOptions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0.0") {
+      let df = try await spark.sql("SELECT 1 AS id")
+      let rows = try await df.select(
+        to_xml(`struct`(col("id")), ["rowTag": "item"]),
+        from_xml(lit("<item><id>1</id></item>"), "id INT", ["rowTag": "item"]).alias("parsed")
+      ).selectExpr("*", "parsed.id").collect()
+      #expect(try rows[0].get(0) as! String == "<item>\n    <id>1</id>\n</item>")
+      #expect(try rows[0].get(2) as! Int32 == 1)
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func xpathArray() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let rows = try await spark.range(1)
+      .select(xpath(lit("<a><b>b1</b><b>b2</b></a>"), lit("a/b/text()"))).collect()
+    #expect(try rows[0].get(0) as! [String] == ["b1", "b2"])
+    await spark.stop()
+  }
+
+  @Test
+  func xpathScalars() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let xml = lit("<a><b>2</b></a>")
+    let path = lit("a/b")
+    let rows = try await spark.range(1).select(
+      xpath_string(xml, path),
+      xpath_boolean(xml, path),
+      xpath_short(xml, path),
+      xpath_int(xml, path),
+      xpath_long(xml, path),
+      xpath_float(xml, path),
+      xpath_double(xml, path),
+      xpath_number(xml, path)
+    ).collect()
+    #expect(try rows[0].get(0) as! String == "2")
+    #expect(try rows[0].get(1) as! Bool == true)
+    #expect(try rows[0].get(2) as! Int16 == 2)
+    #expect(try rows[0].get(3) as! Int32 == 2)
+    #expect(try rows[0].get(4) as! Int64 == 2)
+    #expect(try rows[0].get(5) as! Float == 2.0)
+    #expect(try rows[0].get(6) as! Double == 2.0)
+    #expect(try rows[0].get(7) as! Double == 2.0)
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the following 12 XML functions in a new file, `XmlFunctions.swift`.

**Conversion functions**

| Function | Overloads added | Since |
| -------- | --------------- | ----- |
| `from_xml` | `schema: String` (DDL), `schema: StructType`, `schema: Column` | 4.0.0 |
| `to_xml` | | 4.0.0 |
| `schema_of_xml` | `xml: String`, `xml: Column` | 4.0.0 |

**XPath functions**

| Function | Result type | Since |
| -------- | ----------- | ----- |
| `xpath` | `ARRAY<STRING>` | 3.5.0 |
| `xpath_boolean` | `BOOLEAN` | 3.5.0 |
| `xpath_double`, `xpath_number` | `DOUBLE` | 3.5.0 |
| `xpath_float` | `FLOAT` | 3.5.0 |
| `xpath_short`, `xpath_int`, `xpath_long` | `SMALLINT`, `INT`, `BIGINT` | 3.5.0 |
| `xpath_string` | `STRING` | 3.5.0 |

Like the JSON and CSV functions added by SPARK-59216, `from_xml`, `to_xml` and
`schema_of_xml` take an option map which Apache Spark encodes as a plain trailing
`map(k1, v1, ...)` argument, so this PR reuses the existing internal
`fn(_ name:options:_ args:)` helper. When there is no option, no extra argument is
appended at all.

For the `schema` argument, `from_xml` follows the upstream signature
(`sql/api/src/main/scala/org/apache/spark/sql/functions.scala`) which accepts a
`StructType`, a DDL `String`, or a `Column` such as a `schema_of_xml` result. Unlike
`from_json`, XML has no `MapType`/`ArrayType` form in the upstream API. The `StructType`
overload delegates to the DDL string form via `StructType.toDDL`; the server resolves it
through `ExprUtils.evalSchemaExpr` / `DataType.fromDDL`.

The `path` argument of the XPath functions is a `Column`, matching
`def xpath(xml: Column, path: Column)` upstream. Callers pass a literal with
`lit("a/b/text()")`. This mirrors the existing `get_json_object(_ col: Column, _ path: String)`
precedent, which takes a `String` only because the upstream `get_json_object` does.

### Why are the changes needed?

To improve the API coverage of the Swift Spark Connect client. Currently, no XML function
is supported, so Swift users cannot parse, produce, or query XML strings inside a `Column`
expression without falling back to `selectExpr`. Note that `DataFrameReader.xml` and
`DataFrameWriter.xml` are already supported; this PR adds the column-level counterparts.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature which adds 12 new functions.

```swift
let df = try await spark.sql("SELECT 1 AS id, 'a' AS name")
let parsed = from_xml(to_xml(`struct`(col("id"), col("name"))), "id INT, name STRING")
try await df.select(parsed.alias("parsed")).selectExpr("parsed.id", "parsed.name").show()

try await spark.range(1).select(schema_of_xml("<p><a>1</a><b>x</b></p>")).show()
// STRUCT<a: BIGINT, b: STRING>

try await spark.range(1).select(
  xpath(lit("<a><b>b1</b><b>b2</b></a>"), lit("a/b/text()"))
).show()
// [b1, b2]
```

### How was this patch tested?

Pass the CIs with the newly added test suite, `XmlFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5