### PR TITLE
[SPARK-59225] Support URL functions

### DIFF
--- a/Sources/SparkConnect/UrlFunctions.swift
+++ b/Sources/SparkConnect/UrlFunctions.swift
@@ -1,0 +1,138 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - URL functions
+
+/// Extracts a part from a URL.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: The part to extract from the URL, e.g. `HOST`, `PATH`, `QUERY`, `REF`,
+///     `PROTOCOL`, `FILE`, `AUTHORITY`, or `USERINFO`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func parse_url(_ url: Column, _ partToExtract: String) -> Column {
+  return parse_url(url, lit(partToExtract))
+}
+
+/// Extracts a part from a URL.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: A ``Column`` that evaluates to the part to extract from the URL,
+///     e.g. `HOST`, `PATH`, `QUERY`, `REF`, `PROTOCOL`, `FILE`, `AUTHORITY`, or `USERINFO`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func parse_url(_ url: Column, _ partToExtract: Column) -> Column {
+  return fn("parse_url", url, partToExtract)
+}
+
+/// Extracts the value of a query parameter from a URL.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: The part to extract from the URL. Only `QUERY` uses `key`.
+///   - key: The key of a query parameter in the URL.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func parse_url(_ url: Column, _ partToExtract: String, _ key: String) -> Column {
+  return parse_url(url, lit(partToExtract), lit(key))
+}
+
+/// Extracts the value of a query parameter from a URL.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: A ``Column`` that evaluates to the part to extract from the URL.
+///     Only `QUERY` uses `key`.
+///   - key: A ``Column`` that evaluates to the key of a query parameter in the URL.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func parse_url(_ url: Column, _ partToExtract: Column, _ key: Column) -> Column {
+  return fn("parse_url", url, partToExtract, key)
+}
+
+/// Extracts a part from a URL. This is a special version of ``parse_url(_:_:)`` that returns
+/// a `NULL` value instead of raising an error if the URL is invalid.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: The part to extract from the URL, e.g. `HOST`, `PATH`, `QUERY`, `REF`,
+///     `PROTOCOL`, `FILE`, `AUTHORITY`, or `USERINFO`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func try_parse_url(_ url: Column, _ partToExtract: String) -> Column {
+  return try_parse_url(url, lit(partToExtract))
+}
+
+/// Extracts a part from a URL. This is a special version of ``parse_url(_:_:)`` that returns
+/// a `NULL` value instead of raising an error if the URL is invalid.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: A ``Column`` that evaluates to the part to extract from the URL,
+///     e.g. `HOST`, `PATH`, `QUERY`, `REF`, `PROTOCOL`, `FILE`, `AUTHORITY`, or `USERINFO`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func try_parse_url(_ url: Column, _ partToExtract: Column) -> Column {
+  return fn("try_parse_url", url, partToExtract)
+}
+
+/// Extracts the value of a query parameter from a URL. This is a special version of
+/// ``parse_url(_:_:_:)`` that returns a `NULL` value instead of raising an error if the URL
+/// is invalid.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: The part to extract from the URL. Only `QUERY` uses `key`.
+///   - key: The key of a query parameter in the URL.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func try_parse_url(_ url: Column, _ partToExtract: String, _ key: String) -> Column {
+  return try_parse_url(url, lit(partToExtract), lit(key))
+}
+
+/// Extracts the value of a query parameter from a URL. This is a special version of
+/// ``parse_url(_:_:_:)`` that returns a `NULL` value instead of raising an error if the URL
+/// is invalid.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameters:
+///   - url: A ``Column`` that evaluates to a URL string.
+///   - partToExtract: A ``Column`` that evaluates to the part to extract from the URL.
+///     Only `QUERY` uses `key`.
+///   - key: A ``Column`` that evaluates to the key of a query parameter in the URL.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func try_parse_url(_ url: Column, _ partToExtract: Column, _ key: Column) -> Column {
+  return fn("try_parse_url", url, partToExtract, key)
+}
+
+/// Decodes a `str` in 'application/x-www-form-urlencoded' format using a specific encoding
+/// scheme.
+/// - Parameter str: A ``Column`` that evaluates to a URL-encoded string.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func url_decode(_ str: Column) -> Column {
+  return fn("url_decode", str)
+}
+
+/// Translates a string into 'application/x-www-form-urlencoded' format using a specific
+/// encoding scheme.
+/// - Parameter str: A ``Column`` that evaluates to a string to encode.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func url_encode(_ str: Column) -> Column {
+  return fn("url_encode", str)
+}
+
+/// Decodes a `str` in 'application/x-www-form-urlencoded' format using a specific encoding
+/// scheme. This is a special version of ``url_decode(_:)`` that returns a `NULL` value instead
+/// of raising an error if the decoding cannot be performed.
+/// This requires Apache Spark 4.0.0 or later.
+/// - Parameter str: A ``Column`` that evaluates to a URL-encoded string.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func try_url_decode(_ str: Column) -> Column {
+  return fn("try_url_decode", str)
+}

--- a/Tests/SparkConnectTests/UrlFunctionsTests.swift
+++ b/Tests/SparkConnectTests/UrlFunctionsTests.swift
@@ -1,0 +1,150 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `UrlFunctions`
+@Suite(.serialized)
+struct UrlFunctionsTests {
+
+  @Test
+  func urlFunctions() throws {
+    for (column, name) in [
+      (url_encode(col("a")), "url_encode"),
+      (url_decode(col("a")), "url_decode"),
+      (try_url_decode(col("a")), "try_url_decode"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 1)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// A `String` `partToExtract` is a shorthand for a literal ``Column``.
+  @Test
+  func parseUrl() throws {
+    for (column, name) in [
+      (parse_url(col("a"), "HOST"), "parse_url"),
+      (try_parse_url(col("a"), "HOST"), "try_parse_url"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].literal.string == "HOST")
+    }
+
+    #expect(parse_url(col("a"), lit("HOST")).expr == parse_url(col("a"), "HOST").expr)
+    #expect(try_parse_url(col("a"), lit("HOST")).expr == try_parse_url(col("a"), "HOST").expr)
+
+    let part = parse_url(col("a"), col("p")).expr
+    #expect(part.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "p")
+  }
+
+  /// A `String` `key` is a shorthand for a literal ``Column``.
+  @Test
+  func parseUrlQueryKey() throws {
+    for (column, name) in [
+      (parse_url(col("a"), "QUERY", "k"), "parse_url"),
+      (try_parse_url(col("a"), "QUERY", "k"), "try_parse_url"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 3)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].literal.string == "QUERY")
+      #expect(expr.unresolvedFunction.arguments[2].literal.string == "k")
+    }
+
+    #expect(
+      parse_url(col("a"), lit("QUERY"), lit("k")).expr == parse_url(col("a"), "QUERY", "k").expr)
+    #expect(
+      try_parse_url(col("a"), lit("QUERY"), lit("k")).expr
+        == try_parse_url(col("a"), "QUERY", "k").expr)
+  }
+
+  @Test
+  func selectParseUrl() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let url = lit("https://spark.apache.org/path?query=1#Ref")
+    let rows = try await spark.range(1).select(
+      parse_url(url, "HOST"),
+      parse_url(url, "PATH"),
+      parse_url(url, "QUERY"),
+      parse_url(url, "REF"),
+      parse_url(url, "PROTOCOL"),
+      parse_url(url, "QUERY", "query"),
+      parse_url(url, "QUERY", "missing")
+    ).collect()
+    #expect(
+      rows == [
+        Row("spark.apache.org", "/path", "query=1", "Ref", "https", "1", nil)
+      ])
+    await spark.stop()
+  }
+
+  @Test
+  func selectTryParseUrl() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let url = lit("https://spark.apache.org/path?query=1")
+      let rows = try await spark.range(1).select(
+        try_parse_url(url, "HOST"),
+        try_parse_url(url, "QUERY", "query"),
+        try_parse_url(lit("inva lid"), "HOST"),
+        try_parse_url(lit("inva lid"), "QUERY", "query")
+      ).collect()
+      #expect(rows == [Row("spark.apache.org", "1", nil, nil)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func selectUrlEncodeAndDecode() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let rows = try await spark.range(1).select(
+      url_encode(lit("https://spark.apache.org/a b")),
+      url_decode(lit("https%3A%2F%2Fspark.apache.org%2Fa+b")),
+      url_decode(url_encode(lit("https://spark.apache.org/a b")))
+    ).collect()
+    #expect(
+      rows == [
+        Row(
+          "https%3A%2F%2Fspark.apache.org%2Fa+b", "https://spark.apache.org/a b",
+          "https://spark.apache.org/a b")
+      ])
+    await spark.stop()
+  }
+
+  @Test
+  func selectTryUrlDecode() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.0") {
+      let rows = try await spark.range(1).select(
+        try_url_decode(lit("https%3A%2F%2Fspark.apache.org")),
+        try_url_decode(lit("https%3A%2F%2spark.apache.org"))
+      ).collect()
+      #expect(rows == [Row("https://spark.apache.org", nil)])
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 5 URL functions (10 overloads).

| Function | Since | Signatures |
| --- | --- | --- |
| `parse_url` | 3.5.0 | `(Column, String)`, `(Column, Column)`, `(Column, String, String)`, `(Column, Column, Column)` |
| `try_parse_url` | 4.0.0 | `(Column, String)`, `(Column, Column)`, `(Column, String, String)`, `(Column, Column, Column)` |
| `url_encode` | 3.5.0 | `(Column)` |
| `url_decode` | 3.5.0 | `(Column)` |
| `try_url_decode` | 4.0.0 | `(Column)` |

The functions live in a new `UrlFunctions.swift`, matching the `url_funcs` group of the upstream `functions.scala` and the "URL Functions" section of the PySpark docs.

Where the upstream `partToExtract` and `key` arguments are `Union[Column, str]`, both a `String` and a `Column` overload are provided, following the existing `variant_get` precedent, because these arguments are string literals such as `"HOST"` or `"QUERY"` in practice.

### Why are the changes needed?

To improve API coverage. No URL function was available in this client.

### Does this PR introduce _any_ user-facing change?

No, this is a new addition to the API.

### How was this patch tested?

Pass the CIs with the newly added test suite, `UrlFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5