### PR TITLE
[SPARK-59240] Support `call_function` and `call_udf` functions

### DIFF
--- a/Sources/SparkConnect/UDFFunctions.swift
+++ b/Sources/SparkConnect/UDFFunctions.swift
@@ -1,0 +1,50 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - UDF functions
+
+/// Calls a SQL function.
+/// - Parameters:
+///   - funcName: A function name that follows the SQL identifier syntax
+///   (can be quoted, can be qualified).
+///   - cols: The expression parameters of the function.
+/// - Returns: A ``Column``.
+public func call_function(_ funcName: String, _ cols: Column...) -> Column {
+  return callFunction(funcName, cols)
+}
+
+/// Calls a user-defined function registered by SQL `CREATE FUNCTION`.
+/// This is an alias of ``call_function(_:_:)``.
+/// - Parameters:
+///   - udfName: A user-defined function name that follows the SQL identifier syntax
+///   (can be quoted, can be qualified).
+///   - cols: The expression parameters of the function.
+/// - Returns: A ``Column``.
+public func call_udf(_ udfName: String, _ cols: Column...) -> Column {
+  return callFunction(udfName, cols)
+}
+
+private func callFunction(_ funcName: String, _ cols: [Column]) -> Column {
+  var function = Spark_Connect_CallFunction()
+  function.functionName = funcName
+  function.arguments = cols.map { $0.expr }
+  var expr = Spark_Connect_Expression()
+  expr.callFunction = function
+  return Column(expr)
+}

--- a/Tests/SparkConnectTests/UDFFunctionsTests.swift
+++ b/Tests/SparkConnectTests/UDFFunctionsTests.swift
@@ -1,0 +1,72 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `UDFFunctions`
+@Suite(.serialized)
+struct UDFFunctionsTests {
+
+  @Test
+  func callFunctions() throws {
+    let expr = call_function("abs", col("a")).expr
+    #expect(expr.callFunction.functionName == "abs")
+    #expect(expr.callFunction.arguments.count == 1)
+    #expect(expr.callFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+
+    let udf = call_udf("default.simpleUDF", col("a"), col("b")).expr
+    #expect(udf.callFunction.functionName == "default.simpleUDF")
+    #expect(udf.callFunction.arguments.count == 2)
+  }
+
+  @Test
+  func selectCallFunction() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    #expect(try await df.select(call_function("abs", lit(-1))).collect() == [Row(1)])
+    #expect(
+      try await df.select(call_function("abs", lit(-1))).collect()
+        == df.select(abs(lit(-1))).collect())
+    await spark.stop()
+  }
+
+  @Test
+  func selectCallUDF() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let funcName = "FUNC_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    try await ErrorUtils.tryWithSafeFinally(
+      {
+        try await spark.sql(
+          "CREATE TEMPORARY FUNCTION \(funcName)(v INT) RETURNS INT RETURN v * v"
+        ).count()
+        #expect(try await spark.range(1).select(call_udf(funcName, lit(4))).collect() == [Row(16)])
+      },
+      {
+        try await spark.sql("DROP TEMPORARY FUNCTION IF EXISTS \(funcName)").count()
+      })
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `call_function` and `call_udf` functions in a new `UDFFunctions.swift` file.

| Function | Since | Signature |
| --- | --- | --- |
| `call_function` | 3.5.0 | `(String, Column...)` |
| `call_udf` | 3.4.0 | `(String, Column...)` |

Both are backed by the `CallFunction` protobuf node rather than the existing
internal `fn` helper which builds an `UnresolvedFunction`. This is intentional:
the server's `SparkConnectPlanner.transformUnresolvedFunction` treats the
function name of an `UnresolvedFunction` as a **single identifier** when
`is_user_defined_function` is `false`, which is what our `fn` helper produces.
That would break qualified names such as `call_function("db.my_func", ...)`.
In contrast, `SparkConnectPlanner.transformCallFunction` runs the name through
`parser.parseMultipartIdentifier`, so quoted and qualified names are resolved
correctly. This matches the documented Scala contract, "function name that
follows the SQL identifier syntax (can be quoted, can be qualified)", and
matches PySpark Connect, whose `call_function` also emits a `CallFunction` node.

`call_udf` delegates to `call_function`, mirroring Scala's
`functions.scala`, where `call_udf(udfName, cols: _*) = call_function(udfName, cols: _*)`.

### Why are the changes needed?

For feature parity with Apache Spark.

`call_function` is especially valuable in this client because it is a general
escape hatch: it lets users invoke any SQL function available on the server,
including the ones this library has not wrapped yet.

Although this repository does not provide a UDF registration API, `call_udf`
remains useful for invoking functions registered on the server through SQL
`CREATE FUNCTION`.

### Does this PR introduce _any_ user-facing change?

No, this simply adds two new functions.

### How was this patch tested?

Pass the CIs with the newly added test suite, `UDFFunctionsTests`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5