### PR TITLE
[SPARK-59258] Support higher-order map functions

### DIFF
--- a/Sources/SparkConnect/HigherOrderFunctions.swift
+++ b/Sources/SparkConnect/HigherOrderFunctions.swift
@@ -240,3 +240,61 @@ public func zip_with(_ left: Column, _ right: Column, _ f: (Column, Column) -> C
 public func array_sort(_ col: Column, _ comparator: (Column, Column) -> Column) -> Column {
   return fn("array_sort", col, createLambda(comparator))
 }
+
+/// Applies a function to every key-value pair in a map and returns a map with the results of
+/// those applications as the new keys for the pairs.
+///
+/// ```swift
+/// let df2 = df.select(transform_keys(col("m")) { k, v in k + 1 })
+/// ```
+/// - Parameters:
+///   - expr: A map ``Column``.
+///   - f: A closure taking a key and its value, returning a new key.
+/// - Returns: A ``Column``.
+public func transform_keys(_ expr: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("transform_keys", expr, createLambda(f))
+}
+
+/// Applies a function to every key-value pair in a map and returns a map with the results of
+/// those applications as the new values for the pairs.
+///
+/// ```swift
+/// let df2 = df.select(transform_values(col("m")) { k, v in k + v })
+/// ```
+/// - Parameters:
+///   - expr: A map ``Column``.
+///   - f: A closure taking a key and its value, returning a new value.
+/// - Returns: A ``Column``.
+public func transform_values(_ expr: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("transform_values", expr, createLambda(f))
+}
+
+/// Returns a map whose key-value pairs satisfy a predicate.
+///
+/// ```swift
+/// let df2 = df.select(map_filter(col("m")) { k, v in v > 30 })
+/// ```
+/// - Parameters:
+///   - expr: A map ``Column``.
+///   - f: A predicate closure taking a key and its value.
+/// - Returns: A ``Column``.
+public func map_filter(_ expr: Column, _ f: (Column, Column) -> Column) -> Column {
+  return fn("map_filter", expr, createLambda(f))
+}
+
+/// Merges two given maps, key-wise, into a single map using a function. If one map does not have
+/// a matching key, null is passed for the missing value.
+///
+/// ```swift
+/// let df2 = df.select(map_zip_with(col("m1"), col("m2")) { k, v1, v2 in v1 + v2 })
+/// ```
+/// - Parameters:
+///   - left: A map ``Column``.
+///   - right: A map ``Column``.
+///   - f: A closure taking a key, the value from `left`, and the value from `right`.
+/// - Returns: A ``Column``.
+public func map_zip_with(
+  _ left: Column, _ right: Column, _ f: (Column, Column, Column) -> Column
+) -> Column {
+  return fn("map_zip_with", left, right, createLambda(f))
+}

--- a/Tests/SparkConnectTests/HigherOrderFunctionsTests.swift
+++ b/Tests/SparkConnectTests/HigherOrderFunctionsTests.swift
@@ -41,6 +41,10 @@ struct HigherOrderFunctionsTests {
       (reduce(col("a"), lit(0), { acc, x in acc + x }, finish: { $0 }), "reduce", [2, 1]),
       (zip_with(col("a"), col("b")) { x, y in x + y }, "zip_with", [2]),
       (array_sort(col("a")) { x, y in x - y }, "array_sort", [2]),
+      (transform_keys(col("a")) { k, _ in k }, "transform_keys", [2]),
+      (transform_values(col("a")) { _, v in v }, "transform_values", [2]),
+      (map_filter(col("a")) { _, v in v }, "map_filter", [2]),
+      (map_zip_with(col("a"), col("b")) { _, v1, v2 in v1 + v2 }, "map_zip_with", [3]),
     ] {
       let function = column.expr.unresolvedFunction
       #expect(function.functionName == name)
@@ -119,6 +123,27 @@ struct HigherOrderFunctionsTests {
       transform(array(lit(10), lit(20))) { y in x + y }
     }
     #expect(try await df.select(nested.cast("string")).collect() == [Row("[[11, 21], [12, 22]]")])
+    await spark.stop()
+  }
+
+  @Test
+  func selectHigherOrderMapFunctions() async throws {
+    let spark = try await SparkSession.builder.getOrCreate()
+    let df = try await spark.range(1)
+    let m = map_from_arrays(array(lit(1), lit(2)), array(lit(10), lit(20)))
+
+    #expect(
+      try await df.select(map_filter(m) { _, v in v > 10 }.cast("string")).collect()
+        == [Row("{2 -> 20}")])
+    #expect(
+      try await df.select(transform_keys(m) { k, v in k + v }.cast("string")).collect()
+        == [Row("{11 -> 10, 22 -> 20}")])
+    #expect(
+      try await df.select(transform_values(m) { k, v in k + v }.cast("string")).collect()
+        == [Row("{1 -> 11, 2 -> 22}")])
+    let m2 = map_from_arrays(array(lit(1), lit(2)), array(lit(100), lit(200)))
+    let zipped = map_zip_with(m, m2) { _, v1, v2 in v1 + v2 }
+    #expect(try await df.select(zipped.cast("string")).collect() == [Row("{1 -> 110, 2 -> 220}")])
     await spark.stop()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the four higher-order map functions to `HigherOrderFunctions.swift`, built on the lambda infrastructure added by SPARK-59254.

| Function | Closure |
| -------- | ------- |
| `map_filter(col, f)` | `(Column, Column) -> Column` (key, value) |
| `transform_keys(col, f)` | `(Column, Column) -> Column` (key, value) |
| `transform_values(col, f)` | `(Column, Column) -> Column` (key, value) |
| `map_zip_with(left, right, f)` | `(Column, Column, Column) -> Column` (key, value1, value2) |

`map_zip_with` is the first user of the three-argument `createLambda` overload, which was added by SPARK-59254 but had no caller until now.

### Why are the changes needed?

For feature parity with Apache Spark. These four functions exist in both the
Scala and Python clients but had no Swift equivalent. They complete the set of
higher-order functions, whose array half landed in SPARK-59254.

### Does this PR introduce _any_ user-facing change?

Yes, this adds new public APIs. For example:

```swift
let df = try await spark.range(1)
let m = map_from_arrays(array(lit(1), lit(2)), array(lit(10), lit(20)))

try await df.select(map_filter(m) { _, v in v > 10 }.cast("string")).show()
// {2 -> 20}

try await df.select(transform_keys(m) { k, v in k + v }.cast("string")).show()
// {11 -> 10, 22 -> 20}

try await df.select(transform_values(m) { k, v in k + v }.cast("string")).show()
// {1 -> 11, 2 -> 22}

let m2 = map_from_arrays(array(lit(1), lit(2)), array(lit(100), lit(200)))
try await df.select(map_zip_with(m, m2) { _, v1, v2 in v1 + v2 }.cast("string")).show()
// {1 -> 110, 2 -> 220}
```

All four functions were introduced in Spark 3.1.0, so no version gate is needed.

### How was this patch tested?

Extended the existing `HigherOrderFunctionsTests` suite.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5