### PR TITLE
[SPARK-59228] Support AES and HMAC functions

### DIFF
--- a/Sources/SparkConnect/CryptoFunctions.swift
+++ b/Sources/SparkConnect/CryptoFunctions.swift
@@ -1,0 +1,135 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Crypto functions
+//
+// These functions only build SQL expressions that the server evaluates; no encryption or
+// authentication is performed by this client. A key passed as a literal becomes part of the
+// query plan, so it can show up in server logs, the Spark UI, and plan output such as
+// `DataFrame/explain(_:)`. Read keys from a column of an access-controlled source instead of
+// embedding them in the plan whenever that matters.
+
+/// Returns an encrypted value of `input` using AES in the given `mode` with the specified
+/// `padding`. Key lengths of 16, 24 and 32 bytes are supported. Supported combinations of
+/// (`mode`, `padding`) are ('ECB', 'PKCS'), ('GCM', 'NONE') and ('CBC', 'PKCS').
+///
+/// The `key` becomes part of the query plan when it is a literal, which exposes it to server
+/// logs and plan output.
+/// - Parameters:
+///   - input: A binary ``Column`` to encrypt.
+///   - key: A binary ``Column`` holding the passphrase used to encrypt the data.
+///   - mode: A string ``Column`` selecting the block cipher mode. Valid values: `ECB`, `GCM`,
+///     `CBC`. Defaults to `GCM`.
+///   - padding: A string ``Column`` specifying how to pad messages whose length is not a
+///     multiple of the block size. Valid values: `PKCS`, `NONE`, `DEFAULT`. `DEFAULT` means
+///     `PKCS` for `ECB`, `NONE` for `GCM` and `PKCS` for `CBC`. Defaults to `DEFAULT`.
+///   - iv: A binary ``Column`` holding the initialization vector. Only supported for `CBC` and
+///     `GCM` modes, and must be 16 bytes for `CBC` and 12 bytes for `GCM`. Defaults to an empty
+///     string, which makes the server generate a random vector and prepend it to the output.
+///   - aad: A binary ``Column`` holding additional authenticated data. Only supported for `GCM`
+///     mode, and the identical value must be given to ``aes_decrypt(_:_:mode:padding:aad:)``.
+///     Defaults to an empty string.
+/// - Returns: A ``Column`` that evaluates to a binary.
+public func aes_encrypt(
+  _ input: Column, _ key: Column, mode: Column = lit("GCM"), padding: Column = lit("DEFAULT"),
+  iv: Column = lit(""), aad: Column = lit("")
+) -> Column {
+  return fn("aes_encrypt", input, key, mode, padding, iv, aad)
+}
+
+/// Returns a decrypted value of `input` using AES in the given `mode` with the specified
+/// `padding`. Key lengths of 16, 24 and 32 bytes are supported. Supported combinations of
+/// (`mode`, `padding`) are ('ECB', 'PKCS'), ('GCM', 'NONE') and ('CBC', 'PKCS').
+///
+/// The `key` becomes part of the query plan when it is a literal, which exposes it to server
+/// logs and plan output.
+/// - Parameters:
+///   - input: A binary ``Column`` to decrypt.
+///   - key: A binary ``Column`` holding the passphrase used to decrypt the data.
+///   - mode: A string ``Column`` selecting the block cipher mode. Valid values: `ECB`, `GCM`,
+///     `CBC`. Defaults to `GCM`.
+///   - padding: A string ``Column`` specifying how to pad messages whose length is not a
+///     multiple of the block size. Valid values: `PKCS`, `NONE`, `DEFAULT`. `DEFAULT` means
+///     `PKCS` for `ECB`, `NONE` for `GCM` and `PKCS` for `CBC`. Defaults to `DEFAULT`.
+///   - aad: A binary ``Column`` holding additional authenticated data. Only supported for `GCM`
+///     mode, and must be the same value given to ``aes_encrypt(_:_:mode:padding:iv:aad:)``.
+///     Defaults to an empty string.
+/// - Returns: A ``Column`` that evaluates to a binary.
+public func aes_decrypt(
+  _ input: Column, _ key: Column, mode: Column = lit("GCM"), padding: Column = lit("DEFAULT"),
+  aad: Column = lit("")
+) -> Column {
+  return fn("aes_decrypt", input, key, mode, padding, aad)
+}
+
+/// This is a special version of ``aes_decrypt(_:_:mode:padding:aad:)`` that returns `NULL`
+/// instead of raising an error when decryption fails.
+///
+/// The `key` becomes part of the query plan when it is a literal, which exposes it to server
+/// logs and plan output.
+/// - Parameters:
+///   - input: A binary ``Column`` to decrypt.
+///   - key: A binary ``Column`` holding the passphrase used to decrypt the data.
+///   - mode: A string ``Column`` selecting the block cipher mode. Valid values: `ECB`, `GCM`,
+///     `CBC`. Defaults to `GCM`.
+///   - padding: A string ``Column`` specifying how to pad messages whose length is not a
+///     multiple of the block size. Valid values: `PKCS`, `NONE`, `DEFAULT`. `DEFAULT` means
+///     `PKCS` for `ECB`, `NONE` for `GCM` and `PKCS` for `CBC`. Defaults to `DEFAULT`.
+///   - aad: A binary ``Column`` holding additional authenticated data. Only supported for `GCM`
+///     mode, and must be the same value given to ``aes_encrypt(_:_:mode:padding:iv:aad:)``.
+///     Defaults to an empty string.
+/// - Returns: A ``Column`` that evaluates to a binary.
+public func try_aes_decrypt(
+  _ input: Column, _ key: Column, mode: Column = lit("GCM"), padding: Column = lit("DEFAULT"),
+  aad: Column = lit("")
+) -> Column {
+  return fn("try_aes_decrypt", input, key, mode, padding, aad)
+}
+
+/// Returns the keyed-hash message authentication code (HMAC) of `message` using `key` and
+/// SHA-256. To use a different algorithm, call ``hmac(_:_:_:)``.
+/// This requires a Spark 4.3.0+ server.
+///
+/// The result is raw MAC bytes; wrap it with ``hex(_:)`` or ``base64(_:)`` for a textual value.
+/// The `key` becomes part of the query plan when it is a literal, which exposes it to server
+/// logs and plan output.
+/// - Parameters:
+///   - key: A binary ``Column`` holding the secret key.
+///   - message: A binary ``Column`` holding the message to authenticate.
+/// - Returns: A ``Column`` that evaluates to a binary.
+public func hmac(_ key: Column, _ message: Column) -> Column {
+  return fn("hmac", key, message)
+}
+
+/// Returns the keyed-hash message authentication code (HMAC) of `message` using `key` and the
+/// given hash `algorithm`.
+/// This requires a Spark 4.3.0+ server.
+///
+/// The result is raw MAC bytes; wrap it with ``hex(_:)`` or ``base64(_:)`` for a textual value.
+/// The `key` becomes part of the query plan when it is a literal, which exposes it to server
+/// logs and plan output.
+/// - Parameters:
+///   - key: A binary ``Column`` holding the secret key.
+///   - message: A binary ``Column`` holding the message to authenticate.
+///   - algorithm: A string ``Column`` selecting the hash algorithm. Valid values: `SHA-224`,
+///     `SHA-256`, `SHA-384`, `SHA-512`, `SHA-1`, `MD5`.
+/// - Returns: A ``Column`` that evaluates to a binary.
+public func hmac(_ key: Column, _ message: Column, _ algorithm: Column) -> Column {
+  return fn("hmac", key, message, algorithm)
+}

--- a/Tests/SparkConnectTests/CryptoFunctionsTests.swift
+++ b/Tests/SparkConnectTests/CryptoFunctionsTests.swift
@@ -1,0 +1,161 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `CryptoFunctions`
+@Suite(.serialized)
+struct CryptoFunctionsTests {
+
+  /// An obvious dummy 16-byte AES key used only by these tests.
+  let key = "0000000000000000"
+
+  @Test
+  func aesFunctions() throws {
+    for (column, name, count) in [
+      (aes_encrypt(col("a"), col("k")), "aes_encrypt", 6),
+      (aes_decrypt(col("a"), col("k")), "aes_decrypt", 5),
+      (try_aes_decrypt(col("a"), col("k")), "try_aes_decrypt", 5),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "k")
+      #expect(expr.unresolvedFunction.arguments[2].literal.string == "GCM")
+      #expect(expr.unresolvedFunction.arguments[3].literal.string == "DEFAULT")
+    }
+  }
+
+  /// The omitted optional arguments are filled with their default literals, so the argument
+  /// count never changes.
+  @Test
+  func aesOptionalArguments() throws {
+    let encrypt = aes_encrypt(
+      col("a"), col("k"), mode: lit("CBC"), padding: lit("PKCS"), iv: col("iv"), aad: col("aad")
+    ).expr
+    #expect(encrypt.unresolvedFunction.arguments.count == 6)
+    #expect(encrypt.unresolvedFunction.arguments[2].literal.string == "CBC")
+    #expect(encrypt.unresolvedFunction.arguments[3].literal.string == "PKCS")
+    #expect(encrypt.unresolvedFunction.arguments[4].unresolvedAttribute.unparsedIdentifier == "iv")
+    #expect(encrypt.unresolvedFunction.arguments[5].unresolvedAttribute.unparsedIdentifier == "aad")
+
+    // `aes_encrypt` has an `iv` argument, but `aes_decrypt` and `try_aes_decrypt` do not.
+    let defaultIv = aes_encrypt(col("a"), col("k")).expr.unresolvedFunction.arguments[4]
+    #expect(defaultIv.literal.string == "")
+    for column in [
+      aes_decrypt(col("a"), col("k"), mode: lit("ECB"), padding: lit("PKCS"), aad: col("aad")),
+      try_aes_decrypt(col("a"), col("k"), mode: lit("ECB"), padding: lit("PKCS"), aad: col("aad")),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.arguments.count == 5)
+      #expect(expr.unresolvedFunction.arguments[2].literal.string == "ECB")
+      #expect(expr.unresolvedFunction.arguments[3].literal.string == "PKCS")
+      #expect(expr.unresolvedFunction.arguments[4].unresolvedAttribute.unparsedIdentifier == "aad")
+    }
+    let defaultAad = aes_decrypt(col("a"), col("k")).expr.unresolvedFunction.arguments[4]
+    #expect(defaultAad.literal.string == "")
+  }
+
+  /// Unlike the AES functions, `hmac` omits the optional `algorithm` argument instead of
+  /// filling it with a default literal.
+  @Test
+  func hmacFunction() throws {
+    let expr = hmac(col("k"), col("m")).expr
+    #expect(expr.unresolvedFunction.functionName == "hmac")
+    #expect(expr.unresolvedFunction.arguments.count == 2)
+    #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "k")
+    #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "m")
+
+    let withAlgorithm = hmac(col("k"), col("m"), lit("SHA-1")).expr
+    #expect(withAlgorithm.unresolvedFunction.functionName == "hmac")
+    #expect(withAlgorithm.unresolvedFunction.arguments.count == 3)
+    #expect(withAlgorithm.unresolvedFunction.arguments[2].literal.string == "SHA-1")
+  }
+
+  /// GCM uses a random initialization vector, so only the round trip is deterministic.
+  @Test
+  func aesRoundTrip() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT 'Spark' AS a")
+    let rows = try await df.select(
+      aes_decrypt(aes_encrypt(col("a"), lit(key)), lit(key)).cast("STRING"),
+      aes_decrypt(
+        aes_encrypt(col("a"), lit(key), mode: lit("CBC"), padding: lit("PKCS")),
+        lit(key), mode: lit("CBC"), padding: lit("PKCS")
+      ).cast("STRING"),
+      try_aes_decrypt(aes_encrypt(col("a"), lit(key)), lit(key)).cast("STRING")
+    ).collect()
+    #expect(rows == [Row("Spark", "Spark", "Spark")])
+    await spark.stop()
+  }
+
+  /// ECB has neither an initialization vector nor authentication, so its ciphertext is
+  /// deterministic.
+  @Test
+  func aesEcbIsDeterministic() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT 'Spark' AS a")
+    let encrypt = aes_encrypt(col("a"), lit(key), mode: lit("ECB"), padding: lit("PKCS"))
+    let rows = try await df.select(
+      hex(encrypt),
+      aes_decrypt(encrypt, lit(key), mode: lit("ECB"), padding: lit("PKCS")).cast("STRING")
+    ).collect()
+    #expect(rows == [Row("0776185876454AAB6963D68360C120D9", "Spark")])
+    await spark.stop()
+  }
+
+  /// A wrong key makes `aes_decrypt` fail, while `try_aes_decrypt` returns `NULL`.
+  @Test
+  func tryAesDecryptReturnsNullOnWrongKey() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.sql("SELECT 'Spark' AS a")
+    let encrypted = aes_encrypt(col("a"), lit(key))
+    let wrongKey = lit("1111111111111111")
+    let rows = try await df.select(try_aes_decrypt(encrypted, wrongKey).cast("STRING")).collect()
+    #expect(rows == [Row(nil)])
+
+    try await #require(throws: Error.self) {
+      try await df.select(aes_decrypt(encrypted, wrongKey).cast("STRING")).collect()
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func hmacRoundTrip() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let df = try await spark.sql("SELECT 'key' AS k, 'message' AS m")
+      let rows = try await df.select(
+        hex(hmac(col("k"), col("m"))),
+        hex(hmac(col("k"), col("m"), lit("SHA-1")))
+      ).collect()
+      #expect(
+        rows == [
+          Row(
+            "6E9EF29B75FFFC5B7ABAE527D58FDADB2FE42E7219011976917343065F58ED4A",
+            "2088DF74D5F2146B48146CAF4965377E9D0BE3A4"
+          )
+        ])
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the AES and HMAC functions.

| Function | Since |
| -------- | ----- |
| `aes_encrypt(input, key, mode, padding, iv, aad)` | 3.5.0 |
| `aes_decrypt(input, key, mode, padding, aad)` | 3.5.0 |
| `try_aes_decrypt(input, key, mode, padding, aad)` | 3.5.0 |
| `hmac(key, message, algorithm)` | 4.3.0 |

The new functions live in a new `CryptoFunctions.swift` file. The existing
`HashFunctions.swift` holds one-way digests, while these functions take a secret
key and perform symmetric encryption or message authentication.

Optional arguments follow the upstream PySpark implementations exactly:

- The AES functions fill omitted arguments with their default literals, so
  `aes_encrypt` always sends 6 arguments and `aes_decrypt` / `try_aes_decrypt`
  always send 5. Note that `aes_encrypt` has an `iv` argument while the two
  decrypt functions do not.
- `hmac` omits the optional `algorithm` argument instead of filling it, so it
  sends 2 or 3 arguments. Since a Swift default argument value cannot change the
  argument count, this is expressed as two overloads, matching the two Scala
  `hmac` overloads.

Since these functions are evaluated by the server and a key passed as a literal
becomes part of the query plan, the doc comments note that a literal key can be
exposed through server logs and plan output.

### Why are the changes needed?

To improve the API coverage. These functions are available in PySpark and the
Spark SQL Scala API, but were missing from this Swift client.

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

```swift
let key = lit("0000000000000000")
let df = try await spark.sql("SELECT 'Spark' AS a")
try await df.select(
  aes_decrypt(aes_encrypt(col("a"), key), key).cast("STRING")
).show()
```

```
+-------------------------------------------------------------+
|CAST(aes_decrypt(aes_encrypt(a, 0000000000000000, GCM, ...)...|
+-------------------------------------------------------------+
|Spark                                                        |
+-------------------------------------------------------------+
```

### How was this patch tested?

Pass the CIs with a new test suite, `CryptoFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5