### PR TITLE
[SPARK-59257] Update docker GitHub Actions to the latest ASF-approved hashes

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -21,11 +21,11 @@ jobs:
         example: ${{ fromJSON( inputs.example || '["app", "pi", "pyspark-connect", "spark-sql", "stream"]' ) }}
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
     - name: Login to Docker Hub
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
       with:
         ref: main
     - name: Build and push
-      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
       with:
         # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
         cache-from: type=gha


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `docker/*` GitHub Actions in `.github/workflows/publish_image.yml` to the latest ASF-approved commit hashes from [apache/infrastructure-actions/approved_patterns.yml](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml).

| Action | Before | After |
|---|---|---|
| `docker/setup-qemu-action` | `ce360397` ([v4.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0), 2026-03-04) | `96fe6ef7` ([v4.2.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.2.0), 2026-07-01) |
| `docker/setup-buildx-action` | `4d04d5d9` ([v4.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0), 2026-03-05) | `37fe6310` ([v4.3.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0), 2026-08-17) |
| `docker/login-action` | `4907a6dd` ([v4.1.0](https://github.com/docker/login-action/releases/tag/v4.1.0), 2026-04-02) | `dbcb8138` ([v4.6.0](https://github.com/docker/login-action/releases/tag/v4.6.0), 2026-07-29) |
| `docker/build-push-action` | `bcafcacb` ([v7.1.0](https://github.com/docker/build-push-action/releases/tag/v7.1.0), 2026-04-09) | `53b7df96` ([v7.3.0](https://github.com/docker/build-push-action/releases/tag/v7.3.0), 2026-07-01) |

### Why are the changes needed?

The previously pinned hashes are no longer listed in the ASF-approved patterns. This PR brings the workflow back into compliance with the ASF GitHub Actions policy and picks up the latest releases of these actions.

### Does this PR introduce _any_ user-facing change?

No. This is an infra-only change.

### How was this patch tested?

Manual review. Each new hash was verified against `approved_patterns.yml` and its corresponding release tag via the GitHub API.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1