### PR TITLE
[SPARK-59223] Support VARIANT functions

### DIFF
--- a/Sources/SparkConnect/AggregateFunctions.swift
+++ b/Sources/SparkConnect/AggregateFunctions.swift
@@ -553,6 +553,13 @@ public func regr_syy(_ y: Column, _ x: Column) -> Column {
   return fn("regr_syy", y, x)
 }
 
+/// Returns the merged schema in DDL format of all `VARIANT` values in a group.
+/// - Parameter v: A ``Column`` of the `VARIANT` type to aggregate.
+/// - Returns: A ``Column`` that evaluates to a schema string in DDL format.
+public func schema_of_variant_agg(_ v: Column) -> Column {
+  return fn("schema_of_variant_agg", v)
+}
+
 /// Returns the skewness of the values in a group.
 /// - Parameter col: A ``Column`` to aggregate.
 /// - Returns: A ``Column``.

--- a/Sources/SparkConnect/VariantFunctions.swift
+++ b/Sources/SparkConnect/VariantFunctions.swift
@@ -1,0 +1,327 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - VARIANT functions
+
+/// Parses a JSON string and constructs a `VARIANT` value.
+/// Throws an exception, in the case of an invalid JSON string.
+/// - Parameter json: A ``Column`` that evaluates to a string containing JSON data.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func parse_json(_ json: Column) -> Column {
+  return fn("parse_json", json)
+}
+
+/// Parses a JSON string and constructs a `VARIANT` value.
+/// Returns `NULL`, in the case of an invalid JSON string.
+/// - Parameter json: A ``Column`` that evaluates to a string containing JSON data.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_parse_json(_ json: Column) -> Column {
+  return fn("try_parse_json", json)
+}
+
+/// Converts a column containing nested inputs, i.e. an array, a map, or a struct, into a `VARIANT`
+/// where maps and structs are converted to `VARIANT` objects which are unordered unlike SQL
+/// structs. Input maps can only have string keys.
+/// - Parameter col: A ``Column`` that evaluates to an array, a map, a struct, or a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func to_variant_object(_ col: Column) -> Column {
+  return fn("to_variant_object", col)
+}
+
+/// Checks if a `VARIANT` value is a `VARIANT` null. Returns `true` if and only if the input is a
+/// `VARIANT` null and `false` otherwise, including in the case of a SQL `NULL`.
+/// - Parameter v: A ``Column`` that evaluates to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a boolean.
+public func is_variant_null(_ v: Column) -> Column {
+  return fn("is_variant_null", v)
+}
+
+/// Checks if a `VARIANT` value is valid. Returns `true` if the `VARIANT` is valid, `false` if it
+/// is malformed, and `NULL` if the input is `NULL`.
+/// - Parameter v: A ``Column`` that evaluates to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a boolean.
+public func is_valid_variant(_ v: Column) -> Column {
+  return fn("is_valid_variant", v)
+}
+
+/// Extracts a sub-`VARIANT` from `v` according to `path`, and then casts the sub-`VARIANT` to
+/// `targetType`. Returns `NULL` if the path does not exist.
+/// Throws an exception, if the cast fails.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: An extraction path. A valid path starts with `$` and is followed by zero or more
+///     segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - targetType: The target data type to cast into, in a DDL-formatted string.
+/// - Returns: A ``Column`` of the type specified by `targetType`.
+public func variant_get(_ v: Column, _ path: String, _ targetType: String) -> Column {
+  return variant_get(v, lit(path), targetType)
+}
+
+/// Extracts a sub-`VARIANT` from `v` according to `path`, and then casts the sub-`VARIANT` to
+/// `targetType`. Returns `NULL` if the path does not exist.
+/// Throws an exception, if the cast fails.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to an extraction path. A valid path starts with `$` and
+///     is followed by zero or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - targetType: The target data type to cast into, in a DDL-formatted string.
+/// - Returns: A ``Column`` of the type specified by `targetType`.
+public func variant_get(_ v: Column, _ path: Column, _ targetType: String) -> Column {
+  return fn("variant_get", v, path, lit(targetType))
+}
+
+/// Extracts a sub-`VARIANT` from `v` according to `path`, and then casts the sub-`VARIANT` to
+/// `targetType`. Returns `NULL` if the path does not exist or the cast fails.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: An extraction path. A valid path starts with `$` and is followed by zero or more
+///     segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - targetType: The target data type to cast into, in a DDL-formatted string.
+/// - Returns: A ``Column`` of the type specified by `targetType`.
+public func try_variant_get(_ v: Column, _ path: String, _ targetType: String) -> Column {
+  return try_variant_get(v, lit(path), targetType)
+}
+
+/// Extracts a sub-`VARIANT` from `v` according to `path`, and then casts the sub-`VARIANT` to
+/// `targetType`. Returns `NULL` if the path does not exist or the cast fails.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to an extraction path. A valid path starts with `$` and
+///     is followed by zero or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - targetType: The target data type to cast into, in a DDL-formatted string.
+/// - Returns: A ``Column`` of the type specified by `targetType`.
+public func try_variant_get(_ v: Column, _ path: Column, _ targetType: String) -> Column {
+  return fn("try_variant_get", v, path, lit(targetType))
+}
+
+/// Returns the schema of a `VARIANT` in the SQL format.
+/// - Parameter v: A ``Column`` that evaluates to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func schema_of_variant(_ v: Column) -> Column {
+  return fn("schema_of_variant", v)
+}
+
+/// Inserts a value into a `VARIANT` at the given `JSONPath` location. An object path adds a new
+/// field; an array path inserts at the index, shifting later elements right. Missing intermediate
+/// keys are created. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if the field already exists or a path segment hits a value of an
+/// incompatible type.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the insertion target. A valid path starts with `$`
+///     and is followed by one or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///     The root path `$` is not allowed.
+///   - value: The value to insert. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_insert(_ v: Column, _ path: String, _ value: Column) -> Column {
+  return variant_insert(v, lit(path), value)
+}
+
+/// Inserts a value into a `VARIANT` at the given `JSONPath` location. An object path adds a new
+/// field; an array path inserts at the index, shifting later elements right. Missing intermediate
+/// keys are created. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if the field already exists or a path segment hits a value of an
+/// incompatible type.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the insertion target.
+///     A valid path starts with `$` and is followed by one or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`. The root path `$` is not allowed.
+///   - value: The value to insert. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_insert(_ v: Column, _ path: Column, _ value: Column) -> Column {
+  return fn("variant_insert", v, path, value)
+}
+
+/// Inserts a value into a `VARIANT` at the given `JSONPath` location. An object path adds a new
+/// field; an array path inserts at the index, shifting later elements right. Missing intermediate
+/// keys are created. Returns `NULL` if the field already exists, a path segment hits a value of
+/// an incompatible type, or any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the insertion target. A valid path starts with `$`
+///     and is followed by one or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///     The root path `$` is not allowed.
+///   - value: The value to insert. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_insert(_ v: Column, _ path: String, _ value: Column) -> Column {
+  return try_variant_insert(v, lit(path), value)
+}
+
+/// Inserts a value into a `VARIANT` at the given `JSONPath` location. An object path adds a new
+/// field; an array path inserts at the index, shifting later elements right. Missing intermediate
+/// keys are created. Returns `NULL` if the field already exists, a path segment hits a value of
+/// an incompatible type, or any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the insertion target.
+///     A valid path starts with `$` and is followed by one or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`. The root path `$` is not allowed.
+///   - value: The value to insert. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_insert(_ v: Column, _ path: Column, _ value: Column) -> Column {
+  return fn("try_variant_insert", v, path, value)
+}
+
+/// Sets or upserts a value in a `VARIANT` at the given `JSONPath` location. An existing object
+/// field or array element at the target is replaced. A missing field, array index, or
+/// intermediate path is created, unless `createIfMissing` is `false`, in which case the `VARIANT`
+/// is left unchanged. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if a path segment hits a value of an incompatible type.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the set target. A valid path starts with `$` and is
+///     followed by one or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///     The root path `$` is not allowed.
+///   - value: The value to set. Any expression castable to a `VARIANT`.
+///   - createIfMissing: Whether to create missing keys or out-of-range array indices
+///     (default = `true`).
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_set(
+  _ v: Column, _ path: String, _ value: Column, _ createIfMissing: Bool = true
+) -> Column {
+  return variant_set(v, lit(path), value, createIfMissing)
+}
+
+/// Sets or upserts a value in a `VARIANT` at the given `JSONPath` location. An existing object
+/// field or array element at the target is replaced. A missing field, array index, or
+/// intermediate path is created, unless `createIfMissing` is `false`, in which case the `VARIANT`
+/// is left unchanged. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if a path segment hits a value of an incompatible type.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the set target.
+///     A valid path starts with `$` and is followed by one or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`. The root path `$` is not allowed.
+///   - value: The value to set. Any expression castable to a `VARIANT`.
+///   - createIfMissing: Whether to create missing keys or out-of-range array indices
+///     (default = `true`).
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_set(
+  _ v: Column, _ path: Column, _ value: Column, _ createIfMissing: Bool = true
+) -> Column {
+  return fn("variant_set", v, path, value, lit(createIfMissing))
+}
+
+/// Sets or upserts a value in a `VARIANT` at the given `JSONPath` location. An existing object
+/// field or array element at the target is replaced. A missing field, array index, or
+/// intermediate path is created, unless `createIfMissing` is `false`, in which case the `VARIANT`
+/// is left unchanged. Returns `NULL` if a path segment hits a value of an incompatible type, or
+/// if any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the set target. A valid path starts with `$` and is
+///     followed by one or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///     The root path `$` is not allowed.
+///   - value: The value to set. Any expression castable to a `VARIANT`.
+///   - createIfMissing: Whether to create missing keys or out-of-range array indices
+///     (default = `true`).
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_set(
+  _ v: Column, _ path: String, _ value: Column, _ createIfMissing: Bool = true
+) -> Column {
+  return try_variant_set(v, lit(path), value, createIfMissing)
+}
+
+/// Sets or upserts a value in a `VARIANT` at the given `JSONPath` location. An existing object
+/// field or array element at the target is replaced. A missing field, array index, or
+/// intermediate path is created, unless `createIfMissing` is `false`, in which case the `VARIANT`
+/// is left unchanged. Returns `NULL` if a path segment hits a value of an incompatible type, or
+/// if any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the set target.
+///     A valid path starts with `$` and is followed by one or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`. The root path `$` is not allowed.
+///   - value: The value to set. Any expression castable to a `VARIANT`.
+///   - createIfMissing: Whether to create missing keys or out-of-range array indices
+///     (default = `true`).
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_set(
+  _ v: Column, _ path: Column, _ value: Column, _ createIfMissing: Bool = true
+) -> Column {
+  return fn("try_variant_set", v, path, value, lit(createIfMissing))
+}
+
+/// Appends a value to the array in a `VARIANT` at the given `JSONPath` location. Returns the
+/// `VARIANT` unchanged if a path key or index is absent. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if a path segment hits a value of an incompatible type or the target is
+/// not an array.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the target array. A valid path starts with `$` and
+///     is followed by zero or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - value: The value to append. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_array_append(_ v: Column, _ path: String, _ value: Column) -> Column {
+  return variant_array_append(v, lit(path), value)
+}
+
+/// Appends a value to the array in a `VARIANT` at the given `JSONPath` location. Returns the
+/// `VARIANT` unchanged if a path key or index is absent. Returns `NULL` if any argument is `NULL`.
+/// Throws an exception, if a path segment hits a value of an incompatible type or the target is
+/// not an array.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the target array.
+///     A valid path starts with `$` and is followed by zero or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`.
+///   - value: The value to append. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_array_append(_ v: Column, _ path: Column, _ value: Column) -> Column {
+  return fn("variant_array_append", v, path, value)
+}
+
+/// Appends a value to the array in a `VARIANT` at the given `JSONPath` location. Returns the
+/// `VARIANT` unchanged if a path key or index is absent. Returns `NULL` if a path segment hits a
+/// value of an incompatible type, the target is not an array, or any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A `JSONPath` string identifying the target array. A valid path starts with `$` and
+///     is followed by zero or more segments like `[123]`, `.name`, `['name']`, or `["name"]`.
+///   - value: The value to append. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_array_append(_ v: Column, _ path: String, _ value: Column) -> Column {
+  return try_variant_array_append(v, lit(path), value)
+}
+
+/// Appends a value to the array in a `VARIANT` at the given `JSONPath` location. Returns the
+/// `VARIANT` unchanged if a path key or index is absent. Returns `NULL` if a path segment hits a
+/// value of an incompatible type, the target is not an array, or any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - path: A ``Column`` that evaluates to a `JSONPath` string identifying the target array.
+///     A valid path starts with `$` and is followed by zero or more segments like `[123]`,
+///     `.name`, `['name']`, or `["name"]`.
+///   - value: The value to append. Any expression castable to a `VARIANT`.
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func try_variant_array_append(_ v: Column, _ path: Column, _ value: Column) -> Column {
+  return fn("try_variant_array_append", v, path, value)
+}
+
+/// Recursively removes object fields and array elements whose value is a `VARIANT` null, unless
+/// `includeArrays` is `false`, in which case null array elements are kept.
+/// Returns `NULL` if any argument is `NULL`.
+/// - Parameters:
+///   - v: A ``Column`` that evaluates to a `VARIANT`.
+///   - includeArrays: Whether null elements are also removed from arrays (default = `true`).
+/// - Returns: A ``Column`` that evaluates to a `VARIANT`.
+public func variant_strip_nulls(_ v: Column, _ includeArrays: Bool = true) -> Column {
+  return fn("variant_strip_nulls", v, lit(includeArrays))
+}

--- a/Tests/SparkConnectTests/VariantFunctionsTests.swift
+++ b/Tests/SparkConnectTests/VariantFunctionsTests.swift
@@ -1,0 +1,264 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `VariantFunctions`
+@Suite(.serialized)
+struct VariantFunctionsTests {
+
+  @Test
+  func variantFunctions() throws {
+    for (column, name) in [
+      (parse_json(col("a")), "parse_json"),
+      (try_parse_json(col("a")), "try_parse_json"),
+      (to_variant_object(col("a")), "to_variant_object"),
+      (is_variant_null(col("a")), "is_variant_null"),
+      (is_valid_variant(col("a")), "is_valid_variant"),
+      (schema_of_variant(col("a")), "schema_of_variant"),
+      (schema_of_variant_agg(col("a")), "schema_of_variant_agg"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 1)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// A `String` path is a shorthand for a literal ``Column`` path.
+  @Test
+  func variantGet() throws {
+    for (column, name) in [
+      (variant_get(col("a"), "$.b", "int"), "variant_get"),
+      (try_variant_get(col("a"), "$.b", "int"), "try_variant_get"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 3)
+      #expect(expr.unresolvedFunction.arguments[1].literal.string == "$.b")
+      #expect(expr.unresolvedFunction.arguments[2].literal.string == "int")
+    }
+
+    #expect(
+      variant_get(col("a"), lit("$.b"), "int").expr == variant_get(col("a"), "$.b", "int").expr)
+    #expect(
+      try_variant_get(col("a"), lit("$.b"), "int").expr
+        == try_variant_get(col("a"), "$.b", "int").expr)
+
+    let path = variant_get(col("a"), col("p"), "int").expr
+    #expect(path.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "p")
+  }
+
+  @Test
+  func variantUpdates() throws {
+    for (column, name) in [
+      (variant_insert(col("a"), "$.b", lit(1)), "variant_insert"),
+      (try_variant_insert(col("a"), "$.b", lit(1)), "try_variant_insert"),
+      (variant_array_append(col("a"), "$.b", lit(1)), "variant_array_append"),
+      (try_variant_array_append(col("a"), "$.b", lit(1)), "try_variant_array_append"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 3)
+      #expect(expr.unresolvedFunction.arguments[1].literal.string == "$.b")
+      #expect(expr.unresolvedFunction.arguments[2].literal.long == 1)
+    }
+
+    #expect(
+      variant_insert(col("a"), lit("$.b"), lit(1)).expr
+        == variant_insert(col("a"), "$.b", lit(1)).expr)
+    #expect(
+      try_variant_insert(col("a"), lit("$.b"), lit(1)).expr
+        == try_variant_insert(col("a"), "$.b", lit(1)).expr)
+    #expect(
+      variant_array_append(col("a"), lit("$.b"), lit(1)).expr
+        == variant_array_append(col("a"), "$.b", lit(1)).expr)
+    #expect(
+      try_variant_array_append(col("a"), lit("$.b"), lit(1)).expr
+        == try_variant_array_append(col("a"), "$.b", lit(1)).expr)
+  }
+
+  /// `createIfMissing` is always sent as a literal argument like PySpark's Spark Connect client.
+  @Test
+  func variantSet() throws {
+    for (column, name) in [
+      (variant_set(col("a"), "$.b", lit(1)), "variant_set"),
+      (try_variant_set(col("a"), "$.b", lit(1)), "try_variant_set"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 4)
+      #expect(expr.unresolvedFunction.arguments[1].literal.string == "$.b")
+      #expect(expr.unresolvedFunction.arguments[2].literal.long == 1)
+      #expect(expr.unresolvedFunction.arguments[3].literal.boolean == true)
+    }
+
+    #expect(variant_set(col("a"), "$.b", lit(1), false).expr.unresolvedFunction.arguments[3].literal
+      .boolean == false)
+    #expect(
+      try_variant_set(col("a"), "$.b", lit(1), false).expr.unresolvedFunction.arguments[3].literal
+        .boolean == false)
+    #expect(
+      variant_set(col("a"), lit("$.b"), lit(1)).expr == variant_set(col("a"), "$.b", lit(1)).expr)
+    #expect(
+      try_variant_set(col("a"), lit("$.b"), lit(1)).expr
+        == try_variant_set(col("a"), "$.b", lit(1)).expr)
+  }
+
+  /// `includeArrays` is always sent as a literal argument like PySpark's Spark Connect client.
+  @Test
+  func variantStripNulls() throws {
+    let expr = variant_strip_nulls(col("a")).expr
+    #expect(expr.unresolvedFunction.functionName == "variant_strip_nulls")
+    #expect(expr.unresolvedFunction.arguments.count == 2)
+    #expect(expr.unresolvedFunction.arguments[1].literal.boolean == true)
+
+    let excluded = variant_strip_nulls(col("a"), false).expr
+    #expect(excluded.unresolvedFunction.arguments[1].literal.boolean == false)
+  }
+
+  @Test
+  func parseJson() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let v = parse_json(lit("{\"a\": 1, \"b\": \"x\"}"))
+      let rows = try await spark.range(1).select(
+        v.cast("string"),
+        schema_of_variant(v),
+        variant_get(v, "$.a", "int"),
+        try_variant_get(v, "$.b", "int"),
+        try_parse_json(lit("{{{")).isNull()
+      ).collect()
+      #expect(
+        rows == [Row("{\"a\":1,\"b\":\"x\"}", "OBJECT<a: BIGINT, b: STRING>", Int32(1), nil, true)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func isVariantNull() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let rows = try await spark.range(1).select(
+        is_variant_null(parse_json(lit("null"))),
+        is_variant_null(parse_json(lit("{\"a\": 1}")))
+      ).collect()
+      #expect(rows == [Row(true, false)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func toVariantObject() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let rows = try await spark.range(1).select(
+        to_variant_object(`struct`(lit(1).alias("a"), lit("x").alias("b"))).cast("string")
+      ).collect()
+      #expect(rows == [Row("{\"a\":1,\"b\":\"x\"}")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func schemaOfVariantAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let df = try await spark.sql(
+        "SELECT * FROM VALUES ('{\"a\": 1}'), ('{\"b\": \"x\"}') AS T(j)")
+      let rows = try await df.select(schema_of_variant_agg(parse_json(col("j")))).collect()
+      #expect(rows == [Row("OBJECT<a: BIGINT, b: STRING>")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func isValidVariant() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.2") {
+      let rows = try await spark.range(1).select(
+        is_valid_variant(parse_json(lit("{\"a\": 1}")))
+      ).collect()
+      #expect(rows == [Row(true)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func variantInsert() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = parse_json(lit("{\"a\": 1}"))
+      let rows = try await spark.range(1).select(
+        to_json(variant_insert(v, "$.b", lit(2))),
+        to_json(try_variant_insert(v, "$.b", lit(2))),
+        to_json(try_variant_insert(v, "$.a", lit(2)))
+      ).collect()
+      #expect(rows == [Row("{\"a\":1,\"b\":2}", "{\"a\":1,\"b\":2}", nil)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func variantSetValue() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = parse_json(lit("{\"a\": 1}"))
+      let rows = try await spark.range(1).select(
+        to_json(variant_set(v, "$.a", lit(9))),
+        to_json(variant_set(v, "$.b", lit(2))),
+        to_json(variant_set(v, "$.b", lit(2), false)),
+        to_json(try_variant_set(v, "$.b", lit(2), false))
+      ).collect()
+      #expect(rows == [Row("{\"a\":9}", "{\"a\":1,\"b\":2}", "{\"a\":1}", "{\"a\":1}")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func variantArrayAppend() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = parse_json(lit("[1, 2]"))
+      let rows = try await spark.range(1).select(
+        to_json(variant_array_append(v, "$", lit(3))),
+        to_json(try_variant_array_append(v, "$", lit(3))),
+        to_json(try_variant_array_append(v, "$[1]", lit(3)))
+      ).collect()
+      #expect(rows == [Row("[1,2,3]", "[1,2,3]", nil)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func variantStripNullsValue() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = parse_json(lit("{\"a\": null, \"b\": [null, 1]}"))
+      let rows = try await spark.range(1).select(
+        to_json(variant_strip_nulls(v)),
+        to_json(variant_strip_nulls(v, false))
+      ).collect()
+      #expect(rows == [Row("{\"b\":[1]}", "{\"b\":[null,1]}")])
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 16 `VARIANT` functions (24 overloads).

| Function | Since | Signature |
| --- | --- | --- |
| `parse_json` | 4.0.0 | `(Column)` |
| `try_parse_json` | 4.0.0 | `(Column)` |
| `to_variant_object` | 4.0.0 | `(Column)` |
| `is_variant_null` | 4.0.0 | `(Column)` |
| `variant_get` | 4.0.0 | `(Column, String \| Column, String)` |
| `try_variant_get` | 4.0.0 | `(Column, String \| Column, String)` |
| `schema_of_variant` | 4.0.0 | `(Column)` |
| `schema_of_variant_agg` | 4.0.0 | `(Column)` |
| `is_valid_variant` | 4.2.0 | `(Column)` |
| `variant_insert` | 4.3.0 | `(Column, String \| Column, Column)` |
| `try_variant_insert` | 4.3.0 | `(Column, String \| Column, Column)` |
| `variant_set` | 4.3.0 | `(Column, String \| Column, Column, Bool = true)` |
| `try_variant_set` | 4.3.0 | `(Column, String \| Column, Column, Bool = true)` |
| `variant_array_append` | 4.3.0 | `(Column, String \| Column, Column)` |
| `try_variant_array_append` | 4.3.0 | `(Column, String \| Column, Column)` |
| `variant_strip_nulls` | 4.3.0 | `(Column, Bool = true)` |

The functions live in a new `VariantFunctions.swift`, except `schema_of_variant_agg`
which is an aggregate function and is placed in `AggregateFunctions.swift`.

Where the upstream `path` argument is `Union[Column, str]`, both a `String` and a `Column`
overload are provided, following the existing `schema_of_json` precedent. Like PySpark's
Spark Connect client, the `createIfMissing` and `includeArrays` flags are always sent as
literal arguments.

`variant_delete` is out of scope because it is introduced in Spark 5.0.0.

### Why are the changes needed?

To improve API coverage. `DataType` already models `.variant`, but no `VARIANT` function
was available in this client.

### Does this PR introduce _any_ user-facing change?

No, this is a new addition to the API.

### How was this patch tested?

Pass the CIs with the newly added test suite, `VariantFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5