### PR TITLE
[SPARK-59237] Support `broadcast` function

### DIFF
--- a/Sources/SparkConnect/Functions.swift
+++ b/Sources/SparkConnect/Functions.swift
@@ -290,6 +290,19 @@ public func max(_ col: Column) -> Column {
   return fn("max", col)
 }
 
+/// Marks a ``DataFrame`` as small enough for use in broadcast joins.
+///
+/// The following example marks the right ``DataFrame`` for broadcast hash join.
+///
+/// ```swift
+/// let joined = await left.join(broadcast(right), "id")
+/// ```
+/// - Parameter df: A ``DataFrame`` to broadcast.
+/// - Returns: A ``DataFrame`` with a `broadcast` hint.
+public func broadcast(_ df: DataFrame) async -> DataFrame {
+  return await df.hint("broadcast")
+}
+
 func fn(_ name: String, _ args: Column...) -> Column {
   var function = Spark_Connect_Expression.UnresolvedFunction()
   function.functionName = name

--- a/Tests/SparkConnectTests/FunctionsTests.swift
+++ b/Tests/SparkConnectTests/FunctionsTests.swift
@@ -484,4 +484,24 @@ struct FunctionsTests {
     #expect(try await df.sort(col("v").descNullsFirst()).collect() == [Row(nil), Row(2), Row(1)])
     await spark.stop()
   }
+
+  @Test
+  func broadcastFunction() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await broadcast(spark.range(1))
+    let plan = await df.getPlan() as! Plan
+    #expect(plan.root.hint.name == "broadcast")
+    #expect(plan.root.hint.parameters.isEmpty)
+    await spark.stop()
+  }
+
+  @Test
+  func broadcastJoin() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df1 = try await spark.range(10)
+    let df2 = try await spark.range(5)
+    let joined = await df1.join(broadcast(df2), "id")
+    #expect(try await joined.count() == 5)
+    await spark.stop()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the `broadcast` function.

```swift
public func broadcast(_ df: DataFrame) async -> DataFrame
```

Unlike most functions in `Functions.swift`, `broadcast` takes a `DataFrame` and returns a `DataFrame` marked with a `broadcast` join hint, mirroring PySpark's `broadcast(df) -> df.hint("broadcast")` and Scala's `def broadcast[U](df: Dataset[U]): df.type`.

### Why are the changes needed?

For feature parity with Apache Spark. `broadcast` has been available since Apache Spark 1.6.0
in PySpark and is a commonly used hint for broadcast hash joins.

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds a new public function, `broadcast`.

```swift
let joined = await left.join(broadcast(right), "id")
```

### How was this patch tested?

Pass the CIs with the newly added test cases in `FunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5