### PR TITLE
[SPARK-59239] Support `counter_diff` window function

### DIFF
--- a/Sources/SparkConnect/WindowFunctions.swift
+++ b/Sources/SparkConnect/WindowFunctions.swift
@@ -17,6 +17,49 @@
 // under the License.
 //
 
+/// Computes the differences between consecutive cumulative counter values in a time series,
+/// thereby converting the counter from the cumulative to the delta format.
+///
+/// Gracefully handles counter resets by returning `NULL`. Counter resets are detected when the
+/// counter value decreases.
+///
+/// Use the `PARTITION BY` clause of the window to separate independent counters. This is done by
+/// specifying all columns which uniquely identify a time series. These are typically the counter
+/// name and any attributes tied to the counter.
+///
+/// Use the `ORDER BY` clause of the window to order the observations by the associated timestamp
+/// in ascending order.
+/// - Parameter value: A cumulative counter. Must be a numeric data type. Must be non-negative.
+/// - Returns: A ``Column`` of the same type as the input, holding the difference between the
+///   current and previous counter value within the window partition, according to the order
+///   defined by the window's `ORDER BY` clause.
+public func counter_diff(_ value: Column) -> Column {
+  return fn("counter_diff", value)
+}
+
+/// Computes the differences between consecutive cumulative counter values in a time series,
+/// thereby converting the counter from the cumulative to the delta format.
+///
+/// Gracefully handles counter resets by returning `NULL`. Counter resets are detected when the
+/// counter value decreases, or when the start time advances between rows.
+///
+/// Use the `PARTITION BY` clause of the window to separate independent counters. This is done by
+/// specifying all columns which uniquely identify a time series. These are typically the counter
+/// name and any attributes tied to the counter.
+///
+/// Use the `ORDER BY` clause of the window to order the observations by the associated timestamp
+/// in ascending order.
+/// - Parameters:
+///   - value: A cumulative counter. Must be a numeric data type. Must be non-negative.
+///   - startTime: A timestamp indicating when the counter was last set to zero. Used to signal
+///     counter resets.
+/// - Returns: A ``Column`` of the same type as the input, holding the difference between the
+///   current and previous counter value within the window partition, according to the order
+///   defined by the window's `ORDER BY` clause.
+public func counter_diff(_ value: Column, _ startTime: Column) -> Column {
+  return fn("counter_diff", value, startTime)
+}
+
 /// Returns the cumulative distribution of values within a window partition, i.e. the fraction
 /// of rows that are below the current row.
 /// - Returns: A ``Column``.

--- a/Tests/SparkConnectTests/WindowTests.swift
+++ b/Tests/SparkConnectTests/WindowTests.swift
@@ -43,6 +43,19 @@ struct WindowTests {
     #expect(ntile(4).expr.unresolvedFunction.arguments[0].literal.integer == 4)
 
     for (column, name, count) in [
+      (counter_diff(col("a")), "counter_diff", 1),
+      (counter_diff(col("a"), col("b")), "counter_diff", 2),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+    #expect(
+      counter_diff(col("a"), col("b")).expr.unresolvedFunction.arguments[1]
+        .unresolvedAttribute.unparsedIdentifier == "b")
+
+    for (column, name, count) in [
       (lag(col("a"), 1), "lag", 2),
       (lag(col("a"), 1, 0), "lag", 3),
       (lead(col("a"), 1), "lead", 2),
@@ -174,6 +187,25 @@ struct WindowTests {
         Row("a", 3, 2, -1, 2),
         Row("b", 10, nil, -1, nil),
       ])
+    await spark.stop()
+  }
+
+  @Test
+  func counterDiffOverWindow() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    guard await isSparkVersionAtLeast(spark.version, "4.3") else {
+      await spark.stop()
+      return
+    }
+    let df = try await spark.sql(
+      "SELECT * FROM VALUES ('a', 1, 10), ('a', 2, 30), ('a', 3, 20) AS t(name, ts, counter)")
+    let window = Window.partitionBy("name").orderBy("ts")
+    let rows = try await df
+      .withColumn("diff", counter_diff(col("counter")).over(window))
+      .orderBy("ts")
+      .select("ts", "diff")
+      .collect()
+    #expect(rows == [Row(1, nil), Row(2, 20), Row(3, nil)])
     await spark.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support the `counter_diff` window function.

```swift
public func counter_diff(_ value: Column) -> Column
public func counter_diff(_ value: Column, _ startTime: Column) -> Column
```

### Why are the changes needed?

For feature parity with Apache Spark, which added `counter_diff` in `4.3.0` It converts a cumulative counter time series into the delta format and gracefully handles counter resets by returning `NULL`.
- apache/spark#55828

### Does this PR introduce _any_ user-facing change?

No, this is a new function.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5