### PR TITLE
[SPARK-59238] Support partition transform functions

### DIFF
--- a/Sources/SparkConnect/DataFrameWriterV2.swift
+++ b/Sources/SparkConnect/DataFrameWriterV2.swift
@@ -80,6 +80,16 @@ public actor DataFrameWriterV2: Sendable {
     return self
   }
 
+  /// Partition the output table created by `create`, `createOrReplace`, or `replace` using the
+  /// given columns or transforms like ``years(_:)``, ``months(_:)``, ``days(_:)``,
+  /// ``hours(_:)``, and ``bucket(_:_:)``.
+  /// - Parameter columns: Columns or transforms to partition
+  /// - Returns: A ``DataFrameWriterV2``.
+  public func partitionBy(_ columns: Column...) -> DataFrameWriterV2 {
+    self.partitioningColumns = columns.map { $0.expr }
+    return self
+  }
+
   /// Clusters the output by the given columns on the storage. The rows with matching values in the
   /// specified clustering columns will be consolidated within the same group.
   /// - Parameter columns: Columns to cluster

--- a/Sources/SparkConnect/PartitionTransforms.swift
+++ b/Sources/SparkConnect/PartitionTransforms.swift
@@ -1,0 +1,64 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+/// A transform for any type that partitions by a hash of the input column.
+/// - Parameters:
+///   - numBuckets: A ``Column`` that evaluates to the number of buckets. Must be a constant.
+///   - col: A ``Column`` of any type to partition.
+/// - Returns: A ``Column``.
+public func bucket(_ numBuckets: Column, _ col: Column) -> Column {
+  return fn("bucket", numBuckets, col)
+}
+
+/// A transform for any type that partitions by a hash of the input column.
+/// - Parameters:
+///   - numBuckets: A number of buckets.
+///   - col: A ``Column`` of any type to partition.
+/// - Returns: A ``Column``.
+public func bucket(_ numBuckets: Int32, _ col: Column) -> Column {
+  return fn("bucket", lit(numBuckets), col)
+}
+
+/// A transform for timestamps and dates to partition data into days.
+/// - Parameter col: A ``Column`` that evaluates to a date or a timestamp.
+/// - Returns: A ``Column``.
+public func days(_ col: Column) -> Column {
+  return fn("days", col)
+}
+
+/// A transform for timestamps to partition data into hours.
+/// - Parameter col: A ``Column`` that evaluates to a date or a timestamp.
+/// - Returns: A ``Column``.
+public func hours(_ col: Column) -> Column {
+  return fn("hours", col)
+}
+
+/// A transform for timestamps and dates to partition data into months.
+/// - Parameter col: A ``Column`` that evaluates to a date or a timestamp.
+/// - Returns: A ``Column``.
+public func months(_ col: Column) -> Column {
+  return fn("months", col)
+}
+
+/// A transform for timestamps and dates to partition data into years.
+/// - Parameter col: A ``Column`` that evaluates to a date or a timestamp.
+/// - Returns: A ``Column``.
+public func years(_ col: Column) -> Column {
+  return fn("years", col)
+}

--- a/Tests/SparkConnectTests/PartitionTransformsTests.swift
+++ b/Tests/SparkConnectTests/PartitionTransformsTests.swift
@@ -1,0 +1,76 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `PartitionTransforms`
+@Suite(.serialized)
+struct PartitionTransformsTests {
+  let icebergEnabled = ProcessInfo.processInfo.environment["SPARK_ICEBERG_TEST_ENABLED"] != nil
+
+  @Test
+  func partitionTransforms() throws {
+    for (column, name) in [
+      (days(col("a")), "days"),
+      (hours(col("a")), "hours"),
+      (months(col("a")), "months"),
+      (years(col("a")), "years"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == 1)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  @Test
+  func bucketFunction() throws {
+    for column in [bucket(4, col("a")), bucket(lit(Int32(4)), col("a"))] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == "bucket")
+      #expect(expr.unresolvedFunction.arguments.count == 2)
+      #expect(expr.unresolvedFunction.arguments[0].literal.integer == 4)
+      #expect(expr.unresolvedFunction.arguments[1].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  @Test
+  func partitionByTransform() async throws {
+    guard icebergEnabled else { return }
+    let spark = try await SparkSession.builder.getOrCreate()
+    let tableName = "TABLE_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    try await SQLHelper.withTable(spark, tableName)({
+      let df = try await spark.sql("SELECT TIMESTAMP'2026-09-03 01:02:03' AS ts, 1 AS value")
+      let write = await df.writeTo(tableName)
+        .partitionBy(years(col("ts")), bucket(4, col("value")))
+      try await write.create()
+      #expect(try await spark.table(tableName).count() == 1)
+      let ddl = try await spark.sql("SHOW CREATE TABLE \(tableName)").collect()[0].get(0) as! String
+      #expect(ddl.contains("PARTITIONED BY (years(ts), bucket(4, value))"))
+    })
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 5 partition transform functions in a new file,
`Sources/SparkConnect/PartitionTransforms.swift`, and to add a `Column`-based
`DataFrameWriterV2.partitionBy` overload so that these transforms can actually be used.

| Function | Since | Signature |
| --- | --- | --- |
| `bucket` | 3.1.0 | `(Column, Column)`, `(Int32, Column)` |
| `days` | 3.1.0 | `(Column)` |
| `hours` | 3.1.0 | `(Column)` |
| `months` | 3.1.0 | `(Column)` |
| `years` | 3.1.0 | `(Column)` |

Scala groups these under `@group partition_transforms` in `functions.scala`, so they are
placed in a dedicated file instead of `Functions.swift`. `bucket` takes an `Int32` overload
because PySpark accepts `Union[Column, int]` for `numBuckets`; the literal is wrapped with
`lit(...)`, matching `partitioning.bucket` in
`python/pyspark/sql/connect/functions/partitioning.py`.

In addition, `DataFrameWriterV2.partitionBy(_ columns: Column...)` is added. The existing
`partitionBy(_ columns: String...)` doc comment already claimed to accept "columns or
transforms", but only string column names could be passed, so there was no way to build a
`years(col("ts"))`-partitioned table.

### Why are the changes needed?

To improve API coverage and to make the partition transforms usable end to end.

### Does this PR introduce _any_ user-facing change?

No behavior change. Only `DataFrameWriterV2.partitionBy` gains a new `Column`-variadic overload. This is a pure addition; the existing `String`-variadic overload is unchanged, so no existing code breaks. The 5 functions themselves are new additions to the API.

### How was this patch tested?

Pass the CIs with the newly added test suite, `PartitionTransformsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5