### PR TITLE
[SPARK-59236] Support vector functions

### DIFF
--- a/Sources/SparkConnect/AggregateFunctions.swift
+++ b/Sources/SparkConnect/AggregateFunctions.swift
@@ -691,3 +691,21 @@ public func var_samp(_ col: Column) -> Column {
 public func variance(_ col: Column) -> Column {
   return fn("variance", col)
 }
+
+/// Returns the element-wise mean of the float vectors in a group.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to an `ARRAY<FLOAT>` to aggregate. All the
+///   vectors in a group must have the same dimension.
+/// - Returns: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+public func vector_avg(_ col: Column) -> Column {
+  return fn("vector_avg", col)
+}
+
+/// Returns the element-wise sum of the float vectors in a group.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to an `ARRAY<FLOAT>` to aggregate. All the
+///   vectors in a group must have the same dimension.
+/// - Returns: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+public func vector_sum(_ col: Column) -> Column {
+  return fn("vector_sum", col)
+}

--- a/Sources/SparkConnect/VectorFunctions.swift
+++ b/Sources/SparkConnect/VectorFunctions.swift
@@ -1,0 +1,113 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Vector functions
+
+/// Returns the cosine similarity between two float vectors.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - left: The first vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - right: The second vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>` of the same
+///     dimension as `left`.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_cosine_similarity(_ left: Column, _ right: Column) -> Column {
+  return fn("vector_cosine_similarity", left, right)
+}
+
+/// Returns the inner product (dot product) between two float vectors.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - left: The first vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - right: The second vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>` of the same
+///     dimension as `left`.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_inner_product(_ left: Column, _ right: Column) -> Column {
+  return fn("vector_inner_product", left, right)
+}
+
+/// Returns the Euclidean (L2) distance between two float vectors.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - left: The first vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - right: The second vector. A ``Column`` that evaluates to an `ARRAY<FLOAT>` of the same
+///     dimension as `left`.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_l2_distance(_ left: Column, _ right: Column) -> Column {
+  return fn("vector_l2_distance", left, right)
+}
+
+/// Returns the Lp norm of a float vector using degree `2.0`, i.e. the Euclidean norm.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameter vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_norm(_ vector: Column) -> Column {
+  return fn("vector_norm", vector)
+}
+
+/// Returns the Lp norm of a float vector using the specified degree.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - degree: A ``Column`` that evaluates to a float, `1.0` for the L1 norm, `2.0` for the L2
+///     norm, or infinity for the infinity norm.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_norm(_ vector: Column, _ degree: Column) -> Column {
+  return fn("vector_norm", vector, degree)
+}
+
+/// Returns the Lp norm of a float vector using the specified degree.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - degree: The norm degree, `1.0` for the L1 norm, `2.0` for the L2 norm, or
+///     `Float.infinity` for the infinity norm.
+/// - Returns: A ``Column`` that evaluates to a float.
+public func vector_norm(_ vector: Column, _ degree: Float) -> Column {
+  return fn("vector_norm", vector, lit(degree))
+}
+
+/// Normalizes a float vector to unit length using degree `2.0`, i.e. the Euclidean norm.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameter vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+/// - Returns: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+public func vector_normalize(_ vector: Column) -> Column {
+  return fn("vector_normalize", vector)
+}
+
+/// Normalizes a float vector to unit length using the specified degree.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - degree: A ``Column`` that evaluates to a float, `1.0` for the L1 norm, `2.0` for the L2
+///     norm, or infinity for the infinity norm.
+/// - Returns: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+public func vector_normalize(_ vector: Column, _ degree: Column) -> Column {
+  return fn("vector_normalize", vector, degree)
+}
+
+/// Normalizes a float vector to unit length using the specified degree.
+/// This requires Apache Spark 4.3.0 or later.
+/// - Parameters:
+///   - vector: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+///   - degree: The norm degree, `1.0` for the L1 norm, `2.0` for the L2 norm, or
+///     `Float.infinity` for the infinity norm.
+/// - Returns: A ``Column`` that evaluates to an `ARRAY<FLOAT>`.
+public func vector_normalize(_ vector: Column, _ degree: Float) -> Column {
+  return fn("vector_normalize", vector, lit(degree))
+}

--- a/Tests/SparkConnectTests/VectorFunctionsTests.swift
+++ b/Tests/SparkConnectTests/VectorFunctionsTests.swift
@@ -1,0 +1,123 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `VectorFunctions`
+@Suite(.serialized)
+struct VectorFunctionsTests {
+
+  @Test
+  func vectorFunctions() throws {
+    for (column, name, count) in [
+      (vector_cosine_similarity(col("a"), col("b")), "vector_cosine_similarity", 2),
+      (vector_inner_product(col("a"), col("b")), "vector_inner_product", 2),
+      (vector_l2_distance(col("a"), col("b")), "vector_l2_distance", 2),
+      (vector_norm(col("a")), "vector_norm", 1),
+      (vector_norm(col("a"), col("b")), "vector_norm", 2),
+      (vector_normalize(col("a")), "vector_normalize", 1),
+      (vector_normalize(col("a"), col("b")), "vector_normalize", 2),
+      (vector_avg(col("a")), "vector_avg", 1),
+      (vector_sum(col("a")), "vector_sum", 1),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// A `Float` degree is a shorthand for a literal ``Column`` degree.
+  @Test
+  func vectorDegree() throws {
+    for (column, name) in [
+      (vector_norm(col("a"), 1.0), "vector_norm"),
+      (vector_normalize(col("a"), 1.0), "vector_normalize"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[1].literal.float == 1.0)
+    }
+  }
+
+  @Test
+  func vectorDistanceFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let x = array(lit(Float(1.0)), lit(Float(0.0)))
+      let y = array(lit(Float(0.0)), lit(Float(1.0)))
+      let p = array(lit(Float(1.0)), lit(Float(2.0)))
+      let q = array(lit(Float(4.0)), lit(Float(6.0)))
+      let rows = try await spark.range(1).select(
+        vector_cosine_similarity(x, y), vector_inner_product(x, y), vector_l2_distance(p, q)
+      ).collect()
+      #expect(rows == [Row(Float(0.0), Float(0.0), Float(5.0))])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func vectorNorm() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = array(lit(Float(3.0)), lit(Float(4.0)))
+      let rows = try await spark.range(1).select(
+        vector_norm(v), vector_norm(v, 1.0), vector_norm(v, lit(Float.infinity))
+      ).collect()
+      #expect(rows == [Row(Float(5.0), Float(7.0), Float(4.0))])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func vectorNormalize() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let v = array(lit(Float(3.0)), lit(Float(4.0)))
+      let rows = try await spark.range(1).select(
+        vector_normalize(v), vector_normalize(v, 1.0)
+      ).collect()
+      let l2 = try #require(rows[0].get(0) as? [Float])
+      let l1 = try #require(rows[0].get(1) as? [Float])
+      #expect(zip(l2, [0.6, 0.8]).allSatisfy { abs($0 - $1) < 1e-6 })
+      #expect(zip(l1, [3.0 / 7.0, 4.0 / 7.0]).allSatisfy { abs($0 - $1) < 1e-6 })
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func vectorAggregateFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.3") {
+      let df = try await spark.sql(
+        """
+        SELECT * FROM VALUES
+          ('a', ARRAY(1.0f, 2.0f)), ('a', ARRAY(3.0f, 4.0f)), ('b', ARRAY(5.0f, 6.0f)) AS T(k, v)
+        """)
+      let rows = try await df.groupBy("k")
+        .agg(vector_sum(col("v")).cast("string"), vector_avg(col("v")).cast("string"))
+        .orderBy("k").collect()
+      #expect(rows == [Row("a", "[4.0, 6.0]", "[2.0, 3.0]"), Row("b", "[5.0, 6.0]", "[5.0, 6.0]")])
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 7 vector functions (11 overloads).

| Function | Since | Signature |
| --- | --- | --- |
| `vector_cosine_similarity` | 4.3.0 | `(Column, Column)` |
| `vector_inner_product` | 4.3.0 | `(Column, Column)` |
| `vector_l2_distance` | 4.3.0 | `(Column, Column)` |
| `vector_norm` | 4.3.0 | `(Column)`, `(Column, Float \| Column)` |
| `vector_normalize` | 4.3.0 | `(Column)`, `(Column, Float \| Column)` |
| `vector_avg` | 4.3.0 | `(Column)` |
| `vector_sum` | 4.3.0 | `(Column)` |

The five scalar functions live in a new `VectorFunctions.swift`. The two aggregate functions,
`vector_avg` and `vector_sum`, are added to the existing `AggregateFunctions.swift`, following
the `schema_of_variant_agg` precedent, while their tests stay with the rest of the family in
`VectorFunctionsTests.swift`.

Despite the name, these functions take no dedicated `VECTOR` type. They operate on `ARRAY<FLOAT>`
columns, and all the vectors involved must have the same dimension.

The optional `degree` of `vector_norm` and `vector_normalize` is expressed as a Swift overload,
mirroring the two Scala overloads. In addition to the `Column` overload, a `Float` overload is
provided because the server requires exactly a `FLOAT` for this argument:

```
SELECT vector_norm(ARRAY(3.0f, 4.0f), CAST(1.0 AS DOUBLE))
[DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE] ... The second parameter requires the "FLOAT" type,
however "CAST(1.0 AS DOUBLE)" has the type "DOUBLE".
```

Since `lit(Double)` produces a `double` literal in this client, a `Double` overload would compile
and then fail at analysis time on the server. The `Float` overload keeps `vector_norm(v, 2.0)`
correct by construction, the same reasoning behind the `Int32` srid of `st_setsrid`.

### Why are the changes needed?

To support the vector functions of Apache Spark 4.3.0 and improve the API coverage.

### Does this PR introduce _any_ user-facing change?

No, this PR only adds new functions.

### How was this patch tested?

Pass the CIs with the newly added test suite, `VectorFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5