### PR TITLE
[SPARK-59241] Support Theta, KLL and Tuple sketch functions

### DIFF
--- a/Sources/SparkConnect/AggregateFunctions.swift
+++ b/Sources/SparkConnect/AggregateFunctions.swift
@@ -302,6 +302,215 @@ public func histogram_numeric(_ col: Column, _ nBins: Int32) -> Column {
   return fn("histogram_numeric", col, lit(nBins))
 }
 
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` that merges
+/// the `KllLongsSketch` values in a group. The merged sketch adopts the `k` of the first input
+/// sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameter col: A ``Column`` of binary `KllLongsSketch` representations to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_merge_agg_bigint(_ col: Column) -> Column {
+  return fn("kll_merge_agg_bigint", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` that merges
+/// the `KllLongsSketch` values in a group. The `k` parameter controls the size and accuracy of
+/// the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllLongsSketch` representations to aggregate.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_merge_agg_bigint(_ col: Column, _ k: Int32) -> Column {
+  return kll_merge_agg_bigint(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` that merges
+/// the `KllLongsSketch` values in a group. The `k` parameter controls the size and accuracy of
+/// the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllLongsSketch` representations to aggregate.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_merge_agg_bigint(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_merge_agg_bigint", col, k)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` that merges
+/// the `KllDoublesSketch` values in a group. The merged sketch adopts the `k` of the first
+/// input sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameter col: A ``Column`` of binary `KllDoublesSketch` representations to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_merge_agg_double(_ col: Column) -> Column {
+  return fn("kll_merge_agg_double", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` that merges
+/// the `KllDoublesSketch` values in a group. The `k` parameter controls the size and accuracy
+/// of the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllDoublesSketch` representations to aggregate.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_merge_agg_double(_ col: Column, _ k: Int32) -> Column {
+  return kll_merge_agg_double(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` that merges
+/// the `KllDoublesSketch` values in a group. The `k` parameter controls the size and accuracy
+/// of the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllDoublesSketch` representations to aggregate.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_merge_agg_double(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_merge_agg_double", col, k)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` that merges
+/// the `KllFloatsSketch` values in a group. The merged sketch adopts the `k` of the first input
+/// sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameter col: A ``Column`` of binary `KllFloatsSketch` representations to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_merge_agg_float(_ col: Column) -> Column {
+  return fn("kll_merge_agg_float", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` that merges
+/// the `KllFloatsSketch` values in a group. The `k` parameter controls the size and accuracy of
+/// the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllFloatsSketch` representations to aggregate.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_merge_agg_float(_ col: Column, _ k: Int32) -> Column {
+  return kll_merge_agg_float(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` that merges
+/// the `KllFloatsSketch` values in a group. The `k` parameter controls the size and accuracy of
+/// the sketch.
+/// This requires Apache Spark 4.1.2 or later.
+/// - Parameters:
+///   - col: A ``Column`` of binary `KllFloatsSketch` representations to aggregate.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_merge_agg_float(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_merge_agg_float", col, k)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` built from
+/// the long values in a group. The sketch uses the server-side default `k` of 200.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to a long.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_sketch_agg_bigint(_ col: Column) -> Column {
+  return fn("kll_sketch_agg_bigint", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` built from
+/// the long values in a group. The `k` parameter controls the size and accuracy of the sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a long.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_sketch_agg_bigint(_ col: Column, _ k: Int32) -> Column {
+  return kll_sketch_agg_bigint(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllLongsSketch` built from
+/// the long values in a group. The `k` parameter controls the size and accuracy of the sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a long.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_sketch_agg_bigint(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_sketch_agg_bigint", col, k)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` built from
+/// the double values in a group. The sketch uses the server-side default `k` of 200.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to a double.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_sketch_agg_double(_ col: Column) -> Column {
+  return fn("kll_sketch_agg_double", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` built from
+/// the double values in a group. The `k` parameter controls the size and accuracy of the
+/// sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a double.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_sketch_agg_double(_ col: Column, _ k: Int32) -> Column {
+  return kll_sketch_agg_double(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllDoublesSketch` built from
+/// the double values in a group. The `k` parameter controls the size and accuracy of the
+/// sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a double.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_sketch_agg_double(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_sketch_agg_double", col, k)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` built from
+/// the float values in a group. The sketch uses the server-side default `k` of 200.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to a float.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_sketch_agg_float(_ col: Column) -> Column {
+  return fn("kll_sketch_agg_float", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` built from
+/// the float values in a group. The `k` parameter controls the size and accuracy of the sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a float.
+///   - k: The parameter that controls the size and accuracy of the sketch. It must be between 8
+///     and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_sketch_agg_float(_ col: Column, _ k: Int32) -> Column {
+  return kll_sketch_agg_float(col, lit(k))
+}
+
+/// Returns the compact binary representation of the Datasketches `KllFloatsSketch` built from
+/// the float values in a group. The `k` parameter controls the size and accuracy of the sketch.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to a float.
+///   - k: A ``Column`` that evaluates to the parameter that controls the size and accuracy of
+///     the sketch. It must be a constant between 8 and 65535.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_sketch_agg_float(_ col: Column, _ k: Column) -> Column {
+  return fn("kll_sketch_agg_float", col, k)
+}
+
 /// Returns the kurtosis of the values in a group.
 /// - Parameter col: A ``Column`` to aggregate.
 /// - Returns: A ``Column``.
@@ -656,6 +865,84 @@ public func sum_distinct(_ col: Column) -> Column {
   return fn("sum", [col], isDistinct: true)
 }
 
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` that is the
+/// intersection of the Theta sketches in a group.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` of Theta sketches to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_intersection_agg(_ col: Column) -> Column {
+  return fn("theta_intersection_agg", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` built from the
+/// values in a group, using the server-side default of 12 nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to an array, binary, double, float, integer,
+///   long, or string.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_sketch_agg(_ col: Column) -> Column {
+  return fn("theta_sketch_agg", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` built from the
+/// values in a group, configured with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. Must be between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_sketch_agg(_ col: Column, _ lgNomEntries: Int32) -> Column {
+  return theta_sketch_agg(col, lit(lgNomEntries))
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` built from the
+/// values in a group, configured with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. Must be a constant between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_sketch_agg(_ col: Column, _ lgNomEntries: Column) -> Column {
+  return fn("theta_sketch_agg", col, lgNomEntries)
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` that is the union
+/// of the Theta sketches in a group, using the server-side default of 12 nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` of Theta sketches to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union_agg(_ col: Column) -> Column {
+  return fn("theta_union_agg", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` that is the union
+/// of the Theta sketches in a group, configured with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of Theta sketches to aggregate.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries used by the union
+///     operation. Must be between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union_agg(_ col: Column, _ lgNomEntries: Int32) -> Column {
+  return theta_union_agg(col, lit(lgNomEntries))
+}
+
+/// Returns the compact binary representation of the Datasketches `ThetaSketch` that is the union
+/// of the Theta sketches in a group, configured with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of Theta sketches to aggregate.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries used by the union operation. Must be a constant between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union_agg(_ col: Column, _ lgNomEntries: Column) -> Column {
+  return fn("theta_union_agg", col, lgNomEntries)
+}
+
 /// Returns the mean calculated from values of a group and `null` on overflow.
 /// - Parameter col: A ``Column`` to aggregate.
 /// - Returns: A ``Column``.
@@ -668,6 +955,198 @@ public func try_avg(_ col: Column) -> Column {
 /// - Returns: A ``Column``.
 public func try_sum(_ col: Column) -> Column {
   return fn("try_sum", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries that is the intersection of the Tuple sketches in a group. The server-side default
+/// summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` of `TupleSketch` objects with double summaries to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_agg_double(_ col: Column) -> Column {
+  return fn("tuple_intersection_agg_double", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries that is the intersection of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with double summaries to aggregate.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_agg_double(_ col: Column, mode: Column) -> Column {
+  return fn("tuple_intersection_agg_double", col, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries that is the intersection of the Tuple sketches in a group. The server-side default
+/// summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` of `TupleSketch` objects with integer summaries to aggregate.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_agg_integer(_ col: Column) -> Column {
+  return fn("tuple_intersection_agg_integer", col)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries that is the intersection of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with integer summaries to aggregate.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_agg_integer(_ col: Column, mode: Column) -> Column {
+  return fn("tuple_intersection_agg_integer", col, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries built from the key and summary values in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - key: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - summary: A ``Column`` that evaluates to a double.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_sketch_agg_double(
+  _ key: Column, _ summary: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_sketch_agg_double", key, summary, lgNomEntries, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries built from the key and summary values in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - key: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - summary: A ``Column`` that evaluates to a double.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_sketch_agg_double(
+  _ key: Column, _ summary: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_sketch_agg_double(key, summary, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries built from the key and summary values in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - key: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - summary: A ``Column`` that evaluates to an integer.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_sketch_agg_integer(
+  _ key: Column, _ summary: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_sketch_agg_integer", key, summary, lgNomEntries, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries built from the key and summary values in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - key: A ``Column`` that evaluates to an array, binary, double, float, integer, long, or
+///     string.
+///   - summary: A ``Column`` that evaluates to an integer.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_sketch_agg_integer(
+  _ key: Column, _ summary: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_sketch_agg_integer(key, summary, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries that is the union of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with double summaries to aggregate.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_agg_double(
+  _ col: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_agg_double", col, lgNomEntries, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with double
+/// summaries that is the union of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with double summaries to aggregate.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_agg_double(
+  _ col: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_agg_double(col, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries that is the union of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with integer summaries to aggregate.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_agg_integer(
+  _ col: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_agg_integer", col, lgNomEntries, mode)
+}
+
+/// Returns the compact binary representation of the Datasketches `TupleSketch` with integer
+/// summaries that is the union of the Tuple sketches in a group.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` of `TupleSketch` objects with integer summaries to aggregate.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_agg_integer(
+  _ col: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_agg_integer(col, lgNomEntries: lit(lgNomEntries), mode: mode)
 }
 
 /// Returns the population variance of the values in a group.

--- a/Sources/SparkConnect/KllSketchFunctions.swift
+++ b/Sources/SparkConnect/KllSketchFunctions.swift
@@ -1,0 +1,184 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - KLL sketch functions
+//
+// These functions operate on the compact binary representation of a Datasketches KLL sketch, a
+// probabilistic data structure that estimates quantiles and ranks of a data set. The estimates
+// are approximate. There is one sketch per element type: `KllLongsSketch` (`_bigint`),
+// `KllDoublesSketch` (`_double`) and `KllFloatsSketch` (`_float`). Sketches are produced by the
+// `kll_sketch_agg_*` and `kll_merge_agg_*` aggregate functions in `AggregateFunctions.swift`.
+
+/// Returns the number of items collected in a Datasketches `KllLongsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllLongsSketch`.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func kll_sketch_get_n_bigint(_ col: Column) -> Column {
+  return fn("kll_sketch_get_n_bigint", col)
+}
+
+/// Returns the number of items collected in a Datasketches `KllDoublesSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllDoublesSketch`.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func kll_sketch_get_n_double(_ col: Column) -> Column {
+  return fn("kll_sketch_get_n_double", col)
+}
+
+/// Returns the number of items collected in a Datasketches `KllFloatsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllFloatsSketch`.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func kll_sketch_get_n_float(_ col: Column) -> Column {
+  return fn("kll_sketch_get_n_float", col)
+}
+
+/// Returns the quantile value of a Datasketches `KllLongsSketch` at the given `rank`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+///   - rank: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///     ranks. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a long, or to an array of longs when `rank` is an
+///   array.
+public func kll_sketch_get_quantile_bigint(_ sketch: Column, _ rank: Column) -> Column {
+  return fn("kll_sketch_get_quantile_bigint", sketch, rank)
+}
+
+/// Returns the quantile value of a Datasketches `KllDoublesSketch` at the given `rank`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a
+///     `KllDoublesSketch`.
+///   - rank: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///     ranks. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a double, or to an array of doubles when `rank` is
+///   an array.
+public func kll_sketch_get_quantile_double(_ sketch: Column, _ rank: Column) -> Column {
+  return fn("kll_sketch_get_quantile_double", sketch, rank)
+}
+
+/// Returns the quantile value of a Datasketches `KllFloatsSketch` at the given `rank`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+///   - rank: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///     ranks. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a float, or to an array of floats when `rank` is
+///   an array.
+public func kll_sketch_get_quantile_float(_ sketch: Column, _ rank: Column) -> Column {
+  return fn("kll_sketch_get_quantile_float", sketch, rank)
+}
+
+/// Returns the rank of the given `quantile` value in a Datasketches `KllLongsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+///   - quantile: A ``Column`` that evaluates to a long, or to an array of longs, to look up. It
+///     must be a constant.
+/// - Returns: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///   ranks when `quantile` is an array.
+public func kll_sketch_get_rank_bigint(_ sketch: Column, _ quantile: Column) -> Column {
+  return fn("kll_sketch_get_rank_bigint", sketch, quantile)
+}
+
+/// Returns the rank of the given `quantile` value in a Datasketches `KllDoublesSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a
+///     `KllDoublesSketch`.
+///   - quantile: A ``Column`` that evaluates to a double, or to an array of doubles, to look
+///     up. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///   ranks when `quantile` is an array.
+public func kll_sketch_get_rank_double(_ sketch: Column, _ quantile: Column) -> Column {
+  return fn("kll_sketch_get_rank_double", sketch, quantile)
+}
+
+/// Returns the rank of the given `quantile` value in a Datasketches `KllFloatsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - sketch: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+///   - quantile: A ``Column`` that evaluates to a float, or to an array of floats, to look up.
+///     It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a rank between 0.0 and 1.0, or to an array of such
+///   ranks when `quantile` is an array.
+public func kll_sketch_get_rank_float(_ sketch: Column, _ quantile: Column) -> Column {
+  return fn("kll_sketch_get_rank_float", sketch, quantile)
+}
+
+/// Merges two Datasketches `KllLongsSketch` buffers into one.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - left: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+///   - right: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllLongsSketch`.
+public func kll_sketch_merge_bigint(_ left: Column, _ right: Column) -> Column {
+  return fn("kll_sketch_merge_bigint", left, right)
+}
+
+/// Merges two Datasketches `KllDoublesSketch` buffers into one.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - left: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+///   - right: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllDoublesSketch`.
+public func kll_sketch_merge_double(_ left: Column, _ right: Column) -> Column {
+  return fn("kll_sketch_merge_double", left, right)
+}
+
+/// Merges two Datasketches `KllFloatsSketch` buffers into one.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - left: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+///   - right: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `KllFloatsSketch`.
+public func kll_sketch_merge_float(_ left: Column, _ right: Column) -> Column {
+  return fn("kll_sketch_merge_float", left, right)
+}
+
+/// Returns a human readable summary of a Datasketches `KllLongsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllLongsSketch`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func kll_sketch_to_string_bigint(_ col: Column) -> Column {
+  return fn("kll_sketch_to_string_bigint", col)
+}
+
+/// Returns a human readable summary of a Datasketches `KllDoublesSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllDoublesSketch`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func kll_sketch_to_string_double(_ col: Column) -> Column {
+  return fn("kll_sketch_to_string_double", col)
+}
+
+/// Returns a human readable summary of a Datasketches `KllFloatsSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `KllFloatsSketch`.
+/// - Returns: A ``Column`` that evaluates to a string.
+public func kll_sketch_to_string_float(_ col: Column) -> Column {
+  return fn("kll_sketch_to_string_float", col)
+}

--- a/Sources/SparkConnect/ThetaSketchFunctions.swift
+++ b/Sources/SparkConnect/ThetaSketchFunctions.swift
@@ -1,0 +1,94 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Theta sketch functions
+//
+// These functions operate on the compact binary representation of a Datasketches `ThetaSketch`,
+// a probabilistic data structure that estimates the number of distinct values in a data set and
+// supports set operations. The estimates are approximate. Sketches are produced by the
+// ``theta_sketch_agg(_:)``, ``theta_union_agg(_:)`` and ``theta_intersection_agg(_:)`` aggregate
+// functions in `AggregateFunctions.swift`.
+
+/// Returns the set difference of two Datasketches `ThetaSketch` objects, that is the elements
+/// that are in `col1` but not in `col2`, using a Datasketches `AnotB` object.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch` to
+///     subtract from `col1`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_difference(_ col1: Column, _ col2: Column) -> Column {
+  return fn("theta_difference", col1, col2)
+}
+
+/// Returns the intersection of two Datasketches `ThetaSketch` objects, using a Datasketches
+/// `Intersection` object.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_intersection(_ col1: Column, _ col2: Column) -> Column {
+  return fn("theta_intersection", col1, col2)
+}
+
+/// Returns the estimated number of unique values in a Datasketches `ThetaSketch`.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+/// - Returns: A ``Column`` that evaluates to the estimated number of unique values.
+public func theta_sketch_estimate(_ col: Column) -> Column {
+  return fn("theta_sketch_estimate", col)
+}
+
+/// Merges two Datasketches `ThetaSketch` objects using a Datasketches `Union` object, using the
+/// server-side default of 12 nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union(_ col1: Column, _ col2: Column) -> Column {
+  return fn("theta_union", col1, col2)
+}
+
+/// Merges two Datasketches `ThetaSketch` objects using a Datasketches `Union` object configured
+/// with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries used by the union
+///     operation. Must be between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union(_ col1: Column, _ col2: Column, _ lgNomEntries: Int32) -> Column {
+  return theta_union(col1, col2, lit(lgNomEntries))
+}
+
+/// Merges two Datasketches `ThetaSketch` objects using a Datasketches `Union` object configured
+/// with `lgNomEntries` nominal entries.
+/// This requires Apache Spark 4.1.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries used by the union operation. Must be a constant between 4 and 26.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+public func theta_union(_ col1: Column, _ col2: Column, _ lgNomEntries: Column) -> Column {
+  return fn("theta_union", col1, col2, lgNomEntries)
+}

--- a/Sources/SparkConnect/TupleSketchFunctions.swift
+++ b/Sources/SparkConnect/TupleSketchFunctions.swift
@@ -1,0 +1,405 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+// MARK: - Tuple sketch functions
+//
+// These functions operate on the compact binary representation of a Datasketches `TupleSketch`,
+// a probabilistic data structure that estimates the number of distinct keys in a data set while
+// carrying a summary value per key, and supports set operations. The estimates are approximate.
+// There is one sketch per summary type, `_double` and `_integer`, and the `_theta` variants
+// combine a `TupleSketch` with a `ThetaSketch` produced by the functions in
+// `ThetaSketchFunctions.swift`. Sketches are produced by the `tuple_sketch_agg_*`,
+// `tuple_union_agg_*` and `tuple_intersection_agg_*` aggregate functions in
+// `AggregateFunctions.swift`.
+
+/// Returns the set difference of two Datasketches `TupleSketch` with double summaries objects,
+/// that is the entries whose keys are in `col1` but not in `col2`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch` to
+///     subtract from `col1`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_difference_double(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_difference_double", col1, col2)
+}
+
+/// Returns the set difference of two Datasketches `TupleSketch` with integer summaries objects,
+/// that is the entries whose keys are in `col1` but not in `col2`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch` to
+///     subtract from `col1`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_difference_integer(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_difference_integer", col1, col2)
+}
+
+/// Returns the set difference of a Datasketches `TupleSketch` with double summaries and a
+/// Datasketches `ThetaSketch`, that is the entries of `col1` whose keys are not in `col2`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch` to
+///     subtract from `col1`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_difference_theta_double(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_difference_theta_double", col1, col2)
+}
+
+/// Returns the set difference of a Datasketches `TupleSketch` with integer summaries and a
+/// Datasketches `ThetaSketch`, that is the entries of `col1` whose keys are not in `col2`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch` to
+///     subtract from `col1`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_difference_theta_integer(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_difference_theta_integer", col1, col2)
+}
+
+/// Returns the intersection of two Datasketches `TupleSketch` with double summaries objects.
+/// The server-side default summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_double(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_intersection_double", col1, col2)
+}
+
+/// Returns the intersection of two Datasketches `TupleSketch` with double summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_double(_ col1: Column, _ col2: Column, mode: Column) -> Column {
+  return fn("tuple_intersection_double", col1, col2, mode)
+}
+
+/// Returns the intersection of two Datasketches `TupleSketch` with integer summaries objects.
+/// The server-side default summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_integer(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_intersection_integer", col1, col2)
+}
+
+/// Returns the intersection of two Datasketches `TupleSketch` with integer summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_integer(_ col1: Column, _ col2: Column, mode: Column) -> Column {
+  return fn("tuple_intersection_integer", col1, col2, mode)
+}
+
+/// Returns the intersection of a Datasketches `TupleSketch` with double summaries and a
+/// Datasketches `ThetaSketch`. The server-side default summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_theta_double(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_intersection_theta_double", col1, col2)
+}
+
+/// Returns the intersection of a Datasketches `TupleSketch` with double summaries and a
+/// Datasketches `ThetaSketch`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_theta_double(
+  _ col1: Column, _ col2: Column, mode: Column
+) -> Column {
+  return fn("tuple_intersection_theta_double", col1, col2, mode)
+}
+
+/// Returns the intersection of a Datasketches `TupleSketch` with integer summaries and a
+/// Datasketches `ThetaSketch`. The server-side default summary mode `sum` is used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_theta_integer(_ col1: Column, _ col2: Column) -> Column {
+  return fn("tuple_intersection_theta_integer", col1, col2)
+}
+
+/// Returns the intersection of a Datasketches `TupleSketch` with integer summaries and a
+/// Datasketches `ThetaSketch`.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_intersection_theta_integer(
+  _ col1: Column, _ col2: Column, mode: Column
+) -> Column {
+  return fn("tuple_intersection_theta_integer", col1, col2, mode)
+}
+
+/// Returns the estimated number of unique keys in a Datasketches `TupleSketch` with double
+/// summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_estimate_double(_ col: Column) -> Column {
+  return fn("tuple_sketch_estimate_double", col)
+}
+
+/// Returns the estimated number of unique keys in a Datasketches `TupleSketch` with integer
+/// summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_estimate_integer(_ col: Column) -> Column {
+  return fn("tuple_sketch_estimate_integer", col)
+}
+
+/// Returns the summary value of a Datasketches `TupleSketch` with double summaries, combining
+/// the retained summaries with the given mode. The server-side default summary mode `sum` is
+/// used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_summary_double(_ col: Column) -> Column {
+  return fn("tuple_sketch_summary_double", col)
+}
+
+/// Returns the summary value of a Datasketches `TupleSketch` with double summaries, combining
+/// the retained summaries with the given mode.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_summary_double(_ col: Column, mode: Column) -> Column {
+  return fn("tuple_sketch_summary_double", col, mode)
+}
+
+/// Returns the summary value of a Datasketches `TupleSketch` with integer summaries, combining
+/// the retained summaries with the given mode. The server-side default summary mode `sum` is
+/// used.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func tuple_sketch_summary_integer(_ col: Column) -> Column {
+  return fn("tuple_sketch_summary_integer", col)
+}
+
+/// Returns the summary value of a Datasketches `TupleSketch` with integer summaries, combining
+/// the retained summaries with the given mode.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant.
+/// - Returns: A ``Column`` that evaluates to a long.
+public func tuple_sketch_summary_integer(_ col: Column, mode: Column) -> Column {
+  return fn("tuple_sketch_summary_integer", col, mode)
+}
+
+/// Returns the theta value of a Datasketches `TupleSketch` with double summaries, that is the
+/// fraction of the key space that the sketch retains.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_theta_double(_ col: Column) -> Column {
+  return fn("tuple_sketch_theta_double", col)
+}
+
+/// Returns the theta value of a Datasketches `TupleSketch` with integer summaries, that is the
+/// fraction of the key space that the sketch retains.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameter col: A ``Column`` that evaluates to the binary representation of a
+///   `TupleSketch`.
+/// - Returns: A ``Column`` that evaluates to a double.
+public func tuple_sketch_theta_integer(_ col: Column) -> Column {
+  return fn("tuple_sketch_theta_integer", col)
+}
+
+/// Merges two Datasketches `TupleSketch` with double summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_double(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_double", col1, col2, lgNomEntries, mode)
+}
+
+/// Merges two Datasketches `TupleSketch` with double summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_double(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_double(col1, col2, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Merges two Datasketches `TupleSketch` with integer summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_integer(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_integer", col1, col2, lgNomEntries, mode)
+}
+
+/// Merges two Datasketches `TupleSketch` with integer summaries objects.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_integer(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_integer(col1, col2, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Merges a Datasketches `TupleSketch` with double summaries and a Datasketches `ThetaSketch`
+/// into a `TupleSketch` with double summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_theta_double(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_theta_double", col1, col2, lgNomEntries, mode)
+}
+
+/// Merges a Datasketches `TupleSketch` with double summaries and a Datasketches `ThetaSketch`
+/// into a `TupleSketch` with double summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_theta_double(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_theta_double(col1, col2, lgNomEntries: lit(lgNomEntries), mode: mode)
+}
+
+/// Merges a Datasketches `TupleSketch` with integer summaries and a Datasketches `ThetaSketch`
+/// into a `TupleSketch` with integer summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: A ``Column`` that evaluates to the log-base-2 of the number of nominal
+///     entries, which is the size of the sketch. It must be between 4 and 26, and defaults to
+///     12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_theta_integer(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Column = lit(Int32(12)), mode: Column = lit("sum")
+) -> Column {
+  return fn("tuple_union_theta_integer", col1, col2, lgNomEntries, mode)
+}
+
+/// Merges a Datasketches `TupleSketch` with integer summaries and a Datasketches `ThetaSketch`
+/// into a `TupleSketch` with integer summaries.
+/// This requires Apache Spark 4.2.0 or later.
+/// - Parameters:
+///   - col1: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+///   - col2: A ``Column`` that evaluates to the binary representation of a `ThetaSketch`.
+///   - lgNomEntries: The log-base-2 of the number of nominal entries, which is the size of the
+///     sketch. It must be between 4 and 26, and defaults to 12.
+///   - mode: A ``Column`` that evaluates to the summary mode, one of `sum`, `min`, `max` or
+///     `alwaysone`. It must be a constant. It defaults to `sum`.
+/// - Returns: A ``Column`` that evaluates to the binary representation of a `TupleSketch`.
+public func tuple_union_theta_integer(
+  _ col1: Column, _ col2: Column,
+  lgNomEntries: Int32, mode: Column = lit("sum")
+) -> Column {
+  return tuple_union_theta_integer(col1, col2, lgNomEntries: lit(lgNomEntries), mode: mode)
+}

--- a/Tests/SparkConnectTests/KllSketchFunctionsTests.swift
+++ b/Tests/SparkConnectTests/KllSketchFunctionsTests.swift
@@ -1,0 +1,197 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for KLL sketch functions
+@Suite(.serialized)
+struct KllSketchFunctionsTests {
+
+  @Test
+  func kllSketchFunctions() throws {
+    for (column, name, count) in [
+      (kll_sketch_agg_bigint(col("a")), "kll_sketch_agg_bigint", 1),
+      (kll_sketch_agg_bigint(col("a"), lit(Int32(300))), "kll_sketch_agg_bigint", 2),
+      (kll_merge_agg_bigint(col("a")), "kll_merge_agg_bigint", 1),
+      (kll_merge_agg_bigint(col("a"), lit(Int32(300))), "kll_merge_agg_bigint", 2),
+      (kll_sketch_get_n_bigint(col("a")), "kll_sketch_get_n_bigint", 1),
+      (kll_sketch_get_quantile_bigint(col("a"), col("b")), "kll_sketch_get_quantile_bigint", 2),
+      (kll_sketch_get_rank_bigint(col("a"), col("b")), "kll_sketch_get_rank_bigint", 2),
+      (kll_sketch_merge_bigint(col("a"), col("b")), "kll_sketch_merge_bigint", 2),
+      (kll_sketch_to_string_bigint(col("a")), "kll_sketch_to_string_bigint", 1),
+      (kll_sketch_agg_double(col("a")), "kll_sketch_agg_double", 1),
+      (kll_sketch_agg_double(col("a"), lit(Int32(300))), "kll_sketch_agg_double", 2),
+      (kll_merge_agg_double(col("a")), "kll_merge_agg_double", 1),
+      (kll_merge_agg_double(col("a"), lit(Int32(300))), "kll_merge_agg_double", 2),
+      (kll_sketch_get_n_double(col("a")), "kll_sketch_get_n_double", 1),
+      (kll_sketch_get_quantile_double(col("a"), col("b")), "kll_sketch_get_quantile_double", 2),
+      (kll_sketch_get_rank_double(col("a"), col("b")), "kll_sketch_get_rank_double", 2),
+      (kll_sketch_merge_double(col("a"), col("b")), "kll_sketch_merge_double", 2),
+      (kll_sketch_to_string_double(col("a")), "kll_sketch_to_string_double", 1),
+      (kll_sketch_agg_float(col("a")), "kll_sketch_agg_float", 1),
+      (kll_sketch_agg_float(col("a"), lit(Int32(300))), "kll_sketch_agg_float", 2),
+      (kll_merge_agg_float(col("a")), "kll_merge_agg_float", 1),
+      (kll_merge_agg_float(col("a"), lit(Int32(300))), "kll_merge_agg_float", 2),
+      (kll_sketch_get_n_float(col("a")), "kll_sketch_get_n_float", 1),
+      (kll_sketch_get_quantile_float(col("a"), col("b")), "kll_sketch_get_quantile_float", 2),
+      (kll_sketch_get_rank_float(col("a"), col("b")), "kll_sketch_get_rank_float", 2),
+      (kll_sketch_merge_float(col("a"), col("b")), "kll_sketch_merge_float", 2),
+      (kll_sketch_to_string_float(col("a")), "kll_sketch_to_string_float", 1),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// An `Int32` `k` is a shorthand for a literal ``Column``. The server requires the `INT` type
+  /// here, so the literal must not be a `BIGINT`.
+  @Test
+  func kllK() throws {
+    for (column, name) in [
+      (kll_sketch_agg_bigint(col("a"), 300), "kll_sketch_agg_bigint"),
+      (kll_merge_agg_bigint(col("a"), 300), "kll_merge_agg_bigint"),
+      (kll_sketch_agg_double(col("a"), 300), "kll_sketch_agg_double"),
+      (kll_merge_agg_double(col("a"), 300), "kll_merge_agg_double"),
+      (kll_sketch_agg_float(col("a"), 300), "kll_sketch_agg_float"),
+      (kll_merge_agg_float(col("a"), 300), "kll_merge_agg_float"),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[1].literal.integer == 300)
+    }
+  }
+
+  /// The sketches are exact here because five items fit well within the default `k` of 200.
+  @Test
+  func kllSketchAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (4), (5) AS T(v)")
+      let sketches = await df.select(
+        kll_sketch_agg_bigint(col("v")).alias("b"),
+        kll_sketch_agg_double(col("v").cast("DOUBLE")).alias("d"),
+        kll_sketch_agg_float(col("v").cast("FLOAT"), 300).alias("f")
+      )
+      let rows = try await sketches.select(
+        kll_sketch_get_n_bigint(col("b")),
+        kll_sketch_get_n_double(col("d")),
+        kll_sketch_get_n_float(col("f")),
+        kll_sketch_get_quantile_bigint(col("b"), lit(0.5)),
+        kll_sketch_get_quantile_double(col("d"), lit(0.5)),
+        kll_sketch_get_quantile_float(col("f"), lit(0.5)),
+        kll_sketch_get_rank_bigint(col("b"), lit(3)),
+        kll_sketch_get_rank_double(col("d"), lit(3.0)),
+        kll_sketch_get_rank_float(col("f"), lit(Float(3.0)))
+      ).collect()
+      #expect(
+        rows == [
+          Row(
+            Int64(5), Int64(5), Int64(5), Int64(3), 3.0, Float(3.0),
+            0.6, 0.6, 0.6)
+        ])
+    }
+    await spark.stop()
+  }
+
+  /// A `rank` or `quantile` array yields an array of results.
+  @Test
+  func kllSketchArrayArgument() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (4), (5) AS T(v)")
+      let sketches = await df.select(kll_sketch_agg_bigint(col("v")).alias("b"))
+      let rows = try await sketches.select(
+        kll_sketch_get_quantile_bigint(col("b"), array(lit(0.5), lit(1.0))).cast("STRING"),
+        kll_sketch_get_rank_bigint(col("b"), array(lit(2), lit(4))).cast("STRING")
+      ).collect()
+      #expect(rows == [Row("[3, 5]", "[0.4, 0.8]")])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func kllSketchMerge() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (4), (5) AS T(v)")
+      let sketches = await df.select(
+        kll_sketch_agg_bigint(col("v")).alias("b"),
+        kll_sketch_agg_double(col("v").cast("DOUBLE")).alias("d"),
+        kll_sketch_agg_float(col("v").cast("FLOAT")).alias("f")
+      )
+      let rows = try await sketches.select(
+        kll_sketch_get_n_bigint(kll_sketch_merge_bigint(col("b"), col("b"))),
+        kll_sketch_get_n_double(kll_sketch_merge_double(col("d"), col("d"))),
+        kll_sketch_get_n_float(kll_sketch_merge_float(col("f"), col("f")))
+      ).collect()
+      #expect(rows == [Row(Int64(10), Int64(10), Int64(10))])
+    }
+    await spark.stop()
+  }
+
+  /// `kll_merge_agg_*` is introduced later than the other KLL functions.
+  @Test
+  func kllMergeAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1.2") {
+      let df = try await spark.sql(
+        """
+        SELECT kll_sketch_agg_bigint(v) AS sketch FROM VALUES (1), (2), (3) AS T(v)
+        UNION ALL
+        SELECT kll_sketch_agg_bigint(v) AS sketch FROM VALUES (4), (5), (6) AS T(v)
+        """)
+      let rows = try await df.select(
+        kll_sketch_get_n_bigint(kll_merge_agg_bigint(col("sketch"))),
+        kll_sketch_get_n_bigint(kll_merge_agg_bigint(col("sketch"), 300)),
+        kll_sketch_get_n_bigint(kll_merge_agg_bigint(col("sketch"), lit(Int32(300))))
+      ).collect()
+      #expect(rows == [Row(Int64(6), Int64(6), Int64(6))])
+    }
+    await spark.stop()
+  }
+
+  /// The summary is a human readable string, so only its shape is checked.
+  @Test
+  func kllSketchToString() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (3), (4), (5) AS T(v)")
+      let sketches = await df.select(
+        kll_sketch_agg_bigint(col("v")).alias("b"),
+        kll_sketch_agg_double(col("v").cast("DOUBLE")).alias("d"),
+        kll_sketch_agg_float(col("v").cast("FLOAT")).alias("f")
+      )
+      let rows = try await sketches.select(
+        kll_sketch_to_string_bigint(col("b")),
+        kll_sketch_to_string_double(col("d")),
+        kll_sketch_to_string_float(col("f"))
+      ).collect()
+      #expect(rows.count == 1)
+      for i in 0..<3 {
+        let summary = try #require(rows[0][i] as? String)
+        #expect(summary.contains("Summary"))
+      }
+    }
+    await spark.stop()
+  }
+}

--- a/Tests/SparkConnectTests/ThetaSketchFunctionsTests.swift
+++ b/Tests/SparkConnectTests/ThetaSketchFunctionsTests.swift
@@ -1,0 +1,117 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for Theta sketch functions
+@Suite(.serialized)
+struct ThetaSketchFunctionsTests {
+
+  @Test
+  func thetaSketchFunctions() throws {
+    for (column, name, count) in [
+      (theta_sketch_agg(col("a")), "theta_sketch_agg", 1),
+      (theta_sketch_agg(col("a"), lit(Int32(15))), "theta_sketch_agg", 2),
+      (theta_union_agg(col("a")), "theta_union_agg", 1),
+      (theta_union_agg(col("a"), lit(Int32(15))), "theta_union_agg", 2),
+      (theta_intersection_agg(col("a")), "theta_intersection_agg", 1),
+      (theta_sketch_estimate(col("a")), "theta_sketch_estimate", 1),
+      (theta_union(col("a"), col("b")), "theta_union", 2),
+      (theta_union(col("a"), col("b"), lit(Int32(15))), "theta_union", 3),
+      (theta_intersection(col("a"), col("b")), "theta_intersection", 2),
+      (theta_difference(col("a"), col("b")), "theta_difference", 2),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// An `Int32` `lgNomEntries` is a shorthand for a literal ``Column``. The server requires the
+  /// `INT` type here, so the literal must not be a `BIGINT`.
+  @Test
+  func thetaLgNomEntries() throws {
+    for (column, name, index) in [
+      (theta_sketch_agg(col("a"), 15), "theta_sketch_agg", 1),
+      (theta_union_agg(col("a"), 15), "theta_union_agg", 1),
+      (theta_union(col("a"), col("b"), 15), "theta_union", 2),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[index].literal.integer == 15)
+    }
+  }
+
+  @Test
+  func thetaSketchAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (2), (3) AS T(v)")
+      let rows = try await df.select(
+        theta_sketch_estimate(theta_sketch_agg(col("v"))),
+        theta_sketch_estimate(theta_sketch_agg(col("v"), 15)),
+        theta_sketch_estimate(theta_sketch_agg(col("v"), lit(Int32(15))))
+      ).collect()
+      #expect(rows == [Row(Int64(3), Int64(3), Int64(3))])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func thetaUnionAndIntersectionAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql(
+        """
+        SELECT theta_sketch_agg(v) AS sketch FROM VALUES (1), (2), (2), (3) AS T(v)
+        UNION ALL
+        SELECT theta_sketch_agg(v) AS sketch FROM VALUES (2), (3), (3), (4) AS T(v)
+        """)
+      let rows = try await df.select(
+        theta_sketch_estimate(theta_union_agg(col("sketch"))),
+        theta_sketch_estimate(theta_union_agg(col("sketch"), 15)),
+        theta_sketch_estimate(theta_intersection_agg(col("sketch")))
+      ).collect()
+      #expect(rows == [Row(Int64(4), Int64(4), Int64(2))])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func thetaSetOperations() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.1") {
+      let df = try await spark.sql(
+        "SELECT * FROM VALUES (1, 3), (2, 4), (3, 5), (4, 6) AS T(v1, v2)")
+      let sketches = await df.select(
+        theta_sketch_agg(col("v1")).alias("s1"), theta_sketch_agg(col("v2")).alias("s2"))
+      let rows = try await sketches.select(
+        theta_sketch_estimate(theta_union(col("s1"), col("s2"))),
+        theta_sketch_estimate(theta_union(col("s1"), col("s2"), 15)),
+        theta_sketch_estimate(theta_intersection(col("s1"), col("s2"))),
+        theta_sketch_estimate(theta_difference(col("s1"), col("s2")))
+      ).collect()
+      #expect(rows == [Row(Int64(6), Int64(6), Int64(2), Int64(2))])
+    }
+    await spark.stop()
+  }
+}

--- a/Tests/SparkConnectTests/TupleSketchFunctionsTests.swift
+++ b/Tests/SparkConnectTests/TupleSketchFunctionsTests.swift
@@ -1,0 +1,225 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for Tuple sketch functions
+@Suite(.serialized)
+struct TupleSketchFunctionsTests {
+
+  /// Like PySpark, the functions that take both `lgNomEntries` and `mode` always send them,
+  /// while the ones that only take `mode` omit it when it is not given.
+  @Test
+  func tupleSketchFunctions() throws {
+    for (column, name, count) in [
+      (tuple_sketch_agg_double(col("a"), col("b")), "tuple_sketch_agg_double", 4),
+      (
+        tuple_sketch_agg_double(col("a"), col("b"), lgNomEntries: lit(Int32(15))),
+        "tuple_sketch_agg_double", 4
+      ),
+      (
+        tuple_sketch_agg_double(col("a"), col("b"), mode: lit("min")),
+        "tuple_sketch_agg_double", 4
+      ),
+      (tuple_union_agg_double(col("a")), "tuple_union_agg_double", 3),
+      (tuple_union_agg_double(col("a"), mode: lit("max")), "tuple_union_agg_double", 3),
+      (tuple_intersection_agg_double(col("a")), "tuple_intersection_agg_double", 1),
+      (
+        tuple_intersection_agg_double(col("a"), mode: lit("min")),
+        "tuple_intersection_agg_double", 2
+      ),
+      (tuple_sketch_estimate_double(col("a")), "tuple_sketch_estimate_double", 1),
+      (tuple_sketch_summary_double(col("a")), "tuple_sketch_summary_double", 1),
+      (tuple_sketch_summary_double(col("a"), mode: lit("max")), "tuple_sketch_summary_double", 2),
+      (tuple_sketch_theta_double(col("a")), "tuple_sketch_theta_double", 1),
+      (tuple_union_double(col("a"), col("b")), "tuple_union_double", 4),
+      (tuple_union_theta_double(col("a"), col("b")), "tuple_union_theta_double", 4),
+      (tuple_intersection_double(col("a"), col("b")), "tuple_intersection_double", 2),
+      (
+        tuple_intersection_double(col("a"), col("b"), mode: lit("min")),
+        "tuple_intersection_double", 3
+      ),
+      (tuple_intersection_theta_double(col("a"), col("b")), "tuple_intersection_theta_double", 2),
+      (
+        tuple_intersection_theta_double(col("a"), col("b"), mode: lit("min")),
+        "tuple_intersection_theta_double", 3
+      ),
+      (tuple_difference_double(col("a"), col("b")), "tuple_difference_double", 2),
+      (tuple_difference_theta_double(col("a"), col("b")), "tuple_difference_theta_double", 2),
+      (tuple_sketch_agg_integer(col("a"), col("b")), "tuple_sketch_agg_integer", 4),
+      (
+        tuple_sketch_agg_integer(col("a"), col("b"), lgNomEntries: lit(Int32(15))),
+        "tuple_sketch_agg_integer", 4
+      ),
+      (
+        tuple_sketch_agg_integer(col("a"), col("b"), mode: lit("min")),
+        "tuple_sketch_agg_integer", 4
+      ),
+      (tuple_union_agg_integer(col("a")), "tuple_union_agg_integer", 3),
+      (tuple_union_agg_integer(col("a"), mode: lit("max")), "tuple_union_agg_integer", 3),
+      (tuple_intersection_agg_integer(col("a")), "tuple_intersection_agg_integer", 1),
+      (
+        tuple_intersection_agg_integer(col("a"), mode: lit("min")),
+        "tuple_intersection_agg_integer", 2
+      ),
+      (tuple_sketch_estimate_integer(col("a")), "tuple_sketch_estimate_integer", 1),
+      (tuple_sketch_summary_integer(col("a")), "tuple_sketch_summary_integer", 1),
+      (
+        tuple_sketch_summary_integer(col("a"), mode: lit("max")),
+        "tuple_sketch_summary_integer", 2
+      ),
+      (tuple_sketch_theta_integer(col("a")), "tuple_sketch_theta_integer", 1),
+      (tuple_union_integer(col("a"), col("b")), "tuple_union_integer", 4),
+      (tuple_union_theta_integer(col("a"), col("b")), "tuple_union_theta_integer", 4),
+      (tuple_intersection_integer(col("a"), col("b")), "tuple_intersection_integer", 2),
+      (
+        tuple_intersection_integer(col("a"), col("b"), mode: lit("min")),
+        "tuple_intersection_integer", 3
+      ),
+      (
+        tuple_intersection_theta_integer(col("a"), col("b")),
+        "tuple_intersection_theta_integer", 2
+      ),
+      (
+        tuple_intersection_theta_integer(col("a"), col("b"), mode: lit("min")),
+        "tuple_intersection_theta_integer", 3
+      ),
+      (tuple_difference_integer(col("a"), col("b")), "tuple_difference_integer", 2),
+      (tuple_difference_theta_integer(col("a"), col("b")), "tuple_difference_theta_integer", 2),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments.count == count)
+      #expect(expr.unresolvedFunction.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+    }
+  }
+
+  /// An `Int32` `lgNomEntries` is a shorthand for a literal ``Column``.
+  @Test
+  func tupleLgNomEntries() throws {
+    for (column, name, index) in [
+      (
+        tuple_sketch_agg_double(col("a"), col("b"), lgNomEntries: 15),
+        "tuple_sketch_agg_double", 2
+      ),
+      (tuple_union_agg_double(col("a"), lgNomEntries: 15), "tuple_union_agg_double", 1),
+      (tuple_union_double(col("a"), col("b"), lgNomEntries: 15), "tuple_union_double", 2),
+      (
+        tuple_union_theta_double(col("a"), col("b"), lgNomEntries: 15),
+        "tuple_union_theta_double", 2
+      ),
+      (
+        tuple_sketch_agg_integer(col("a"), col("b"), lgNomEntries: 15),
+        "tuple_sketch_agg_integer", 2
+      ),
+      (tuple_union_agg_integer(col("a"), lgNomEntries: 15), "tuple_union_agg_integer", 1),
+      (tuple_union_integer(col("a"), col("b"), lgNomEntries: 15), "tuple_union_integer", 2),
+      (
+        tuple_union_theta_integer(col("a"), col("b"), lgNomEntries: 15),
+        "tuple_union_theta_integer", 2
+      ),
+    ] {
+      let expr = column.expr
+      #expect(expr.unresolvedFunction.functionName == name)
+      #expect(expr.unresolvedFunction.arguments[index].literal.integer == 15)
+    }
+  }
+
+  /// The omitted `lgNomEntries` and `mode` are filled with their default literals.
+  @Test
+  func tupleDefaultArguments() throws {
+    let expr = tuple_sketch_agg_double(col("a"), col("b")).expr
+    #expect(expr.unresolvedFunction.arguments[2].literal.integer == 12)
+    #expect(expr.unresolvedFunction.arguments[3].literal.string == "sum")
+  }
+
+  @Test
+  func tupleSketchAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.2") {
+      let df = try await spark.sql(
+        "SELECT * FROM VALUES (1, 10.0), (2, 20.0), (2, 30.0) AS T(k, v)")
+      let rows = try await df.select(
+        tuple_sketch_estimate_double(tuple_sketch_agg_double(col("k"), col("v"))),
+        tuple_sketch_estimate_integer(
+          tuple_sketch_agg_integer(col("k"), col("v").cast("INT"), lgNomEntries: 15)),
+        tuple_sketch_summary_double(tuple_sketch_agg_double(col("k"), col("v"))),
+        tuple_sketch_summary_double(
+          tuple_sketch_agg_double(col("k"), col("v"), mode: lit("min"))),
+        tuple_sketch_theta_double(tuple_sketch_agg_double(col("k"), col("v")))
+      ).collect()
+      #expect(rows == [Row(2.0, 2.0, 60.0, 30.0, 1.0)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func tupleSetOperations() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.2") {
+      let df = try await spark.sql(
+        """
+        SELECT * FROM VALUES (1, 10.0, 2, 100.0), (2, 20.0, 3, 200.0), (3, 30.0, 4, 300.0)
+        AS T(k1, v1, k2, v2)
+        """)
+      let sketches = await df.select(
+        tuple_sketch_agg_double(col("k1"), col("v1")).alias("a"),
+        tuple_sketch_agg_double(col("k2"), col("v2")).alias("b"),
+        theta_sketch_agg(col("k2")).alias("t")
+      )
+      let rows = try await sketches.select(
+        tuple_sketch_estimate_double(tuple_union_double(col("a"), col("b"))),
+        tuple_sketch_estimate_double(tuple_intersection_double(col("a"), col("b"))),
+        tuple_sketch_estimate_double(tuple_difference_double(col("a"), col("b"))),
+        tuple_sketch_estimate_double(tuple_union_theta_double(col("a"), col("t"))),
+        tuple_sketch_estimate_double(tuple_intersection_theta_double(col("a"), col("t"))),
+        tuple_sketch_estimate_double(tuple_difference_theta_double(col("a"), col("t"))),
+        tuple_sketch_summary_double(tuple_union_double(col("a"), col("b"))),
+        tuple_sketch_summary_double(
+          tuple_intersection_double(col("a"), col("b"), mode: lit("min")))
+      ).collect()
+      #expect(rows == [Row(4.0, 2.0, 1.0, 4.0, 2.0, 1.0, 660.0, 50.0)])
+    }
+    await spark.stop()
+  }
+
+  @Test
+  func tupleUnionAndIntersectionAgg() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    if await isSparkVersionAtLeast(spark.version, "4.2") {
+      let df = try await spark.sql(
+        """
+        SELECT tuple_sketch_agg_integer(k, v) AS sketch FROM VALUES (1, 10), (2, 20) AS T(k, v)
+        UNION ALL
+        SELECT tuple_sketch_agg_integer(k, v) AS sketch FROM VALUES (2, 5), (3, 30) AS T(k, v)
+        """)
+      let rows = try await df.select(
+        tuple_sketch_estimate_integer(tuple_union_agg_integer(col("sketch"))),
+        tuple_sketch_estimate_integer(tuple_intersection_agg_integer(col("sketch"))),
+        tuple_sketch_summary_integer(tuple_union_agg_integer(col("sketch"), lgNomEntries: 15)),
+        tuple_sketch_summary_integer(
+          tuple_intersection_agg_integer(col("sketch"), mode: lit("max")))
+      ).collect()
+      #expect(rows == [Row(3.0, 1.0, Int64(65), Int64(20))])
+    }
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support 52 Datasketches sketch functions (86 declarations).

The KLL functions have three element-type variants (`_bigint`, `_double`, `_float`) and the
Tuple functions have two summary-type variants (`_double`, `_integer`).

| Function | Since |
| --- | --- |
| `theta_sketch_agg`, `theta_union_agg`, `theta_intersection_agg` | 4.1.0 |
| `theta_sketch_estimate`, `theta_union`, `theta_intersection`, `theta_difference` | 4.1.0 |
| `kll_sketch_agg_<T>` | 4.1.0 |
| `kll_merge_agg_<T>` | **4.1.2** |
| `kll_sketch_get_n_<T>`, `kll_sketch_get_quantile_<T>`, `kll_sketch_get_rank_<T>` | 4.1.0 |
| `kll_sketch_merge_<T>`, `kll_sketch_to_string_<T>` | 4.1.0 |
| `tuple_sketch_agg_<T>`, `tuple_union_agg_<T>`, `tuple_intersection_agg_<T>` | 4.2.0 |
| `tuple_sketch_estimate_<T>`, `tuple_sketch_summary_<T>`, `tuple_sketch_theta_<T>` | 4.2.0 |
| `tuple_union_<T>`, `tuple_union_theta_<T>` | 4.2.0 |
| `tuple_intersection_<T>`, `tuple_intersection_theta_<T>` | 4.2.0 |
| `tuple_difference_<T>`, `tuple_difference_theta_<T>` | 4.2.0 |

The 37 scalar functions live in three new files, `ThetaSketchFunctions.swift`,
`KllSketchFunctions.swift` and `TupleSketchFunctions.swift`. The 15 aggregate functions go
into `AggregateFunctions.swift`, following the existing `count_min_sketch`,
`schema_of_variant_agg` and `vector_avg` precedents.

Optional arguments follow the upstream PySpark implementations exactly. Most functions omit
`lgNomEntries` / `k` / `mode` when they are not given, so the argument count varies and they
are expressed as overloads, like the existing `hmac`. The exceptions are
`tuple_sketch_agg_*`, `tuple_union_agg_*`, `tuple_union_*` and `tuple_union_theta_*`, which
always send `lgNomEntries` and `mode` filled with `12` and `"sum"`; these use labeled Swift
default argument values, like the existing `aes_encrypt`.

An `Int32` overload is provided for `lgNomEntries` and `k` alongside the `Column` one, since
the server requires the `INT` type there and the existing `lit(_ value: Int)` produces a
`BIGINT` literal that would be rejected.

### Why are the changes needed?

To improve API coverage. These functions are available in PySpark and the Spark SQL Scala
API, but were missing from this Swift client, where `count_min_sketch` was the only
supported sketch function.

### Does this PR introduce _any_ user-facing change?

No, this is a new addition to the API.

```swift
let df = try await spark.sql("SELECT * FROM VALUES (1), (2), (2), (3) AS T(v)")
try await df.select(theta_sketch_estimate(theta_sketch_agg(col("v")))).show()
```

```
+--------------------------------------------------+
|theta_sketch_estimate(theta_sketch_agg(v))        |
+--------------------------------------------------+
|3                                                 |
+--------------------------------------------------+
```

### How was this patch tested?

Pass the CIs with three new test suites, `ThetaSketchFunctionsTests`,
`KllSketchFunctionsTests` and `TupleSketchFunctionsTests` (18 tests).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5