### PR TITLE
[SPARK-59260] Index all public functions and types in the DocC catalog

### DIFF
--- a/Sources/SparkConnect/Documentation.docc/AggregateFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/AggregateFunctions.md
@@ -1,0 +1,174 @@
+# Aggregate Functions
+
+Summarize groups of rows with counts, statistics, sketches, and collections.
+
+## Overview
+
+Aggregate functions reduce many rows to one value. Use them with
+``DataFrame/groupBy(_:)`` or ``GroupedData/agg(_:_:)``, or as window functions with
+``Column/over(_:)``.
+
+```swift
+try await df.groupBy("dept")
+  .agg(count(lit(1)).alias("n"), avg(col("salary")), stddev(col("salary")))
+  .show()
+```
+
+Sketch-based approximate aggregates are listed here as well; the scalar
+functions that read their results live in <doc:SketchFunctions>.
+
+## Topics
+
+### General
+
+- ``any_value(_:)``
+- ``any_value(_:_:)``
+- ``avg(_:)``
+- ``count(_:)``
+- ``countDistinct(_:_:)``
+- ``count_distinct(_:_:)``
+- ``count_if(_:)``
+- ``first(_:)``
+- ``first(_:_:)``
+- ``first_value(_:)``
+- ``first_value(_:_:)``
+- ``grouping(_:)``
+- ``grouping_id(_:)``
+- ``last(_:)``
+- ``last(_:_:)``
+- ``last_value(_:)``
+- ``last_value(_:_:)``
+- ``max(_:)``
+- ``max_by(_:_:)``
+- ``mean(_:)``
+- ``median(_:)``
+- ``min(_:)``
+- ``min_by(_:_:)``
+- ``mode(_:)``
+- ``mode(_:_:)``
+- ``product(_:)``
+- ``sum(_:)``
+- ``sumDistinct(_:)``
+- ``sum_distinct(_:)``
+- ``try_avg(_:)``
+- ``try_sum(_:)``
+
+### Statistical
+
+- ``approx_count_distinct(_:)``
+- ``approx_count_distinct(_:_:)``
+- ``approx_percentile(_:_:_:)-(_,Double,_)``
+- ``approx_percentile(_:_:_:)-(_,[Double],_)``
+- ``corr(_:_:)``
+- ``count_min_sketch(_:_:_:)``
+- ``count_min_sketch(_:_:_:_:)``
+- ``covar_pop(_:_:)``
+- ``covar_samp(_:_:)``
+- ``histogram_numeric(_:_:)``
+- ``kurtosis(_:)``
+- ``percentile(_:_:_:)-(_,Double,_)``
+- ``percentile(_:_:_:)-(_,[Double],_)``
+- ``percentile_approx(_:_:_:)``
+- ``skewness(_:)``
+- ``std(_:)``
+- ``stddev(_:)``
+- ``stddev_pop(_:)``
+- ``stddev_samp(_:)``
+- ``var_pop(_:)``
+- ``var_samp(_:)``
+- ``variance(_:)``
+
+### Regression
+
+- ``regr_avgx(_:_:)``
+- ``regr_avgy(_:_:)``
+- ``regr_count(_:_:)``
+- ``regr_intercept(_:_:)``
+- ``regr_r2(_:_:)``
+- ``regr_slope(_:_:)``
+- ``regr_sxx(_:_:)``
+- ``regr_sxy(_:_:)``
+- ``regr_syy(_:_:)``
+
+### Boolean and Bitwise
+
+- ``bit_and(_:)``
+- ``bit_or(_:)``
+- ``bit_xor(_:)``
+- ``bitmap_and_agg(_:)``
+- ``bitmap_construct_agg(_:)``
+- ``bitmap_or_agg(_:)``
+- ``bool_and(_:)``
+- ``bool_or(_:)``
+- ``every(_:)``
+- ``some(_:)``
+
+### Collections
+
+- ``array_agg(_:)``
+- ``collect_list(_:)``
+- ``collect_set(_:)``
+- ``collect_union(_:)``
+- ``listagg(_:)``
+- ``listagg(_:_:)``
+- ``listagg_distinct(_:)``
+- ``listagg_distinct(_:_:)``
+- ``string_agg(_:)``
+- ``string_agg(_:_:)``
+- ``string_agg_distinct(_:)``
+- ``string_agg_distinct(_:_:)``
+
+### Sketches
+
+- ``hll_sketch_agg(_:)``
+- ``hll_sketch_agg(_:_:)-(_,Column)``
+- ``hll_sketch_agg(_:_:)-(_,Int32)``
+- ``hll_union_agg(_:)``
+- ``hll_union_agg(_:_:)-(_,Bool)``
+- ``hll_union_agg(_:_:)-(_,Column)``
+- ``kll_merge_agg_bigint(_:)``
+- ``kll_merge_agg_bigint(_:_:)-(_,Column)``
+- ``kll_merge_agg_bigint(_:_:)-(_,Int32)``
+- ``kll_merge_agg_double(_:)``
+- ``kll_merge_agg_double(_:_:)-(_,Column)``
+- ``kll_merge_agg_double(_:_:)-(_,Int32)``
+- ``kll_merge_agg_float(_:)``
+- ``kll_merge_agg_float(_:_:)-(_,Column)``
+- ``kll_merge_agg_float(_:_:)-(_,Int32)``
+- ``kll_sketch_agg_bigint(_:)``
+- ``kll_sketch_agg_bigint(_:_:)-(_,Column)``
+- ``kll_sketch_agg_bigint(_:_:)-(_,Int32)``
+- ``kll_sketch_agg_double(_:)``
+- ``kll_sketch_agg_double(_:_:)-(_,Column)``
+- ``kll_sketch_agg_double(_:_:)-(_,Int32)``
+- ``kll_sketch_agg_float(_:)``
+- ``kll_sketch_agg_float(_:_:)-(_,Column)``
+- ``kll_sketch_agg_float(_:_:)-(_,Int32)``
+- ``theta_intersection_agg(_:)``
+- ``theta_sketch_agg(_:)``
+- ``theta_sketch_agg(_:_:)-(_,Column)``
+- ``theta_sketch_agg(_:_:)-(_,Int32)``
+- ``theta_union_agg(_:)``
+- ``theta_union_agg(_:_:)-(_,Column)``
+- ``theta_union_agg(_:_:)-(_,Int32)``
+- ``tuple_intersection_agg_double(_:)``
+- ``tuple_intersection_agg_double(_:mode:)``
+- ``tuple_intersection_agg_integer(_:)``
+- ``tuple_intersection_agg_integer(_:mode:)``
+- ``tuple_sketch_agg_double(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_sketch_agg_double(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``
+- ``tuple_sketch_agg_integer(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_sketch_agg_integer(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``
+- ``tuple_union_agg_double(_:lgNomEntries:mode:)-(_,Column,_)``
+- ``tuple_union_agg_double(_:lgNomEntries:mode:)-(_,Int32,_)``
+- ``tuple_union_agg_integer(_:lgNomEntries:mode:)-(_,Column,_)``
+- ``tuple_union_agg_integer(_:lgNomEntries:mode:)-(_,Int32,_)``
+
+### Vectors
+
+- ``vector_avg(_:)``
+- ``vector_sum(_:)``
+
+### Variant
+
+- ``schema_of_variant_agg(_:)``

--- a/Sources/SparkConnect/Documentation.docc/CollectionFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/CollectionFunctions.md
@@ -1,0 +1,122 @@
+# Collection Functions
+
+Work with array, map, and struct columns, including higher-order functions.
+
+## Overview
+
+```swift
+try await df.select(array_contains(col("tags"), "swift"),
+                    transform(col("nums"), { $0 * 2 }),
+                    map_keys(col("attrs")))
+  .show()
+```
+
+## Topics
+
+### Array Construction
+
+- ``array(_:)``
+- ``array_repeat(_:_:)-(_,Int32)``
+- ``array_repeat(_:_:)-(_,Column)``
+- ``arrays_zip(_:)``
+- ``sequence(_:_:)``
+- ``sequence(_:_:_:)``
+- ``stack(_:)``
+
+### Array Access
+
+- ``array_contains(_:_:)-(_,Column)``
+- ``array_contains(_:_:)-(_,SparkLiteral)``
+- ``array_position(_:_:)-(_,Column)``
+- ``array_position(_:_:)-(_,SparkLiteral)``
+- ``arrays_overlap(_:_:)``
+- ``element_at(_:_:)-(_,Column)``
+- ``element_at(_:_:)-(_,SparkLiteral)``
+- ``get(_:_:)``
+- ``slice(_:_:_:)-(_,Column,_)``
+- ``slice(_:_:_:)-(_,Int32,_)``
+- ``try_element_at(_:_:)``
+
+### Array Modification
+
+- ``array_append(_:_:)-(_,Column)``
+- ``array_append(_:_:)-(_,SparkLiteral)``
+- ``array_compact(_:)``
+- ``array_distinct(_:)``
+- ``array_insert(_:_:_:)``
+- ``array_prepend(_:_:)-(_,Column)``
+- ``array_prepend(_:_:)-(_,SparkLiteral)``
+- ``array_remove(_:_:)-(_,Column)``
+- ``array_remove(_:_:)-(_,SparkLiteral)``
+- ``array_sort(_:)``
+- ``array_sort(_:_:)``
+- ``reverse(_:)``
+- ``shuffle(_:)``
+- ``shuffle(_:_:)``
+- ``sort_array(_:)``
+- ``sort_array(_:_:)``
+
+### Array Summaries
+
+- ``array_join(_:_:)``
+- ``array_join(_:_:_:)``
+- ``array_max(_:)``
+- ``array_min(_:)``
+- ``array_size(_:)``
+- ``cardinality(_:)``
+- ``size(_:)``
+
+### Set Operations
+
+- ``array_except(_:_:)``
+- ``array_intersect(_:_:)``
+- ``array_union(_:_:)``
+
+### Maps
+
+- ``map(_:)``
+- ``map_concat(_:)``
+- ``map_contains_key(_:_:)-(_,Column)``
+- ``map_contains_key(_:_:)-(_,SparkLiteral)``
+- ``map_entries(_:)``
+- ``map_filter(_:_:)``
+- ``map_from_arrays(_:_:)``
+- ``map_from_entries(_:)``
+- ``map_keys(_:)``
+- ``map_values(_:)``
+- ``map_zip_with(_:_:_:)``
+- ``str_to_map(_:)``
+- ``str_to_map(_:_:)``
+- ``str_to_map(_:_:_:)``
+
+### Structs
+
+- ``named_struct(_:)``
+- ``struct(_:)``
+
+### Flattening
+
+- ``concat(_:)``
+- ``explode(_:)``
+- ``explode_outer(_:)``
+- ``flatten(_:)``
+- ``inline(_:)``
+- ``inline_outer(_:)``
+- ``posexplode(_:)``
+- ``posexplode_outer(_:)``
+
+### Higher-Order Functions
+
+- ``aggregate(_:_:_:)``
+- ``aggregate(_:_:_:finish:)``
+- ``exists(_:_:)``
+- ``filter(_:_:)-(_,(Column)->Column)``
+- ``filter(_:_:)-(_,(Column,Column)->Column)``
+- ``forall(_:_:)``
+- ``reduce(_:_:_:)``
+- ``reduce(_:_:_:finish:)``
+- ``transform(_:_:)-(_,(Column)->Column)``
+- ``transform(_:_:)-(_,(Column,Column)->Column)``
+- ``transform_keys(_:_:)``
+- ``transform_values(_:_:)``
+- ``zip_with(_:_:_:)``

--- a/Sources/SparkConnect/Documentation.docc/Column.md
+++ b/Sources/SparkConnect/Documentation.docc/Column.md
@@ -1,0 +1,155 @@
+# ``SparkConnect/Column``
+
+A column expression: the value that ``DataFrame`` operations select, filter,
+and aggregate on.
+
+## Overview
+
+Create a `Column` with ``col(_:)``, `lit`, or ``expr(_:)``, then compose
+it with operators and the methods below. The complete set of SQL functions that
+produce columns is listed in <doc:Functions>.
+
+```swift
+let df = try await spark.sql("SELECT * FROM people")
+
+try await df
+  .select(col("name"), (col("age") + 1).alias("next_age"))
+  .filter(col("age").between(20, 29) && col("name").startsWith("A"))
+  .orderBy(col("age").desc())
+  .show()
+```
+
+Swift's operators are overloaded for `Column`, so `col("a") + 1`,
+`col("a") == "x"`, and `col("a") && col("b")` all build expressions rather than
+evaluating locally.
+
+## Topics
+
+### Creating a Column
+
+- ``Column/init(_:)``
+
+### Arithmetic Operators
+
+- ``Column/+(_:_:)-(Column,Column)``
+- ``Column/+(_:_:)-(_,SparkLiteral)``
+- ``Column/+(_:_:)-(SparkLiteral,_)``
+- ``Column/-(_:)``
+- ``Column/-(_:_:)-5jg0c``
+- ``Column/-(_:_:)-3xuar``
+- ``Column/-(_:_:)-6p3n1``
+- ``Column/*(_:_:)-(Column,Column)``
+- ``Column/*(_:_:)-(_,SparkLiteral)``
+- ``Column/*(_:_:)-(SparkLiteral,_)``
+- ``Column//(_:_:)-(Column,Column)``
+- ``Column//(_:_:)-(_,SparkLiteral)``
+- ``Column//(_:_:)-(SparkLiteral,_)``
+- ``Column/%(_:_:)-(Column,Column)``
+- ``Column/%(_:_:)-(_,SparkLiteral)``
+- ``Column/%(_:_:)-(SparkLiteral,_)``
+
+### Comparison Operators
+
+- ``Column/==(_:_:)-(Column,Column)``
+- ``Column/==(_:_:)-(_,SparkLiteral)``
+- ``Column/==(_:_:)-(SparkLiteral,_)``
+- ``Column/!=(_:_:)-(Column,Column)``
+- ``Column/!=(_:_:)-(_,SparkLiteral)``
+- ``Column/!=(_:_:)-(SparkLiteral,_)``
+- ``Column/<(_:_:)-(Column,Column)``
+- ``Column/<(_:_:)-(_,SparkLiteral)``
+- ``Column/<(_:_:)-(SparkLiteral,_)``
+- ``Column/<=(_:_:)-(Column,Column)``
+- ``Column/<=(_:_:)-(_,SparkLiteral)``
+- ``Column/<=(_:_:)-(SparkLiteral,_)``
+- ``Column/>(_:_:)-(Column,Column)``
+- ``Column/>(_:_:)-(_,SparkLiteral)``
+- ``Column/>(_:_:)-(SparkLiteral,_)``
+- ``Column/>=(_:_:)-(Column,Column)``
+- ``Column/>=(_:_:)-(_,SparkLiteral)``
+- ``Column/>=(_:_:)-(SparkLiteral,_)``
+- ``Column/eqNullSafe(_:)-(Column)``
+- ``Column/eqNullSafe(_:)-(SparkLiteral)``
+- ``Column/between(_:_:)-(Column,Column)``
+- ``Column/between(_:_:)-(Column,SparkLiteral)``
+- ``Column/between(_:_:)-(SparkLiteral,Column)``
+- ``Column/between(_:_:)-(SparkLiteral,SparkLiteral)``
+
+### Logical Operators
+
+- ``Column/&&(_:_:)-(Column,Column)``
+- ``Column/&&(_:_:)-(_,SparkLiteral)``
+- ``Column/&&(_:_:)-(SparkLiteral,_)``
+- ``Column/||(_:_:)-(Column,Column)``
+- ``Column/||(_:_:)-(_,SparkLiteral)``
+- ``Column/||(_:_:)-(SparkLiteral,_)``
+- ``Column/!(_:)``
+
+### Bitwise Operations
+
+- ``Column/bitwiseAND(_:)-(Column)``
+- ``Column/bitwiseAND(_:)-(SparkLiteral)``
+- ``Column/bitwiseOR(_:)-(Column)``
+- ``Column/bitwiseOR(_:)-(SparkLiteral)``
+- ``Column/bitwiseXOR(_:)-(Column)``
+- ``Column/bitwiseXOR(_:)-(SparkLiteral)``
+
+### Null Checks
+
+- ``Column/isNull()``
+- ``Column/isNotNull()``
+
+### String Matching
+
+- ``Column/contains(_:)-(Column)``
+- ``Column/contains(_:)-(SparkLiteral)``
+- ``Column/startsWith(_:)-(String)``
+- ``Column/startsWith(_:)-(Column)``
+- ``Column/endsWith(_:)-(String)``
+- ``Column/endsWith(_:)-(Column)``
+- ``Column/like(_:)``
+- ``Column/ilike(_:)``
+- ``Column/rlike(_:)``
+
+### Substrings
+
+- ``Column/substr(_:_:)-(Column,_)``
+- ``Column/substr(_:_:)-(Int,_)``
+
+### Set Membership
+
+- ``Column/isin(_:)``
+
+### Conditional Expressions
+
+- ``Column/when(_:_:)-(_,Column)``
+- ``Column/when(_:_:)-(_,SparkLiteral)``
+- ``Column/otherwise(_:)-(Column)``
+- ``Column/otherwise(_:)-(SparkLiteral)``
+
+### Type Conversion
+
+- ``Column/cast(_:)``
+
+### Complex Type Access
+
+- ``Column/getField(_:)``
+- ``Column/getItem(_:)``
+
+### Naming
+
+- ``Column/alias(_:)``
+
+### Sort Order
+
+- ``Column/asc()``
+- ``Column/ascNullsFirst()``
+- ``Column/ascNullsLast()``
+- ``Column/desc()``
+- ``Column/descNullsFirst()``
+- ``Column/descNullsLast()``
+
+### Window Frames
+
+- ``Column/over()``
+- ``Column/over(_:)``

--- a/Sources/SparkConnect/Documentation.docc/ColumnFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/ColumnFunctions.md
@@ -1,0 +1,52 @@
+# Column Functions
+
+Build column references, literals, and sort orders.
+
+## Overview
+
+Every SQL function in this library takes and returns a ``Column``. These
+functions create the columns you start from: a reference to a named column, a
+literal value, an arbitrary SQL expression, or a sort order for
+``DataFrame/orderBy(_:)``.
+
+```swift
+let df = try await spark.range(10)
+try await df.select(col("id"), lit("swift").alias("lang"))
+  .orderBy(desc("id"))
+  .show()
+```
+
+## Topics
+
+### Column References
+
+- ``col(_:)``
+- ``column(_:)``
+- ``expr(_:)``
+
+### Literals
+
+- ``lit(_:)-(Bool)``
+- ``lit(_:)-(Double)``
+- ``lit(_:)-(Float)``
+- ``lit(_:)-(Int)``
+- ``lit(_:)-(Int16)``
+- ``lit(_:)-(Int32)``
+- ``lit(_:)-(Int64)``
+- ``lit(_:)-(Int8)``
+- ``lit(_:)-(LocalTime)``
+- ``lit(_:)-(String)``
+- ``lit(_:)-(TimestampNanos)``
+
+### Sort Orders
+
+- ``asc(_:)``
+- ``asc_nulls_first(_:)``
+- ``asc_nulls_last(_:)``
+- ``desc(_:)``
+- ``desc_nulls_first(_:)``
+- ``desc_nulls_last(_:)``
+
+### Join Hints
+
+- ``broadcast(_:)``

--- a/Sources/SparkConnect/Documentation.docc/ConditionalFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/ConditionalFunctions.md
@@ -1,0 +1,44 @@
+# Conditional and Predicate Functions
+
+Branch on conditions, handle nulls, and match patterns.
+
+## Overview
+
+```swift
+try await df.select(when(col("age") < 18, "minor").otherwise("adult"),
+                    coalesce(col("nickname"), col("name")),
+                    col("email").rlike("@example\\.com$"))
+  .show()
+```
+
+## Topics
+
+### Conditional Expressions
+
+- ``coalesce(_:)``
+- ``ifnull(_:_:)``
+- ``nanvl(_:_:)``
+- ``nullif(_:_:)``
+- ``nullifzero(_:)``
+- ``nvl(_:_:)``
+- ``nvl2(_:_:_:)``
+- ``when(_:_:)-(_,Column)``
+- ``when(_:_:)-(_,SparkLiteral)``
+- ``zeroifnull(_:)``
+
+### Null and NaN Predicates
+
+- ``equal_null(_:_:)``
+- ``isnan(_:)``
+- ``isnotnull(_:)``
+- ``isnull(_:)``
+
+### Pattern Matching
+
+- ``ilike(_:_:)``
+- ``ilike(_:_:_:)``
+- ``like(_:_:)``
+- ``like(_:_:_:)``
+- ``regexp(_:_:)``
+- ``regexp_like(_:_:)``
+- ``rlike(_:_:)``

--- a/Sources/SparkConnect/Documentation.docc/DateTimeFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/DateTimeFunctions.md
@@ -1,0 +1,152 @@
+# Date and Time Functions
+
+Build, parse, extract, shift, and bucket dates, times, and timestamps.
+
+## Overview
+
+```swift
+try await df.select(current_date(), date_add(col("d"), 7),
+                    date_format(col("ts"), "yyyy-MM-dd HH:mm"))
+  .show()
+```
+
+## Topics
+
+### Current Date and Time
+
+- ``curdate()``
+- ``current_date()``
+- ``current_time()``
+- ``current_time(_:)``
+- ``current_timestamp()``
+- ``current_timezone()``
+- ``localtimestamp()``
+- ``now()``
+
+### Field Extraction
+
+- ``date_part(_:_:)``
+- ``datepart(_:_:)``
+- ``day(_:)``
+- ``dayname(_:)``
+- ``dayofmonth(_:)``
+- ``dayofweek(_:)``
+- ``dayofyear(_:)``
+- ``extract(_:_:)``
+- ``hour(_:)``
+- ``last_day(_:)``
+- ``minute(_:)``
+- ``month(_:)``
+- ``monthname(_:)``
+- ``next_day(_:_:)-(_,Column)``
+- ``next_day(_:_:)-(_,String)``
+- ``quarter(_:)``
+- ``second(_:)``
+- ``weekday(_:)``
+- ``weekofyear(_:)``
+- ``year(_:)``
+
+### Arithmetic
+
+- ``add_months(_:_:)-(_,Column)``
+- ``add_months(_:_:)-(_,Int32)``
+- ``date_add(_:_:)-(_,Column)``
+- ``date_add(_:_:)-(_,Int32)``
+- ``date_diff(_:_:)``
+- ``date_sub(_:_:)-(_,Column)``
+- ``date_sub(_:_:)-(_,Int32)``
+- ``date_trunc(_:_:)``
+- ``dateadd(_:_:)``
+- ``datediff(_:_:)``
+- ``months_between(_:_:)``
+- ``months_between(_:_:_:)``
+- ``time_diff(_:_:_:)``
+- ``time_trunc(_:_:)``
+- ``timestamp_add(_:_:_:)``
+- ``timestamp_diff(_:_:_:)``
+- ``trunc(_:_:)``
+
+### Construction
+
+- ``make_date(_:_:_:)``
+- ``make_dt_interval(days:hours:mins:secs:)``
+- ``make_interval(years:months:weeks:days:hours:mins:secs:)``
+- ``make_time(_:_:_:)``
+- ``make_timestamp(_:_:_:_:_:_:)``
+- ``make_timestamp(_:_:_:_:_:_:_:)``
+- ``make_timestamp_ltz(_:_:_:_:_:_:)``
+- ``make_timestamp_ltz(_:_:_:_:_:_:_:)``
+- ``make_timestamp_ntz(_:_:_:_:_:_:)``
+- ``make_ym_interval(years:months:)``
+- ``try_make_interval(years:months:weeks:days:hours:mins:secs:)``
+- ``try_make_timestamp(_:_:_:_:_:_:)``
+- ``try_make_timestamp(_:_:_:_:_:_:_:)``
+- ``try_make_timestamp_ltz(_:_:_:_:_:_:)``
+- ``try_make_timestamp_ltz(_:_:_:_:_:_:_:)``
+- ``try_make_timestamp_ntz(_:_:_:_:_:_:)``
+
+### Parsing and Formatting
+
+- ``date_format(_:_:)``
+- ``from_unixtime(_:)``
+- ``from_unixtime(_:_:)``
+- ``to_date(_:)``
+- ``to_date(_:_:)``
+- ``to_time(_:)``
+- ``to_time(_:_:)``
+- ``to_timestamp(_:)``
+- ``to_timestamp(_:_:)``
+- ``to_timestamp_ltz(_:)``
+- ``to_timestamp_ltz(_:_:)``
+- ``to_timestamp_ntz(_:)``
+- ``to_timestamp_ntz(_:_:)``
+- ``to_unix_timestamp(_:)``
+- ``to_unix_timestamp(_:_:)``
+- ``try_to_date(_:)``
+- ``try_to_date(_:_:)``
+- ``try_to_time(_:)``
+- ``try_to_time(_:_:)``
+- ``try_to_timestamp(_:)``
+- ``try_to_timestamp(_:_:)``
+- ``unix_timestamp()``
+- ``unix_timestamp(_:)``
+- ``unix_timestamp(_:_:)``
+
+### Epoch Conversion
+
+- ``date_from_unix_date(_:)``
+- ``time_from_micros(_:)``
+- ``time_from_millis(_:)``
+- ``time_from_seconds(_:)``
+- ``time_to_micros(_:)``
+- ``time_to_millis(_:)``
+- ``time_to_seconds(_:)``
+- ``timestamp_micros(_:)``
+- ``timestamp_millis(_:)``
+- ``timestamp_nanos(_:)``
+- ``timestamp_seconds(_:)``
+- ``unix_date(_:)``
+- ``unix_micros(_:)``
+- ``unix_millis(_:)``
+- ``unix_nanos(_:)``
+- ``unix_seconds(_:)``
+
+### Time Zones
+
+- ``convert_timezone(_:_:)``
+- ``convert_timezone(_:_:_:)``
+- ``from_utc_timestamp(_:_:)-(_,Column)``
+- ``from_utc_timestamp(_:_:)-(_,String)``
+- ``to_utc_timestamp(_:_:)-(_,Column)``
+- ``to_utc_timestamp(_:_:)-(_,String)``
+
+### Windowing
+
+- ``session_window(_:_:)-(_,Column)``
+- ``session_window(_:_:)-(_,String)``
+- ``time_bucket(_:_:)``
+- ``time_bucket(_:_:_:)``
+- ``window(_:_:)``
+- ``window(_:_:_:)``
+- ``window(_:_:_:_:)``
+- ``window_time(_:)``

--- a/Sources/SparkConnect/Documentation.docc/Functions.md
+++ b/Sources/SparkConnect/Documentation.docc/Functions.md
@@ -1,0 +1,56 @@
+# SQL Functions
+
+The SQL functions available to ``Column`` expressions, grouped by category.
+
+## Overview
+
+`SparkConnect` exposes Spark SQL's function library as free Swift functions
+that build ``Column`` expressions. Import the module and call them directly.
+
+```swift
+import SparkConnect
+
+let spark = try await SparkSession.builder.getOrCreate()
+let df = try await spark.sql("SELECT * FROM events")
+
+try await df.select(col("user"), to_date(col("ts")).alias("day"))
+  .groupBy("day")
+  .agg(count_distinct(col("user")).alias("dau"))
+  .orderBy(desc("dau"))
+  .show()
+```
+
+Availability follows the server: functions marked as requiring a specific
+Apache Spark version fail at runtime against older servers.
+
+## Topics
+
+### Building Columns
+
+- <doc:ColumnFunctions>
+
+### Aggregation
+
+- <doc:AggregateFunctions>
+- <doc:WindowFunctions>
+
+### Scalar Functions by Data Type
+
+- <doc:MathFunctions>
+- <doc:StringFunctions>
+- <doc:DateTimeFunctions>
+- <doc:CollectionFunctions>
+- <doc:SemiStructuredFunctions>
+- <doc:GeospatialFunctions>
+
+### Logic and Control Flow
+
+- <doc:ConditionalFunctions>
+
+### Approximation
+
+- <doc:SketchFunctions>
+
+### Everything Else
+
+- <doc:MiscFunctions>

--- a/Sources/SparkConnect/Documentation.docc/GeospatialFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/GeospatialFunctions.md
@@ -1,0 +1,33 @@
+# Geospatial Functions
+
+Construct and inspect GEOMETRY and GEOGRAPHY values.
+
+## Overview
+
+Geospatial support requires Apache Spark 4.2.0 or later and is controlled
+by the `spark.sql.geospatial.enabled` configuration.
+
+```swift
+try await df.select(st_srid(st_geomfromwkb(col("wkb"), 4326))).show()
+```
+
+## Topics
+
+### Construction
+
+- ``st_geogfromwkb(_:)``
+- ``st_geomfromwkb(_:)``
+- ``st_geomfromwkb(_:_:)-(_,Column)``
+- ``st_geomfromwkb(_:_:)-(_,Int32)``
+
+### Serialization
+
+- ``st_asbinary(_:)``
+- ``st_asbinary(_:_:)-(_,Column)``
+- ``st_asbinary(_:_:)-(_,String)``
+
+### Spatial Reference Systems
+
+- ``st_setsrid(_:_:)-(_,Column)``
+- ``st_setsrid(_:_:)-(_,Int32)``
+- ``st_srid(_:)``

--- a/Sources/SparkConnect/Documentation.docc/Info.plist
+++ b/Sources/SparkConnect/Documentation.docc/Info.plist
@@ -24,9 +24,7 @@
     <string>org.apache.spark.connect.swift.SparkConnect</string>
     <key>CFBundleName</key>
     <string>SparkConnect</string>
-    <key>CFBundleVersion</key>
-    <string>0.1.0</string>
     <key>NSHumanReadableCopyright</key>
-    <string>© 2025 Apache Software Foundation</string>
+    <string>© 2025 and onwards, The Apache Software Foundation</string>
 </dict>
 </plist>

--- a/Sources/SparkConnect/Documentation.docc/MathFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/MathFunctions.md
@@ -1,0 +1,121 @@
+# Math Functions
+
+Arithmetic, rounding, trigonometry, bitwise, and vector operations.
+
+## Overview
+
+```swift
+try await df.select(round(col("value"), 2), sqrt(col("value")), abs(col("delta")))
+  .show()
+```
+
+## Topics
+
+### Arithmetic
+
+- ``abs(_:)``
+- ``greatest(_:_:_:)``
+- ``least(_:_:_:)``
+- ``negative(_:)``
+- ``pmod(_:_:)``
+- ``positive(_:)``
+- ``pow(_:_:)``
+- ``power(_:_:)``
+- ``sign(_:)``
+- ``signum(_:)``
+- ``try_add(_:_:)``
+- ``try_divide(_:_:)``
+- ``try_mod(_:_:)``
+- ``try_multiply(_:_:)``
+- ``try_subtract(_:_:)``
+
+### Rounding
+
+- ``bround(_:)``
+- ``bround(_:_:)``
+- ``ceil(_:)``
+- ``ceil(_:_:)``
+- ``ceiling(_:)``
+- ``ceiling(_:_:)``
+- ``floor(_:)``
+- ``floor(_:_:)``
+- ``rint(_:)``
+- ``round(_:)``
+- ``round(_:_:)``
+
+### Exponential and Logarithmic
+
+- ``cbrt(_:)``
+- ``e()``
+- ``exp(_:)``
+- ``expm1(_:)``
+- ``ln(_:)``
+- ``log(_:)``
+- ``log(_:_:)``
+- ``log10(_:)``
+- ``log1p(_:)``
+- ``log2(_:)``
+- ``sqrt(_:)``
+
+### Trigonometric
+
+- ``acos(_:)``
+- ``acosh(_:)``
+- ``asin(_:)``
+- ``asinh(_:)``
+- ``atan(_:)``
+- ``atan2(_:_:)``
+- ``atanh(_:)``
+- ``cos(_:)``
+- ``cosh(_:)``
+- ``cot(_:)``
+- ``csc(_:)``
+- ``degrees(_:)``
+- ``hypot(_:_:)``
+- ``pi()``
+- ``radians(_:)``
+- ``sec(_:)``
+- ``sin(_:)``
+- ``sinh(_:)``
+- ``tan(_:)``
+- ``tanh(_:)``
+
+### Number Bases and Conversion
+
+- ``bin(_:)``
+- ``conv(_:_:_:)``
+- ``factorial(_:)``
+- ``hex(_:)``
+- ``unhex(_:)``
+- ``width_bucket(_:_:_:_:)``
+
+### Random
+
+- ``rand()``
+- ``rand(_:)``
+- ``randn()``
+- ``randn(_:)``
+- ``uniform(_:_:)``
+- ``uniform(_:_:_:)``
+
+### Bitwise
+
+- ``bit_count(_:)``
+- ``bit_get(_:_:)``
+- ``bitwise_not(_:)``
+- ``getbit(_:_:)``
+- ``shiftleft(_:_:)``
+- ``shiftright(_:_:)``
+- ``shiftrightunsigned(_:_:)``
+
+### Vectors
+
+- ``vector_cosine_similarity(_:_:)``
+- ``vector_inner_product(_:_:)``
+- ``vector_l2_distance(_:_:)``
+- ``vector_norm(_:)``
+- ``vector_norm(_:_:)-(_,Column)``
+- ``vector_norm(_:_:)-(_,Float)``
+- ``vector_normalize(_:)``
+- ``vector_normalize(_:_:)-(_,Column)``
+- ``vector_normalize(_:_:)-(_,Float)``

--- a/Sources/SparkConnect/Documentation.docc/MiscFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/MiscFunctions.md
@@ -1,0 +1,86 @@
+# Misc Functions
+
+Session metadata, hashing, encryption, partition transforms, and UDF calls.
+
+## Overview
+
+```swift
+try await spark.range(1).select(current_user(), version(), md5(lit("spark"))).show()
+```
+
+## Topics
+
+### Session and Environment
+
+- ``current_catalog()``
+- ``current_database()``
+- ``current_path()``
+- ``current_schema()``
+- ``current_user()``
+- ``monotonically_increasing_id()``
+- ``session_user()``
+- ``spark_partition_id()``
+- ``typeof(_:)``
+- ``user()``
+- ``uuid()``
+- ``uuid(_:)-(Column)``
+- ``uuid(_:)-(SparkLiteral)``
+- ``version()``
+
+### Input File Metadata
+
+- ``input_file_block_length()``
+- ``input_file_block_start()``
+- ``input_file_name()``
+
+### Bitmaps
+
+- ``bitmap_bit_position(_:)``
+- ``bitmap_bucket_number(_:)``
+- ``bitmap_count(_:)``
+
+### Assertions and Errors
+
+- ``assert_true(_:)``
+- ``assert_true(_:_:)-(_,Column)``
+- ``assert_true(_:_:)-(_,String)``
+- ``raise_error(_:)-(Column)``
+- ``raise_error(_:)-(String)``
+
+### Reflection
+
+- ``java_method(_:)``
+- ``reflect(_:)``
+- ``try_reflect(_:)``
+
+### Hashing
+
+- ``crc32(_:)``
+- ``hash(_:)``
+- ``md5(_:)``
+- ``sha(_:)``
+- ``sha1(_:)``
+- ``sha2(_:_:)``
+- ``xxhash64(_:)``
+
+### Encryption
+
+- ``aes_decrypt(_:_:mode:padding:aad:)``
+- ``aes_encrypt(_:_:mode:padding:iv:aad:)``
+- ``hmac(_:_:)``
+- ``hmac(_:_:_:)``
+- ``try_aes_decrypt(_:_:mode:padding:aad:)``
+
+### User-Defined Functions
+
+- ``call_function(_:_:)``
+- ``call_udf(_:_:)``
+
+### Partition Transforms
+
+- ``bucket(_:_:)-(Column,_)``
+- ``bucket(_:_:)-(Int32,_)``
+- ``days(_:)``
+- ``hours(_:)``
+- ``months(_:)``
+- ``years(_:)``

--- a/Sources/SparkConnect/Documentation.docc/SemiStructuredFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/SemiStructuredFunctions.md
@@ -1,0 +1,79 @@
+# Semi-Structured Data Functions
+
+Parse and generate JSON, XML, CSV, and VARIANT values.
+
+## Overview
+
+```swift
+try await df.select(from_json(col("payload"), "id INT, name STRING"),
+                    to_json(col("record")),
+                    variant_get(parse_json(col("raw")), "$.id", "int"))
+  .show()
+```
+
+## Topics
+
+### JSON
+
+- ``from_json(_:_:_:)-(_,Column,_)``
+- ``from_json(_:_:_:)-(_,String,_)``
+- ``from_json(_:_:_:)-(_,StructType,_)``
+- ``get_json_object(_:_:)``
+- ``json_array_length(_:)``
+- ``json_object_keys(_:)``
+- ``json_tuple(_:_:)``
+- ``schema_of_json(_:_:)-(Column,_)``
+- ``schema_of_json(_:_:)-(String,_)``
+- ``to_json(_:_:)``
+
+### XML
+
+- ``from_xml(_:_:_:)-(_,Column,_)``
+- ``from_xml(_:_:_:)-(_,String,_)``
+- ``from_xml(_:_:_:)-(_,StructType,_)``
+- ``schema_of_xml(_:_:)-(Column,_)``
+- ``schema_of_xml(_:_:)-(String,_)``
+- ``to_xml(_:_:)``
+- ``xpath(_:_:)``
+- ``xpath_boolean(_:_:)``
+- ``xpath_double(_:_:)``
+- ``xpath_float(_:_:)``
+- ``xpath_int(_:_:)``
+- ``xpath_long(_:_:)``
+- ``xpath_number(_:_:)``
+- ``xpath_short(_:_:)``
+- ``xpath_string(_:_:)``
+
+### CSV
+
+- ``from_csv(_:_:_:)-(_,Column,_)``
+- ``from_csv(_:_:_:)-(_,String,_)``
+- ``schema_of_csv(_:_:)-(Column,_)``
+- ``schema_of_csv(_:_:)-(String,_)``
+- ``to_csv(_:_:)``
+
+### Variant
+
+- ``is_valid_variant(_:)``
+- ``is_variant_null(_:)``
+- ``parse_json(_:)``
+- ``schema_of_variant(_:)``
+- ``to_variant_object(_:)``
+- ``try_parse_json(_:)``
+- ``try_variant_array_append(_:_:_:)-(_,Column,_)``
+- ``try_variant_array_append(_:_:_:)-(_,String,_)``
+- ``try_variant_get(_:_:_:)-(_,Column,_)``
+- ``try_variant_get(_:_:_:)-(_,String,_)``
+- ``try_variant_insert(_:_:_:)-(_,Column,_)``
+- ``try_variant_insert(_:_:_:)-(_,String,_)``
+- ``try_variant_set(_:_:_:_:)-(_,Column,_,_)``
+- ``try_variant_set(_:_:_:_:)-(_,String,_,_)``
+- ``variant_array_append(_:_:_:)-(_,Column,_)``
+- ``variant_array_append(_:_:_:)-(_,String,_)``
+- ``variant_get(_:_:_:)-(_,Column,_)``
+- ``variant_get(_:_:_:)-(_,String,_)``
+- ``variant_insert(_:_:_:)-(_,Column,_)``
+- ``variant_insert(_:_:_:)-(_,String,_)``
+- ``variant_set(_:_:_:_:)-(_,Column,_,_)``
+- ``variant_set(_:_:_:_:)-(_,String,_,_)``
+- ``variant_strip_nulls(_:_:)``

--- a/Sources/SparkConnect/Documentation.docc/SketchFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/SketchFunctions.md
@@ -1,0 +1,83 @@
+# Sketch Functions
+
+Read and combine HyperLogLog, Theta, KLL, and Tuple sketches.
+
+## Overview
+
+Sketches are compact, mergeable summaries used for approximate distinct
+counts, set operations, and quantiles. Build them with the sketch aggregates in
+<doc:AggregateFunctions>, then use the scalar functions here to merge sketches
+and read estimates out of them.
+
+```swift
+try await df.groupBy("day")
+  .agg(hll_sketch_agg(col("user_id")).alias("sk"))
+  .select(hll_sketch_estimate(col("sk")))
+  .show()
+```
+
+## Topics
+
+### HyperLogLog
+
+- ``hll_sketch_estimate(_:)``
+- ``hll_union(_:_:)``
+- ``hll_union(_:_:_:)``
+
+### Theta
+
+- ``theta_difference(_:_:)``
+- ``theta_intersection(_:_:)``
+- ``theta_sketch_estimate(_:)``
+- ``theta_union(_:_:)``
+- ``theta_union(_:_:_:)-(_,_,Column)``
+- ``theta_union(_:_:_:)-(_,_,Int32)``
+
+### KLL
+
+- ``kll_sketch_get_n_bigint(_:)``
+- ``kll_sketch_get_n_double(_:)``
+- ``kll_sketch_get_n_float(_:)``
+- ``kll_sketch_get_quantile_bigint(_:_:)``
+- ``kll_sketch_get_quantile_double(_:_:)``
+- ``kll_sketch_get_quantile_float(_:_:)``
+- ``kll_sketch_get_rank_bigint(_:_:)``
+- ``kll_sketch_get_rank_double(_:_:)``
+- ``kll_sketch_get_rank_float(_:_:)``
+- ``kll_sketch_merge_bigint(_:_:)``
+- ``kll_sketch_merge_double(_:_:)``
+- ``kll_sketch_merge_float(_:_:)``
+- ``kll_sketch_to_string_bigint(_:)``
+- ``kll_sketch_to_string_double(_:)``
+- ``kll_sketch_to_string_float(_:)``
+
+### Tuple
+
+- ``tuple_difference_double(_:_:)``
+- ``tuple_difference_integer(_:_:)``
+- ``tuple_difference_theta_double(_:_:)``
+- ``tuple_difference_theta_integer(_:_:)``
+- ``tuple_intersection_double(_:_:)``
+- ``tuple_intersection_double(_:_:mode:)``
+- ``tuple_intersection_integer(_:_:)``
+- ``tuple_intersection_integer(_:_:mode:)``
+- ``tuple_intersection_theta_double(_:_:)``
+- ``tuple_intersection_theta_double(_:_:mode:)``
+- ``tuple_intersection_theta_integer(_:_:)``
+- ``tuple_intersection_theta_integer(_:_:mode:)``
+- ``tuple_sketch_estimate_double(_:)``
+- ``tuple_sketch_estimate_integer(_:)``
+- ``tuple_sketch_summary_double(_:)``
+- ``tuple_sketch_summary_double(_:mode:)``
+- ``tuple_sketch_summary_integer(_:)``
+- ``tuple_sketch_summary_integer(_:mode:)``
+- ``tuple_sketch_theta_double(_:)``
+- ``tuple_sketch_theta_integer(_:)``
+- ``tuple_union_double(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_union_double(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``
+- ``tuple_union_integer(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_union_integer(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``
+- ``tuple_union_theta_double(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_union_theta_double(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``
+- ``tuple_union_theta_integer(_:_:lgNomEntries:mode:)-(_,_,Column,_)``
+- ``tuple_union_theta_integer(_:_:lgNomEntries:mode:)-(_,_,Int32,_)``

--- a/Sources/SparkConnect/Documentation.docc/SparkConnect.md
+++ b/Sources/SparkConnect/Documentation.docc/SparkConnect.md
@@ -24,15 +24,29 @@ SparkConnect is a modern Swift library that provides a native interface to Apach
 ### Sessions
 
 - ``SparkSession``
+- ``RuntimeConf``
 
 ### DataFrames
 
 - ``DataFrame``
 - ``GroupedData``
+- ``DataFrameNaFunctions``
+- ``DataFrameStatFunctions``
+- ``Observation``
 - ``Row``
-- ``LocalTime``
-- ``TimestampNanos``
+- ``RowSchema``
 - ``StorageLevel``
+
+### Expressions
+
+- ``Column``
+- ``SparkLiteral``
+- <doc:Functions>
+
+### Window Frames
+
+- ``Window``
+- ``WindowSpec``
 
 ### Data Types
 
@@ -40,6 +54,8 @@ SparkConnect is a modern Swift library that provides a native interface to Apach
 - ``StructType``
 - ``StructField``
 - ``UserDefinedType``
+- ``LocalTime``
+- ``TimestampNanos``
 - ``YearMonthIntervalField``
 - ``DayTimeIntervalField``
 
@@ -47,20 +63,47 @@ SparkConnect is a modern Swift library that provides a native interface to Apach
 
 - ``DataFrameReader``
 - ``DataFrameWriter``
+- ``DataFrameWriterV2``
 - ``MergeIntoWriter``
+- ``WhenMatched``
+- ``WhenNotMatched``
+- ``WhenNotMatchedBySource``
 
-### Catalog & Configuration
+### Catalog
 
 - ``Catalog``
-- ``RuntimeConf``
+- ``CatalogMetadata``
+- ``Database``
+- ``SparkTable``
+- ``CatalogColumn``
+- ``Function``
+- ``TablePartition``
 
 ### Streaming
 
 - ``DataStreamReader``
 - ``DataStreamWriter``
+- ``Trigger``
 - ``StreamingQuery``
 - ``StreamingQueryManager``
+- ``StreamingQueryException``
+- ``StreamingQueryStatus``
 - ``StreamingQueryProgress``
 - ``SourceProgress``
 - ``SinkProgress``
 - ``StateOperatorProgress``
+
+### Error Handling
+
+- ``SparkConnectError``
+- ``~=(_:_:)``
+
+### Low-Level and Utility APIs
+
+- ``SparkConnectClient``
+- ``CaseInsensitiveDictionary``
+- ``ErrorUtils``
+- ``ProtoUtils``
+- ``SparkFileUtils``
+- ``CRC32``
+- ``SHA256``

--- a/Sources/SparkConnect/Documentation.docc/StringFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/StringFunctions.md
@@ -1,0 +1,179 @@
+# String Functions
+
+Manipulate, search, encode, and validate string columns.
+
+## Overview
+
+```swift
+try await df.select(upper(col("name")), substring(col("code"), 1, 3),
+                    regexp_replace(col("text"), "\\s+", " "))
+  .show()
+```
+
+## Topics
+
+### Case Conversion
+
+- ``initcap(_:)``
+- ``lcase(_:)``
+- ``lower(_:)``
+- ``ucase(_:)``
+- ``upper(_:)``
+
+### Length and Position
+
+- ``bit_length(_:)``
+- ``char_length(_:)``
+- ``character_length(_:)``
+- ``find_in_set(_:_:)``
+- ``instr(_:_:)-(_,Column)``
+- ``instr(_:_:)-(_,String)``
+- ``instr(_:_:_:)-(_,_,Column)``
+- ``instr(_:_:_:)-(_,_,Int32)``
+- ``instr(_:_:_:_:)-(_,_,Column,_)``
+- ``instr(_:_:_:_:)-(_,_,Int32,_)``
+- ``len(_:)``
+- ``length(_:)``
+- ``locate(_:_:)``
+- ``locate(_:_:_:)``
+- ``octet_length(_:)``
+- ``position(_:_:)``
+- ``position(_:_:_:)``
+
+### Padding and Trimming
+
+- ``btrim(_:)``
+- ``btrim(_:_:)``
+- ``lpad(_:_:_:)-(_,Column,_)``
+- ``lpad(_:_:_:)-(_,Int32,_)``
+- ``ltrim(_:)``
+- ``ltrim(_:_:)-(_,Column)``
+- ``ltrim(_:_:)-(_,String)``
+- ``rpad(_:_:_:)-(_,Column,_)``
+- ``rpad(_:_:_:)-(_,Int32,_)``
+- ``rtrim(_:)``
+- ``rtrim(_:_:)-(_,Column)``
+- ``rtrim(_:_:)-(_,String)``
+- ``trim(_:)``
+- ``trim(_:_:)-(_,Column)``
+- ``trim(_:_:)-(_,String)``
+
+### Substrings and Splitting
+
+- ``elt(_:)``
+- ``left(_:_:)``
+- ``right(_:_:)``
+- ``split(_:_:)-(_,Column)``
+- ``split(_:_:)-(_,String)``
+- ``split(_:_:_:)-(_,Column,_)``
+- ``split(_:_:_:)-(_,_,Int32)``
+- ``split_part(_:_:_:)``
+- ``substr(_:_:)``
+- ``substr(_:_:_:)``
+- ``substring(_:_:_:)-(_,Column,_)``
+- ``substring(_:_:_:)-(_,Int32,_)``
+- ``substring_index(_:_:_:)``
+
+### Concatenation and Formatting
+
+- ``concat_ws(_:_:)``
+- ``format_number(_:_:)``
+- ``format_string(_:_:)``
+- ``printf(_:_:)``
+- ``repeat(_:_:)-(_,Column)``
+- ``repeat(_:_:)-(_,Int32)``
+
+### Search and Replace
+
+- ``contains(_:_:)``
+- ``endswith(_:_:)``
+- ``overlay(_:_:_:)``
+- ``overlay(_:_:_:_:)``
+- ``quote(_:)``
+- ``replace(_:_:)``
+- ``replace(_:_:_:)``
+- ``startswith(_:_:)``
+- ``translate(_:_:_:)``
+
+### Regular Expressions
+
+- ``regexp_count(_:_:)``
+- ``regexp_extract(_:_:_:)``
+- ``regexp_extract_all(_:_:)``
+- ``regexp_extract_all(_:_:_:)``
+- ``regexp_instr(_:_:)``
+- ``regexp_instr(_:_:_:)``
+- ``regexp_replace(_:_:_:)-(_,Column,_)``
+- ``regexp_replace(_:_:_:)-(_,String,_)``
+- ``regexp_replace(_:_:_:_:)-(_,Column,_,_)``
+- ``regexp_replace(_:_:_:_:)-(_,_,_,Int32)``
+- ``regexp_substr(_:_:)``
+
+### Encoding and Decoding
+
+- ``ascii(_:)``
+- ``base64(_:)``
+- ``char(_:)``
+- ``chr(_:)``
+- ``decode(_:_:)``
+- ``encode(_:_:)``
+- ``from_base32(_:)``
+- ``to_base32(_:)``
+- ``to_binary(_:)``
+- ``to_binary(_:_:)``
+- ``try_to_binary(_:)``
+- ``try_to_binary(_:_:)``
+- ``unbase64(_:)``
+
+### UTF-8 Validation
+
+- ``is_valid_utf8(_:)``
+- ``make_valid_utf8(_:)``
+- ``try_validate_utf8(_:)``
+- ``validate_utf8(_:)``
+
+### Collation
+
+- ``collate(_:_:)``
+- ``collation(_:)``
+
+### Type Conversion
+
+- ``to_char(_:_:)``
+- ``to_number(_:_:)``
+- ``to_varchar(_:_:)``
+- ``try_to_number(_:_:)``
+
+### Similarity
+
+- ``jaro_winkler_similarity(_:_:)``
+- ``levenshtein(_:_:)``
+- ``levenshtein(_:_:_:)``
+- ``sentences(_:)``
+- ``sentences(_:_:)``
+- ``sentences(_:_:_:)``
+- ``soundex(_:)``
+
+### Masking and Randomness
+
+- ``mask(_:)``
+- ``mask(_:_:)``
+- ``mask(_:_:_:)``
+- ``mask(_:_:_:_:)``
+- ``mask(_:_:_:_:_:)``
+- ``randstr(_:)``
+- ``randstr(_:_:)``
+
+### URLs
+
+- ``parse_url(_:_:)-(_,Column)``
+- ``parse_url(_:_:)-(_,String)``
+- ``parse_url(_:_:_:)-(_,Column,_)``
+- ``parse_url(_:_:_:)-(_,String,_)``
+- ``try_parse_url(_:_:)-(_,Column)``
+- ``try_parse_url(_:_:)-(_,String)``
+- ``try_parse_url(_:_:_:)-(_,Column,_)``
+- ``try_parse_url(_:_:_:)-(_,String,_)``
+- ``try_url_decode(_:)``
+- ``url_decode(_:)``
+- ``url_encode(_:)``

--- a/Sources/SparkConnect/Documentation.docc/WindowFunctions.md
+++ b/Sources/SparkConnect/Documentation.docc/WindowFunctions.md
@@ -1,0 +1,41 @@
+# Window Functions
+
+Rank rows and reach across rows inside a window frame.
+
+## Overview
+
+Window functions are used with ``Column/over(_:)`` and a ``WindowSpec``
+built by ``Window``.
+
+```swift
+let w = Window.partitionBy("dept").orderBy("salary")
+try await df.select(col("name"), rank().over(w), lag(col("salary"), 1).over(w))
+  .show()
+```
+
+Ordinary aggregate functions can also be used over a window; see
+<doc:AggregateFunctions>.
+
+## Topics
+
+### Ranking
+
+- ``cume_dist()``
+- ``dense_rank()``
+- ``ntile(_:)``
+- ``percent_rank()``
+- ``rank()``
+- ``row_number()``
+
+### Value Access
+
+- ``lag(_:_:)``
+- ``lag(_:_:_:)``
+- ``lead(_:_:)``
+- ``lead(_:_:_:)``
+- ``nth_value(_:_:)``
+
+### Counters
+
+- ``counter_diff(_:)``
+- ``counter_diff(_:_:)``


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR rebuilds the DocC catalog's Topics index so that the library's public API is
discoverable in the generated documentation. No source code is changed.

**SQL functions.** None of the module-level functions were curated. All 753 public top-level
functions fell into DocC's automatically-generated `Functions` section on the module landing
page as one flat, unsectioned list. This PR adds 13 article pages:

- `Functions.md`, a hub page linking to the family pages below.
- `ColumnFunctions.md` (21), `AggregateFunctions.md` (130), `WindowFunctions.md` (13),
  `MathFunctions.md` (85), `StringFunctions.md` (124), `DateTimeFunctions.md` (115),
  `CollectionFunctions.md` (81), `SemiStructuredFunctions.md` (53), `SketchFunctions.md` (52),
  `GeospatialFunctions.md` (10), `ConditionalFunctions.md` (21), `MiscFunctions.md` (48).

Each page has an Overview with a runnable example and splits its Topics into 3-14 semantic
sections. Pages are organized by source-file family, so adding a function to
`XmlFunctions.swift` maps to one obvious place in the docs. The single exception is
`count`/`sum`/`avg`/`mean`/`min`/`max` from `Functions.swift`, curated on the aggregate page
where readers will look for them.

All 753 declarations are curated exactly once. The 82 overloaded names use DocC's type
signature disambiguation, for example:

```
- ``lit(_:)-(Bool)``
- ``parse_url(_:_:)-(_,Column)``
```

**Missing public types.** `SparkConnect.md` gains `Column`, `SparkLiteral`, `Window`,
`WindowSpec`, `Trigger`, `StreamingQueryException`, `StreamingQueryStatus`,
`DataFrameWriterV2`, `WhenMatched`, `WhenNotMatched`, `WhenNotMatchedBySource`,
`DataFrameNaFunctions`, `DataFrameStatFunctions`, `Observation`, `RowSchema`,
`SparkConnectError`, `~=(_:_:)`, `RuntimeConf`, and the six catalog value types
(`CatalogMetadata`, `CatalogColumn`, `Database`, `SparkTable`, `Function`, `TablePartition`),
across new `Expressions`, `Window Frames`, and `Error Handling` sections. `LocalTime` and
`TimestampNanos` move from `DataFrames` to `Data Types`.

`SparkConnectClient`, `CaseInsensitiveDictionary`, `ErrorUtils`, `ProtoUtils`,
`SparkFileUtils`, `CRC32`, and `SHA256` are curated under `Low-Level and Utility APIs`. These
are `public`, so DocC lists them whether or not they are curated; the `/// @nodoc` marker used
by the vendored Arrow sources is a jazzy/SPI convention that DocC does not act on, and actually
hiding them would need the underscored `@_documentation(visibility:)` attribute. Grouping them
under an explicitly named section is honest about what they are without touching any source.

**`Column.md`.** A new symbol page with an Overview and 15 topic sections covering all 84
public members. Operator overloads are separated into Arithmetic, Comparison, and Logical
sections instead of appearing as repeated identical titles in the automatic member list.

**Bundle metadata.** `Info.plist` drops the `CFBundleVersion` key and updates
`NSHumanReadableCopyright` to `© 2025 and onwards, The Apache Software Foundation`, matching
the "and onwards" form used in this project's `NOTICE` so it needs no yearly edit. The version
key was set to `0.1.0` and had never been updated across the `0.2.0` through `0.7.0` releases;
it is removed rather than bumped because DocC does not consume it. The
`INFO.PLIST FALLBACKS` section of `docc convert --help` lists only `CFBundleDisplayName`,
`CFBundleIdentifier`, a default module kind, and a default code-listing language; the version
never reaches the generated site, and a stale value produces no diagnostic, which is why it
went unnoticed. Keeping it would mean either shipping a wrong value again after the next
release or adding a release step to maintain something nothing reads.

### Why are the changes needed?

The published documentation on Swift Package Index does not currently make this library
navigable. 259 SQL functions were added recently and the catalog index had never been updated,
so the largest part of the public API was reachable only through one undifferentiated
auto-generated list, and core types such as `Column` appeared only in DocC's automatic
`Structures`/`Classes` groups mixed in with the vendored Arrow implementation.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change; the generated DocC site is reorganized.

### How was this patch tested?

Pass the CI. In addition, DocC was built locally and compared against the pre-change baseline.
The repository has no DocC plugin dependency, so symbol graphs were extracted from a release
build and `docc` was invoked directly rather than adding a dependency to `Package.swift`:

```
swift build -c release \
  -Xswiftc -emit-symbol-graph -Xswiftc -emit-symbol-graph-dir -Xswiftc /tmp/sg
```

```
xcrun docc convert Sources/SparkConnect/Documentation.docc \
  --fallback-display-name SparkConnect \
  --fallback-bundle-identifier org.apache.spark.connect.swift.SparkConnect \
  --additional-symbol-graph-dir /tmp/sg --output-path /tmp/docs
```

Results:

- 61 warnings before this change, 61 after; `diff` of the two warning lists is empty. All 61
  are pre-existing warnings from doc comments in `.swift` sources and are untouched here, so
  `--warnings-as-errors` is not usable on this catalog yet.
- Inspecting the rendered JSON confirms 765 topic links across the 13 function pages, all
  unique, with no duplicate curation and no link resolving to an unintended symbol.
  `column.json` shows 84 unique links, every one a `Column` member.
- The auto-generated `Functions` section (753 entries) is gone from the module landing page,
  which now has 11 curated sections holding 60 entries. The only remaining uncurated top-level
  symbols are vendored Arrow and FlatBuffers types.
- Every symbol name written in Topics was cross-checked against the sources; no missing name.
- `plutil -lint` reports the plist as valid. Converting with and without `CFBundleVersion`
  produces 3,256 rendered JSON files that are all semantically identical, confirming the key
  contributes nothing to the site.
- `markdownlint --config .markdownlint.yaml --ignore-path .markdownlintignore` is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5