### PR TITLE
[SPARK-59254] Support higher-order array functions

### DIFF
--- a/Sources/SparkConnect/HigherOrderFunctions.swift
+++ b/Sources/SparkConnect/HigherOrderFunctions.swift
@@ -1,0 +1,242 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Synchronization
+
+// MARK: - Higher-order functions
+//
+// These functions take a Swift closure and turn it into a Spark Connect lambda expression. The
+// closures are non-escaping because they are invoked immediately while the expression is built
+// and never stored. The single-argument ``array_sort(_:)`` lives in `CollectionFunctions.swift`.
+
+/// A monotonically increasing counter used to give every lambda variable a unique name.
+private let lambdaVariableID = Atomic<Int>(0)
+
+/// Creates an `UnresolvedNamedLambdaVariable` whose name is `prefix` suffixed with a unique id.
+///
+/// Lambda variable name prefixes (`x`, `y`, `z`) are reused across higher-order functions, so a
+/// unique suffix is required to keep an inner lambda from shadowing an enclosing one.
+private func lambdaVariable(_ prefix: String) -> Column {
+  let id = lambdaVariableID.wrappingAdd(1, ordering: .relaxed).newValue
+  var variable = Spark_Connect_Expression.UnresolvedNamedLambdaVariable()
+  variable.nameParts = ["\(prefix)_\(id)"]
+  var expr = Spark_Connect_Expression()
+  expr.unresolvedNamedLambdaVariable = variable
+  return Column(expr)
+}
+
+/// Builds a `LambdaFunction` ``Column`` from `arguments` and the given lambda `body`.
+private func lambda(_ arguments: [Column], _ body: Column) -> Column {
+  var function = Spark_Connect_Expression.LambdaFunction()
+  function.function = body.expr
+  function.arguments = arguments.map { $0.expr.unresolvedNamedLambdaVariable }
+  var expr = Spark_Connect_Expression()
+  expr.lambdaFunction = function
+  return Column(expr)
+}
+
+/// Converts a single-argument Swift closure into a lambda expression ``Column``.
+func createLambda(_ f: (Column) -> Column) -> Column {
+  let x = lambdaVariable("x")
+  return lambda([x], f(x))
+}
+
+/// Converts a two-argument Swift closure into a lambda expression ``Column``.
+func createLambda(_ f: (Column, Column) -> Column) -> Column {
+  let x = lambdaVariable("x")
+  let y = lambdaVariable("y")
+  return lambda([x, y], f(x, y))
+}
+
+/// Converts a three-argument Swift closure into a lambda expression ``Column``.
+func createLambda(_ f: (Column, Column, Column) -> Column) -> Column {
+  let x = lambdaVariable("x")
+  let y = lambdaVariable("y")
+  let z = lambdaVariable("z")
+  return lambda([x, y, z], f(x, y, z))
+}
+
+/// Returns an array of elements after applying a transformation to each element in the input
+/// array.
+///
+/// ```swift
+/// let df2 = df.select(transform(col("i")) { $0 + 1 })
+/// ```
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A closure applied to each array element.
+/// - Returns: A ``Column``.
+public func transform(_ column: Column, _ f: (Column) -> Column) -> Column {
+  return fn("transform", column, createLambda(f))
+}
+
+/// Returns an array of elements after applying a transformation to each element in the input
+/// array.
+///
+/// ```swift
+/// let df2 = df.select(transform(col("i")) { x, i in x + i })
+/// ```
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A closure applied to each array element and its 0-based index.
+/// - Returns: A ``Column``.
+public func transform(_ column: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("transform", column, createLambda(f))
+}
+
+/// Returns whether a predicate holds for one or more elements in the array.
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A predicate closure applied to each array element.
+/// - Returns: A ``Column``.
+public func exists(_ column: Column, _ f: (Column) -> Column) -> Column {
+  return fn("exists", column, createLambda(f))
+}
+
+/// Returns whether a predicate holds for every element in the array.
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A predicate closure applied to each array element.
+/// - Returns: A ``Column``.
+public func forall(_ column: Column, _ f: (Column) -> Column) -> Column {
+  return fn("forall", column, createLambda(f))
+}
+
+/// Returns an array of elements for which a predicate holds in the given array.
+///
+/// ```swift
+/// let df2 = df.select(filter(col("i")) { $0 % 2 == 0 })
+/// ```
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A predicate closure applied to each array element.
+/// - Returns: A ``Column``.
+public func filter(_ column: Column, _ f: (Column) -> Column) -> Column {
+  return fn("filter", column, createLambda(f))
+}
+
+/// Returns an array of elements for which a predicate holds in the given array.
+///
+/// ```swift
+/// let df2 = df.select(filter(col("i")) { _, i in i % 2 == 0 })
+/// ```
+/// - Parameters:
+///   - column: An array ``Column``.
+///   - f: A predicate closure applied to each array element and its 0-based index.
+/// - Returns: A ``Column``.
+public func filter(_ column: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("filter", column, createLambda(f))
+}
+
+/// Applies a binary operator to an initial state and all elements in the array, and reduces this
+/// to a single state. The final state is converted into the final result by applying a finish
+/// function.
+/// - Parameters:
+///   - expr: An array ``Column``.
+///   - initialValue: The initial value ``Column``.
+///   - merge: A closure taking the combined value and an input value, returning a combined value.
+///   - finish: A closure converting the combined value to the final result.
+/// - Returns: A ``Column``.
+public func aggregate(
+  _ expr: Column, _ initialValue: Column, _ merge: (Column, Column) -> Column,
+  finish: (Column) -> Column
+) -> Column {
+  return fn("aggregate", expr, initialValue, createLambda(merge), createLambda(finish))
+}
+
+/// Applies a binary operator to an initial state and all elements in the array, and reduces this
+/// to a single state.
+///
+/// ```swift
+/// let df2 = df.select(aggregate(col("i"), lit(0)) { acc, x in acc + x })
+/// ```
+/// - Parameters:
+///   - expr: An array ``Column``.
+///   - initialValue: The initial value ``Column``.
+///   - merge: A closure taking the combined value and an input value, returning a combined value.
+/// - Returns: A ``Column``.
+public func aggregate(
+  _ expr: Column, _ initialValue: Column, _ merge: (Column, Column) -> Column
+) -> Column {
+  return aggregate(expr, initialValue, merge, finish: { $0 })
+}
+
+/// Applies a binary operator to an initial state and all elements in the array, and reduces this
+/// to a single state. The final state is converted into the final result by applying a finish
+/// function.
+/// - Parameters:
+///   - expr: An array ``Column``.
+///   - initialValue: The initial value ``Column``.
+///   - merge: A closure taking the combined value and an input value, returning a combined value.
+///   - finish: A closure converting the combined value to the final result.
+/// - Returns: A ``Column``.
+public func reduce(
+  _ expr: Column, _ initialValue: Column, _ merge: (Column, Column) -> Column,
+  finish: (Column) -> Column
+) -> Column {
+  return fn("reduce", expr, initialValue, createLambda(merge), createLambda(finish))
+}
+
+/// Applies a binary operator to an initial state and all elements in the array, and reduces this
+/// to a single state.
+///
+/// ```swift
+/// let df2 = df.select(reduce(col("i"), lit(0)) { acc, x in acc + x })
+/// ```
+/// - Parameters:
+///   - expr: An array ``Column``.
+///   - initialValue: The initial value ``Column``.
+///   - merge: A closure taking the combined value and an input value, returning a combined value.
+/// - Returns: A ``Column``.
+public func reduce(
+  _ expr: Column, _ initialValue: Column, _ merge: (Column, Column) -> Column
+) -> Column {
+  return reduce(expr, initialValue, merge, finish: { $0 })
+}
+
+/// Merges two given arrays, element-wise, into a single array using a function. If one array is
+/// shorter, nulls are appended at the end to match the length of the longer array, before
+/// applying the function.
+///
+/// ```swift
+/// let df2 = df.select(zip_with(col("val1"), col("val2")) { x, y in x + y })
+/// ```
+/// - Parameters:
+///   - left: An array ``Column``.
+///   - right: An array ``Column``.
+///   - f: A closure taking an element of `left` and the matching element of `right`.
+/// - Returns: A ``Column``.
+public func zip_with(_ left: Column, _ right: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("zip_with", left, right, createLambda(f))
+}
+
+/// Sorts the input array based on the given comparator function. The comparator will take two
+/// arguments representing two elements of the array. It returns a negative integer, 0, or a
+/// positive integer as the first element is less than, equal to, or greater than the second
+/// element. If the comparator function returns null, the function will fail and raise an error.
+///
+/// The comparator must return an `INT`. Swift `Int` literals are `BIGINT`, so cast the result
+/// when it is derived from them, e.g. `array_sort(col("a")) { x, y in (y - x).cast("int") }`.
+/// - Parameters:
+///   - col: An array ``Column``.
+///   - comparator: A binary comparator closure.
+/// - Returns: A ``Column``.
+public func array_sort(_ col: Column, _ comparator: (Column, Column) -> Column) -> Column {
+  return fn("array_sort", col, createLambda(comparator))
+}

--- a/Tests/SparkConnectTests/HigherOrderFunctionsTests.swift
+++ b/Tests/SparkConnectTests/HigherOrderFunctionsTests.swift
@@ -1,0 +1,124 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Testing
+
+@testable import SparkConnect
+
+/// A test suite for `HigherOrderFunctions`
+@Suite(.serialized)
+struct HigherOrderFunctionsTests {
+
+  @Test
+  func higherOrderFunctionExpressions() throws {
+    // (expression, function name, expected number of variables of each lambda argument)
+    for (column, name, arities) in [
+      (transform(col("a")) { $0 }, "transform", [1]),
+      (transform(col("a")) { x, i in x + i }, "transform", [2]),
+      (exists(col("a")) { $0 }, "exists", [1]),
+      (forall(col("a")) { $0 }, "forall", [1]),
+      (filter(col("a")) { $0 }, "filter", [1]),
+      (filter(col("a")) { x, i in x + i }, "filter", [2]),
+      (aggregate(col("a"), lit(0)) { acc, x in acc + x }, "aggregate", [2, 1]),
+      (aggregate(col("a"), lit(0), { acc, x in acc + x }, finish: { $0 }), "aggregate", [2, 1]),
+      (reduce(col("a"), lit(0)) { acc, x in acc + x }, "reduce", [2, 1]),
+      (reduce(col("a"), lit(0), { acc, x in acc + x }, finish: { $0 }), "reduce", [2, 1]),
+      (zip_with(col("a"), col("b")) { x, y in x + y }, "zip_with", [2]),
+      (array_sort(col("a")) { x, y in x - y }, "array_sort", [2]),
+    ] {
+      let function = column.expr.unresolvedFunction
+      #expect(function.functionName == name)
+      #expect(function.arguments[0].unresolvedAttribute.unparsedIdentifier == "a")
+      let lambdas = function.arguments.filter { !$0.lambdaFunction.arguments.isEmpty }
+      #expect(lambdas.count == arities.count)
+      for (lambda, arity) in zip(lambdas, arities) {
+        #expect(lambda.lambdaFunction.arguments.count == arity)
+        #expect(lambda.lambdaFunction.arguments.allSatisfy { $0.nameParts.count == 1 })
+      }
+    }
+  }
+
+  @Test
+  func lambdaVariableNamesAreUnique() throws {
+    // An inner lambda must not shadow the variable of an enclosing lambda.
+    let column = transform(col("a")) { x in transform(col("b")) { y in x + y } }
+    let outer = column.expr.unresolvedFunction.arguments[1].lambdaFunction
+    let inner = outer.function.unresolvedFunction.arguments[1].lambdaFunction
+    let outerName = outer.arguments[0].nameParts[0]
+    let innerName = inner.arguments[0].nameParts[0]
+    #expect(outerName.hasPrefix("x_"))
+    #expect(innerName.hasPrefix("x_"))
+    #expect(outerName != innerName)
+
+    // The inner body adds the outer variable to the inner one.
+    let body = inner.function.unresolvedFunction.arguments
+    #expect(body[0].unresolvedNamedLambdaVariable.nameParts == [outerName])
+    #expect(body[1].unresolvedNamedLambdaVariable.nameParts == [innerName])
+  }
+
+  @Test
+  func selectHigherOrderArrayFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let arr = array(lit(1), lit(2), lit(3))
+
+    #expect(
+      try await df.select(transform(arr) { $0 * 2 }.cast("string")).collect() == [Row("[2, 4, 6]")])
+    #expect(
+      try await df.select(transform(arr) { x, i in x + i }.cast("string")).collect()
+        == [Row("[1, 3, 5]")])
+    #expect(
+      try await df.select(filter(arr) { $0 % 2 == 1 }.cast("string")).collect() == [Row("[1, 3]")])
+    #expect(
+      try await df.select(filter(arr) { _, i in i < 2 }.cast("string")).collect()
+        == [Row("[1, 2]")])
+    #expect(try await df.select(exists(arr) { $0 > 2 }).collect() == [Row(true)])
+    #expect(try await df.select(exists(arr) { $0 > 3 }).collect() == [Row(false)])
+    #expect(try await df.select(forall(arr) { $0 > 0 }).collect() == [Row(true)])
+    #expect(try await df.select(forall(arr) { $0 > 1 }).collect() == [Row(false)])
+    #expect(try await df.select(aggregate(arr, lit(0)) { acc, x in acc + x }).collect() == [Row(6)])
+    #expect(
+      try await df.select(aggregate(arr, lit(0)) { acc, x in acc + x } finish: { $0 * 10 })
+        .collect() == [Row(60)])
+    #expect(try await df.select(reduce(arr, lit(0)) { acc, x in acc + x }).collect() == [Row(6)])
+    #expect(
+      try await df.select(reduce(arr, lit(0)) { acc, x in acc + x } finish: { $0 * 10 })
+        .collect() == [Row(60)])
+    #expect(
+      try await df.select(
+        zip_with(arr, array(lit(10), lit(20), lit(30))) { x, y in x + y }.cast("string")
+      ).collect() == [Row("[11, 22, 33]")])
+    // The comparator must return INT.
+    let descending = array_sort(array(lit(1), lit(3), lit(2))) { x, y in (y - x).cast("int") }
+    #expect(try await df.select(descending.cast("string")).collect() == [Row("[3, 2, 1]")])
+    await spark.stop()
+  }
+
+  @Test
+  func selectNestedLambda() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    // The inner lambda body references the enclosing lambda variable.
+    let nested = transform(array(lit(1), lit(2))) { x in
+      transform(array(lit(10), lit(20))) { y in x + y }
+    }
+    #expect(try await df.select(nested.cast("string")).collect() == [Row("[[11, 21], [12, 22]]")])
+    await spark.stop()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for lambda expressions and the higher-order array
functions that consume them, in a new `HigherOrderFunctions.swift` file. No
existing file is modified.

Lambda infrastructure (internal):

- `createLambda` in one-, two-, and three-argument forms, converting a Swift
  closure into a `LambdaFunction` expression.
- Lambda variables get a unique name (`x_1`, `y_2`, ...) from an
  `Atomic<Int>` counter, matching Scala's
  `UnresolvedNamedLambdaVariable.apply` and PySpark's `fresh_var_name`.

New public functions:

| Function | Closure |
| -------- | ------- |
| `transform(col, f)` | `(Column) -> Column` and `(Column, Column) -> Column` (element, index) |
| `filter(col, f)` | `(Column) -> Column` and `(Column, Column) -> Column` (element, index) |
| `exists(col, f)` | `(Column) -> Column` |
| `forall(col, f)` | `(Column) -> Column` |
| `aggregate(col, initialValue, merge, finish:)` | `(Column, Column) -> Column`, `(Column) -> Column` (`finish:` optional) |
| `reduce(col, initialValue, merge, finish:)` | `(Column, Column) -> Column`, `(Column) -> Column` (`finish:` optional) |
| `zip_with(left, right, f)` | `(Column, Column) -> Column` |
| `array_sort(col, comparator)` | `(Column, Column) -> Column` |

The closures are non-escaping because they are invoked immediately while the
expression is built and never stored.

`finish:` is labeled so the optional finish closure can be passed as a second
trailing closure; the first closure of every function stays unlabeled, matching
the rest of the API.

### Why are the changes needed?

For feature parity with Apache Spark. These functions exist in both the Scala
and Python clients but had no Swift equivalent, because there was no way to
build a Spark Connect lambda expression from a Swift closure. The generated
protobuf types (`Expression.LambdaFunction` and
`Expression.UnresolvedNamedLambdaVariable`) were already available, so no proto
regeneration is required.

The unique variable naming is required for correctness, not cosmetics. The
server passes `name_parts` through unchanged
(`SparkConnectPlanner.transformUnresolvedNamedLambdaVariable`), so with fixed
names an inner lambda would shadow the variable of an enclosing one and
`transform(a) { x in transform(b) { y in x + y } }` would silently compute
`x + x`.

The functions live in their own file rather than in `CollectionFunctions.swift`
because they share the lambda infrastructure, which stays internal to the module,
and because the follow-up higher-order map functions (`map_filter`,
`transform_keys`, `transform_values`, `map_zip_with`) belong next to them. This
also keeps `CollectionFunctions.swift` from growing past 900 lines.

### Does this PR introduce _any_ user-facing change?

Yes, this adds new public APIs. For example:

```swift
let df = try await spark.range(1)
let arr = array(lit(1), lit(2), lit(3))

try await df.select(transform(arr) { $0 * 2 }.cast("string")).show()
// [2, 4, 6]

try await df.select(aggregate(arr, lit(0)) { acc, x in acc + x }).show()
// 6

try await df.select(aggregate(arr, lit(0)) { acc, x in acc + x } finish: { $0 * 10 }).show()
// 60
```

All of these functions were introduced in Spark 3.5 or earlier
(`array_sort` with a comparator in 3.4.0), so no version gate is needed.

### How was this patch tested?

Added a new `HigherOrderFunctionsTests` suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1
